### PR TITLE
switch from 'print()' to logging in scanapi and runengine

### DIFF
--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -7,7 +7,6 @@ import time
 from threading import Thread
 from Queue import Queue
 import numpy as np
-import collections
 
 from ..session import register_object
 from ..controls.signal import SignalGroup

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -173,7 +173,6 @@ class RunEngine(object):
             for pos in positioners}
 
     def _start_scan(self, **kwargs):
-        # print('Starting Scan...{}'.format(kwargs))
         run_start = kwargs.get('run_start')
         dets = kwargs.get('detectors')
         trigs = kwargs.get('triggers')
@@ -206,7 +205,6 @@ class RunEngine(object):
             if posvals is None:
                 break
             # execute user code
-            # print('execute user code')
             # detvals = {d.name: d.value for d in dets}
             # TODO: handle triggers here (pvs that cause detectors to fire)
             if trigs is not None:
@@ -215,13 +213,11 @@ class RunEngine(object):
             # TODO: again, WTF is with the delays required? CA is too fast,
             # and python is too slow (or vice versa!)
             time.sleep(0.05)
-#            detvals = collections.OrderedDict()
             detvals = {}
             for det in dets:
                 if isinstance(det, SignalGroup):
                     # If we have a signal group, loop over all names
                     # and signals
-                    # print('vars(det) in ophyd _start_scan', vars(det))
                     for sig in det.signals:
                         detvals.update({sig.name: {
                             'timestamp': sig.timestamp[sig.pvname.index(sig.report['pv'])],
@@ -235,15 +231,14 @@ class RunEngine(object):
             # TODO: timestamp this datapoint?
             # data.update({'timestamp': time.time()})
             # pass data onto Demuxer for distribution
-            self._sessionmgr._logger.info(
-                '{}'.format(self._demunge_values(detvals, names)))
+            self._sessionmgr._logger.info(self._demunge_values(detvals, names))
             # grab the current time as a timestamp that describes when the
             # event data was bundled together
             bundle_time = time.time()
             # actually insert the event into metadataStore
             try:
                 self._sessionmgr._logger.debug(
-                    'inserting event {}------------------'.format(seq_num))
+                    'inserting event %d------------------',seq_num)
                 event = mds.insert_event(event_descriptor=event_descriptor,
                                          time=bundle_time, data=detvals,
                                          seq_num=seq_num)
@@ -259,16 +254,15 @@ class RunEngine(object):
                     run_start=run_start, time=evdesc_creation_time,
                     data_keys=mds.format_data_keys(data_key_info))
                 self._sessionmgr._logger.debug(
-                    'event_descriptor: {}'.format(vars(event_descriptor)))
+                    'event_descriptor: %s',vars(event_descriptor))
                 # insert the event again. this time it better damn well work
                 self._sessionmgr._logger.debug(
-                    'inserting event {}------------------'.format(seq_num))
+                    'inserting event %d------------------',seq_num)
                 event = mds.insert_event(event_descriptor=event_descriptor,
                                          time=bundle_time, data=detvals,
                                          seq_num=seq_num)
-            self._sessionmgr._logger.debug('event {}--------'.format(seq_num,
-                vars(event)))
-            self._sessionmgr._logger.debug('{}'.format(vars(event)))
+            self._sessionmgr._logger.debug('event %d--------',seq_num)
+            self._sessionmgr._logger.debug('%s',vars(event))
 
             seq_num += 1
             # update the 'data' object from detvals dict
@@ -287,7 +281,7 @@ class RunEngine(object):
 
         Parameters
         ----------
-        vals : Ordered dict
+        vals :  dict
         '''
         msg = ''.join('{}\t'.format(vals[name][0]) for name in keys)
         return msg

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -626,15 +626,10 @@ class DScan(AScan):
                   for pos, start in
                   zip(self.positioners, self._start_positions)]
 
-#        print("\n")
-#        print(tc.Red + "Moving positioners back to start positions.......",
-#              end='')
-#        sys.stdout.flush()
         logger.info("Moving positioners back to start positions.......")
         while any(not stat.done for stat in status):
             sleep(0.01)
 
-#        print(tc.Green + " Done.")
         logger.info(tc.Green + " Done.")
 
 
@@ -658,10 +653,6 @@ class Count(Scan):
         super(Count, self).post_scan()
 
         msg = self._fmt_count()
-
-#        print('')
-#        print(msg)
-#        print('')
 
         logger.info('\n'+msg+'\n')
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -654,7 +654,7 @@ class Count(Scan):
 
         msg = self._fmt_count()
 
-        logger.info('\n'+msg+'\n')
+        logger.info(msg)
 
         # Make a logbook entry
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -626,14 +626,16 @@ class DScan(AScan):
                   for pos, start in
                   zip(self.positioners, self._start_positions)]
 
-        print("\n")
-        print(tc.Red + "Moving positioners back to start positions.......",
-              end='')
-        sys.stdout.flush()
+#        print("\n")
+#        print(tc.Red + "Moving positioners back to start positions.......",
+#              end='')
+#        sys.stdout.flush()
+        logger.info("Moving positioners back to start positions.......")
         while any(not stat.done for stat in status):
             sleep(0.01)
 
-        print(tc.Green + " Done.")
+#        print(tc.Green + " Done.")
+        logger.info(tc.Green + " Done.")
 
 
 class Count(Scan):
@@ -657,9 +659,11 @@ class Count(Scan):
 
         msg = self._fmt_count()
 
-        print('')
-        print(msg)
-        print('')
+#        print('')
+#        print(msg)
+#        print('')
+
+        logger.info('\n'+msg+'\n')
 
         # Make a logbook entry
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -693,6 +693,7 @@ class Count(Scan):
             detectors
         """
         rtn = []
+        rtn.append('\n')
         rtn.append('{:<28} | {}'.format('Detector', 'Value'))
         rtn.append('{0:=^60}'.format(''))
         data = collections.OrderedDict(sorted(self.last_data.data_dict.items()))


### PR DESCRIPTION
addresses concerns raised around issue #74 