### PR TITLE
ENH: Added functionality to format signal groups and trigger scaler

### DIFF
--- a/ophyd/controls/scaler.py
+++ b/ophyd/controls/scaler.py
@@ -32,13 +32,17 @@ class EpicsScaler(SignalGroup):
         Eventually need to provide PR1..16 -- preset counts too.
         '''
         signals = [EpicsSignal(self.field_pv('CNT'),
-                               alias='_count_ctl'),
+                               alias='_count_ctl',
+                               name=''.join([self.name, '_cnt'])),
                    EpicsSignal(self.field_pv('CONT'),
-                               alias='_count_mode'),
+                               alias='_count_mode',
+                               name=''.join([self.name, '_cont'])),
                    EpicsSignal(self.field_pv('T'),
-                               alias='_elapsed_time'),
+                               alias='_elapsed_time',
+                               name=''.join([self.name, '_t'])),
                    EpicsSignal(self.field_pv('TP'),
-                               alias='_preset_time')
+                               alias='_preset_time',
+                               name=''.join([self.name, '_preset']))
                    ]
 
         # create the 'NM1..numchan' channel name Signals
@@ -46,6 +50,7 @@ class EpicsScaler(SignalGroup):
         for ch in range(1, numchan + 1):
             name = ''.join([self.field_pv('NM'), str(ch)])
             ch_names.append(EpicsSignal(name,
+                            name=''.join([self.name, '_nm', str(ch)]),
                             alias=''.join(['_ch', str(ch), '_name'])))
         signals += ch_names
         # create the 'S1..numchan' channel count Signals (read-only)
@@ -53,6 +58,7 @@ class EpicsScaler(SignalGroup):
         for ch in range(1, numchan + 1):
             name = ''.join([self.field_pv('S'), str(ch)])
             ch_names.append(EpicsSignal(name, rw=False,
+                            name=''.join([self.name, '_s', str(ch)]),
                             alias=''.join(['_ch', str(ch), '_count'])))
         signals += ch_names
 
@@ -86,6 +92,10 @@ class EpicsScaler(SignalGroup):
     # TODO: should writes be non-blocking by default?
     def stop(self):
         self._count_ctl.value = 0
+
+    @property
+    def count(self):
+        return self._count_ctl
 
     @property
     def count_mode(self):

--- a/ophyd/controls/signal.py
+++ b/ophyd/controls/signal.py
@@ -474,6 +474,10 @@ class SignalGroup(OphydObject):
         return [signal.get(**kwargs)
                 for signal in self._signals]
 
+    @property
+    def signals(self):
+        return self._signals
+
     def put(self, values, **kwargs):
         return [signal.put(value, **kwargs)
                 for signal, value in zip(self._signals, values)]

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -171,12 +171,14 @@ class RunEngine(object):
 
     def _get_data_keys(self, **kwargs):
         # ATM, these are both lists
-        pos = kwargs.get('positioners')
-        det = kwargs.get('detectors')
+        names = [o.name for o in kwargs.get('positioners')]
+        for det in kwargs.get('detectors'):
+            if isinstance(det, SignalGroup):
+                names += [o.name for o in det.signals]
+            else:
+                names.append(det.name)
 
-        objs = pos + det
-
-        return [o.name for o in objs]
+        return names
 
     def start_run(self, runid, begin_args=None, end_args=None, scan_args=None):
         # create run_header and event_descriptors

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -6,6 +6,7 @@ from threading import Thread
 from Queue import Queue
 
 from ..session import register_object
+from ..controls.signal import SignalGroup
 
 try:
     from databroker.api import data_collection
@@ -139,7 +140,14 @@ class RunEngine(object):
             # and python is too slow (or vice versa!)
             time.sleep(0.05)
             detvals = {}
-            [detvals.update({d.name: d.value}) for d in dets]
+            for det in dets:
+                if isinstance(det, SignalGroup):
+                    # If we have a signal group, loop over all names
+                    # and signals
+                    for sig in det.signals:
+                        detvals.update({sig.name: sig.value})
+                else:
+                    detvals.update({det.name: det.value})
             detvals.update(posvals)
             # TODO: timestamp this datapoint?
             # data.update({'timestamp': time.time()})


### PR DESCRIPTION
@dchabot, @klauer 

This is a suggested enhancement to run_engine and signal groups. Here we set the signal names in the group to have the base signal name and a postfix for the type of signal (for example `'_s1'` for S1 of the scaler). 

This then also adds signal groups to the event descriptors and events such that the signals are all added. I think this makes more intuitive sense to "bundle" up signals into groups which are then added. For example all the signals for a temperature controller could be bundled in a signal group.

Thoughts.... I tested this and it works OK with the scaler. 

I also added the `sclr.count` as the trigger so this can be triggered in the scan. 