### PR TITLE
ENH: run only loops once if no positioners are provided

### DIFF
--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -61,9 +61,11 @@ class Demuxer(object):
 
 
 class RunEngine(object):
+
     '''
 
     '''
+
     def __init__(self, logger):
         self._demuxer = Demuxer()
         self._logger = register_object(self)
@@ -103,20 +105,20 @@ class RunEngine(object):
 
         # status now holds the MoveStatus() instances
         time.sleep(0.05)
-        #TODO: this should iterate at most N times to catch hangups
+        # TODO: this should iterate at most N times to catch hangups
         while not all(s.done for s in status):
             time.sleep(0.1)
 
         if settle_time is not None:
             time.sleep(settle_time)
-        #return {pos.name: pos.position for pos in positioners}
+        # return {pos.name: pos.position for pos in positioners}
         ret = {}
         [ret.update({pos.name: pos.position}) for pos in positioners]
 
         return ret
 
     def _start_scan(self, **kwargs):
-        print('Starting Scan...{}'.format(kwargs))
+        # print('Starting Scan...{}'.format(kwargs))
         hdr = kwargs.get('header')
         evdesc = kwargs.get('event_descriptor')
         dets = kwargs.get('detectors')
@@ -130,35 +132,38 @@ class RunEngine(object):
             if posvals is None:
                 break
             # execute user code
-            print('execute user code')
+            # print('execute user code')
             #detvals = {d.name: d.value for d in dets}
-            #TODO: handle triggers here (pvs that cause detectors to fire)
+            # TODO: handle triggers here (pvs that cause detectors to fire)
             if trigs is not None:
                 for t in trigs:
                     t.put(1, wait=True)
-            #TODO: again, WTF is with the delays required? CA is too fast,
+            # TODO: again, WTF is with the delays required? CA is too fast,
             # and python is too slow (or vice versa!)
             time.sleep(0.05)
             detvals = {}
             [detvals.update({d.name: d.value}) for d in dets]
             detvals.update(posvals)
-            #TODO: timestamp this datapoint?
+            # TODO: timestamp this datapoint?
             #data.update({'timestamp': time.time()})
             # pass data onto Demuxer for distribution
-            print('datapoint[{}]: {}'.format(seqno,detvals))
+            print('datapoint[{}]: {}'.format(seqno, detvals))
             event = data_collection.format_event(hdr, evdesc,
-                                              seq_no=seqno,
-                                              data=detvals)
+                                                 seq_no=seqno,
+                                                 data=detvals)
             create_event(event)
             seqno += 1
-            #update the 'data' object from detvals dict
-            for k,v in detvals.iteritems():
+            # update the 'data' object from detvals dict
+            for k, v in detvals.iteritems():
                 data[k].append(v)
+
+            if kwargs.get('positioners') is None:
+                break
         self._scan_state = False
         return
 
     def _get_data_keys(self, **kwargs):
-        #ATM, these are both lists
+        # ATM, these are both lists
         pos = kwargs.get('positioners')
         det = kwargs.get('detectors')
 
@@ -171,17 +176,17 @@ class RunEngine(object):
         header = data_collection.create_run_header(scan_id=runid, **scan_args)
         #header = {'run_header': 'Foo'}
         keys = self._get_data_keys(**scan_args)
-        data = {k:[] for k in keys}
-        print('keys = %s'%keys)
+        data = {k: [] for k in keys}
+        # print('keys = %s'%keys)
         #event_descriptor = {'a': 1, 'b':2}
         event_descriptor = data_collection.create_event_descriptor(
-                            run_header=header, event_type_id=1, data_keys=keys,
-                            descriptor_name='Scan Foo')
+            run_header=header, event_type_id=1, data_keys=keys,
+            descriptor_name='Scan Foo')
         if scan_args is not None:
             scan_args['header'] = header
             scan_args['event_descriptor'] = event_descriptor
             scan_args['data'] = data
-        #write the header and event_descriptor to the header PV
+        # write the header and event_descriptor to the header PV
 
         self._begin_run(begin_args)
 

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-import logging
+# import logging
 import sys
 import time
 from threading import Thread
@@ -133,7 +133,7 @@ class RunEngine(object):
                 break
             # execute user code
             # print('execute user code')
-            #detvals = {d.name: d.value for d in dets}
+            # detvals = {d.name: d.value for d in dets}
             # TODO: handle triggers here (pvs that cause detectors to fire)
             if trigs is not None:
                 for t in trigs:
@@ -145,7 +145,7 @@ class RunEngine(object):
             [detvals.update({d.name: d.value}) for d in dets]
             detvals.update(posvals)
             # TODO: timestamp this datapoint?
-            #data.update({'timestamp': time.time()})
+            # data.update({'timestamp': time.time()})
             # pass data onto Demuxer for distribution
             print('datapoint[{}]: {}'.format(seqno, detvals))
             event = data_collection.format_event(hdr, evdesc,
@@ -158,6 +158,8 @@ class RunEngine(object):
                 data[k].append(v)
 
             if kwargs.get('positioners') is None:
+                break
+            if len(kwargs.get('positioners')) == 0:
                 break
         self._scan_state = False
         return
@@ -174,11 +176,11 @@ class RunEngine(object):
     def start_run(self, runid, begin_args=None, end_args=None, scan_args=None):
         # create run_header and event_descriptors
         header = data_collection.create_run_header(scan_id=runid, **scan_args)
-        #header = {'run_header': 'Foo'}
+        # header = {'run_header': 'Foo'}
         keys = self._get_data_keys(**scan_args)
         data = {k: [] for k in keys}
         # print('keys = %s'%keys)
-        #event_descriptor = {'a': 1, 'b':2}
+        # event_descriptor = {'a': 1, 'b':2}
         event_descriptor = data_collection.create_event_descriptor(
             run_header=header, event_type_id=1, data_keys=keys,
             descriptor_name='Scan Foo')


### PR DESCRIPTION
Not sure if this was intended or not, but if no positioners are provided then the run loops infinitely until Ctrl-C. This change only loops through once if the positioners are not set (None) or they are a null list. 

This is just a suggestion, but has the added advantage that a "count" as per spec just becomes a run() of the base scan class and all data is saved as if it was a scan. I like this as it is a good way to trigger a single image acquisition for example.

P.S. Also formatted as per PEP8