### PR TITLE
ENH: Record 'trajectory_vars' in RunStart.

### DIFF
--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -340,6 +340,14 @@ class RunEngine(object):
             owner = getpass.getuser()
         runid = str(runid)
 
+        # The values of every positioner have a special, immutable
+        # significance: we vary them intentionally. These are
+        # the 'trajectory variables'.
+        positioners = scan_args.get('positioners', None)
+        if positioners is not None:
+            positioner_names = [p.name for p in positioners]
+            custom['trajectory_vars'] = positioner_names
+
         blc = mds.insert_beamline_config(beamline_config, time=time.time())
         # insert the run_start into metadatastore
         recorded_time = time.time()


### PR DESCRIPTION
Based on feedback from @cmazzoli and @skalbfleisch, hashed out on the train with @tacaswell. Of course this requires discussion with @dchabot and others.

## What

A scan like

    dscan(sli, 0, 5, 5)

saves a new (optional) RunStart field: `trajectory_vars: ['sli']`.

## Why

* Without trajectory variables, there is no way to tell from the data which motors were actively moved and which merely drifted. Our argument is that this is not actually info about "user intention" (Olog stuff) but actually part of a record of the measurement itself.
* Trajectory variables are not the same as the independent variable(s). For example, they would not include time or other variables that change without a specified trajectory. And you can't tell from looking at a list of trajectory variables whether they are mutually independent (like a mesh scan) or not. For this you need the scientist / Olog.
* Trajectory variables are not the same as `plot_x`, which is a mutable user preference -- and likely to be more like independent variable(s). (But it will obviously be useful for helping guess what to plot against.)
* It also provides a useful way to search: "Show me every experiment where I moved the delta motor."

## Implementation Details

* `trajectory_vars` will often be an empty list, such as for `ct()`. This is no problem.
* We will not require this field. We can use a spare, nonunique index for fast searches. No migration required.
