### PR TITLE
Experimental: ophyd callbacks for built-in or user-defined plotting

### DIFF
--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -248,10 +248,6 @@ class RunEngine(object):
             self.logger.debug('%s', vars(event))
 
             scan.emit_event(event)
-            for f_mgr in plt._pylab_helpers.Gcf.get_all_fig_managers():
-                # TODO Use this in the future, or just plt.draw_all I guess?
-                # if force or f_mgr.canvas.figure.stale:
-                f_mgr.canvas.draw()
 
             seq_num += 1
             # update the 'data' object from detvals dict
@@ -364,7 +360,6 @@ class RunEngine(object):
         self._scan_thread.start()
         end_args['scan'] = scan
         try:
-            setup = False
             while self._scan_state is True:
                 try:
                     descriptor = scan.desc_queue.get(timeout=0.05)
@@ -372,21 +367,12 @@ class RunEngine(object):
                     pass
                 else:
                     scan.cb_registry.process('descriptor',  descriptor)
-                    setup = True
-                if not setup:
-                    continue
                 try:
                     event = scan.ev_queue.get(timeout=0.05)
                 except Empty:
                     pass
                 else:
-                    scan.cb_registry.process('descriptor',  descriptor)
                     scan.cb_registry.process('event', event)
-            	for f_mgr in plt._pylab_helpers.Gcf.get_all_fig_managers():
-                    print(f_mgr)
-                    f_mgr.canvas.figure.show()
-                    f_mgr.canvas.draw()
-                    f_mgr.canvas.flush_events()
         except KeyboardInterrupt:
             self._scan_state = False
             self._scan_thread.join()

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -9,12 +9,14 @@ import string
 import traceback
 
 from IPython.utils.coloransi import TermColors as tc
+from matplotlib.cbook import CallbackRegistry
 from filestore.api import retrieve
 from mongoengine import DoesNotExist
 
 from ..runengine import RunEngine
 from ..session import get_session_manager
 from ..utils import LimitError
+from ..utils.plotting import PlotManager
 from ..controls import Detector
 
 session_manager = get_session_manager()
@@ -34,7 +36,7 @@ def estimate(x, y):
     stats['x_at_ymax'] = x[y.argmax()]
     # Calculate CEN from derivative
     zero_cross = np.where(np.diff(np.sign(y - (stats['ymax']
-                                               + stats['ymin'])/2)))[0]
+ stats['ymin'])/2)))[0]
     if zero_cross.size == 2:
         stats['cen'] = (x[zero_cross].sum() / 2,
                         (stats['ymax'] + stats['ymin'])/2)
@@ -143,6 +145,7 @@ class Scan(object):
     _shared_config = {'default_detectors': [],
                       'user_detectors': [],
                       'scan_data': None, }
+    valid_callbacks = ['start', 'stop', 'event', 'descriptor']
 
     def __init__(self, *args, **kwargs):
         super(Scan, self).__init__(*args, **kwargs)
@@ -154,7 +157,9 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
+        self._cb_registry = CallbackRegistry()
         self.autoplot = True
+        self._plot_mgr = PlotManager()
 
         self.paths = list()
         self.positioners = list()
@@ -211,6 +216,7 @@ class Scan(object):
 
     def pre_scan(self):
         """Routine run before scan starts"""
+        self._plot_mgr.update_positioners(self.positioners)
         pass
 
     def post_scan(self):
@@ -326,101 +332,59 @@ class Scan(object):
         """
         return self._shared_config['user_detectors'] + self.default_detectors
 
-    def setup_plot(self, event_descriptor):
-        if not self.autoplot:
-            return
-        scalars = []
-        images = []
-        cubes = []
-        for key, val in six.iteritems(event_descriptor.data_keys):
-            if val['shape'] is None:
-                scalars.append(key)
-                continue
-            ndim = len(val['shape'])
-            if ndim == 2:
-                images.append(key)
-            elif ndim == 3:
-                cubes.append(key)
-            else:
-                pass  # >3D data just won't be shown
+    def register_callback(self, name, func):
+        """
+        Register a callback function.
 
-        if len(positioners) == 1:
-            self._x = positioners[0]
-            if self._x not in scalars:
-                raise NotImplementedError("Not sure how to plot this. Turn of "
-                                          "the scan's autoplot attribute.")
-            scalars.remove(self._x)
+        The Run Engine will execute callback functions at the start and end
+        of a scan, and after the insertion of new Event Descriptors
+        and Events.
+
+        Parameters
+        ----------
+        name: {'start', 'stop', 'descriptor', 'event'}
+        func: callable with signature f(Scan, mongoengine.Document)
+        """
+        if name not in self.valid_callbacks:
+            raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
+        self._cb_registry.connect(name, func)
+
+    def emit_event(self, event):
+        "Called by the Run Engine after each new event is created."
+        self._cb_registry.process('event', event)
+
+    def emit_descriptor(self, descriptor):
+        "Called by the Run Engine after each new event desc is created."
+        self._cb_registry.process('descriptor', descriptor)
+
+    def emit_start(self, start):
+        "Called by the Run Engine after a scan is started."
+        self._cb_registry.process('start', start)
+
+    def emit_stop(self, stop):
+        "Called by the Run Engine after a scan is stopped."
+        self._cb_registry.process('stop', stop)
+
+    @property
+    def autoplot(self):
+        return self._autoplot
+
+    @autoplot.setter
+    def autoplot(self, val):
+        if bool(val) = self._autoplot:
+            return
+        self._autoplot = bool(val)
+        cb_reg = self._cb_registry  # for brevity
+        if val:
+            # when a callback is registered, it returns an integer ID
+            # that can be used to deregister it.
+            self._plot_callback_ids = []
+            cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
+            self._plot_callback_ids.append(cid)
+            cid = cb_reg.connect('event', self._plot_mgr.update_plot)
+            self._plot_callback_ids.append(cid)
         else:
-            self._x_name = None  # plot against seq_num
-        self._cube_names = cubes
-
-        # Build figures, axes, lines.
-        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
-        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
-        self._scalar_lines = {name: ax.plot([], [])[0]}
-        self._scalar_fig.subplots_adjust()
-        for name, ax in six.iteritems(self._scalar_axes):
-            ax.set(title=name)
-        self._image_figs = {name: plt.figure() for name in in images + cubes}
-        self._image_axes = {fig.add_axes((0, 0, 1, 1)) for fig in self._image_figs}
-        self._img_objs = {}  # will hold AxesImage objects
-        self._img_uids = {name: deque() for name in images + cubes}
-
-    def update_plot(self, event):
-        if not self.autoplot:
-            return
-        # Add a data point to the subplot for each scalar.
-        x_val = event[self._x_name][0]  # unpack value from raw Event
-        for name, ax in self._scalar_axes:
-            y_val = event[name][0]  # unpack value from raw Event
-            line = self._scalar_lines[name]
-            old_x, old_y = line.get_data()
-            x = np.append(old_x, x_val)
-            y = np.append(old_y, y_val)
-            line.set_data(x, y)
-        self._scalar_fig.canvas.draw()
-
-        # Try to get the latest image, or a recent image,
-        # to update each image figure.
-        for name, ax in self._image_axes:
-            datum_uid = event[name][0]
-            img_array = None
-            try:
-                img_array = retrieve(datum_uid)
-            except DoesNotExist:
-                # Data may not be readable yet.
-                # Try uids in cache, starting with the most recent one.
-                uids = self._img_uids[name]
-                for i, datum_uid in enumerate(uids):
-                    try:
-                        img_array = filestore.retrieve(datum_uid)
-                    except filestore.DatumNotFound
-                        continue
-                    else:
-                        # To avoid ever showing an image that is older
-                        # than we one we just found,
-                        # remove all older images from the cache.
-                        for _ in len(uids) - i:
-                            self.uids.pop()
-                        break
-                self._img_uids[name].appendleft(datum_uid)
-
-            # No image available? Skip this update.
-            if img_array is None:
-                continue
-
-            # If this is an image cube, sum along the first axis
-            # and display it like an image.
-            # TODO: Display volumes for real.
-            if name in self._cube_names:
-                img_array = img_array.sum(0)
-
-            # Update the image.
-            if name not in self._img_objs:
-                self._img_obj[name] = ax.imshow(img_array)
-            else:
-                img_obj.set_array(img_array)
-            self._img_figs[name].canvas.draw()
+            [cg_reg.disconnect(cid) for cid in self._plot_callback_ids]
 
 
 class AScan(Scan):

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -164,6 +164,11 @@ class Scan(object):
         self._autoplot = None
         self.autoplot = True
 
+        self.ev_queue = Queue()
+        self.desc_queue = Queue()
+        self._register_scan_callback('event', self._push_to_ev_queue)
+        self._register_scan_callback('descriptor', self._push_to_desc_queue)
+
         self.paths = list()
         self.positioners = list()
 
@@ -337,20 +342,34 @@ class Scan(object):
 
     def register_callback(self, name, func):
         """
-        Register a callback function.
+        Register a callback function to be processed by the main thread.
 
-        The Run Engine will execute callback functions at the start and end
+        The Run Engine can execute callback functions at the start and end
         of a scan, and after the insertion of new Event Descriptors
         and Events.
 
         Parameters
         ----------
         name: {'start', 'stop', 'descriptor', 'event'}
-        func: callable with signature f(Scan, mongoengine.Document)
+        func: callable with signature ``f(mongoengine.Document)``
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
-        self._scan_cb_registry.connect(name, func)
+        return self.cb_registry.connect(name, func)
+
+    def _register_scan_callback(self, name, func):
+        """Register a callback to be processed by the scan thread.
+
+        Like register_callback above, but private and referring to
+        a different callback registry.
+        """
+        return self._scan_cb_registry.connect(name, func)
+
+    def _push_to_ev_queue(self, event):
+        self.ev_queue.put(event)
+
+    def _push_to_desc_queue(self, descriptor):
+        self.desc_queue.put(descriptor)
 
     def emit_event(self, event):
         "Called by the Run Engine after each new event is created."
@@ -377,14 +396,14 @@ class Scan(object):
         if bool(val) == self._autoplot:
             return
         self._autoplot = bool(val)
-        cb_reg = self._cb_registry  # for brevity
+        cb_reg = self.cb_registry  # for brevity
         if val:
             # when a callback is registered, it returns an integer ID
             # that can be used to deregister it.
             self._plot_callback_ids = []
-            cid = cb_reg.connect('descriptor', self.add_to_queue)
+            cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
             self._plot_callback_ids.append(cid)
-            cid = cb_reg.connect('event', self.add_to_queue)
+            cid = cb_reg.connect('event', self._plot_mgr.update_plot)
             self._plot_callback_ids.append(cid)
         else:
             [cb_reg.disconnect(cid) for cid in self._plot_callback_ids]

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -146,7 +146,7 @@ class Scan(object):
     _shared_config = {'default_detectors': [],
                       'user_detectors': [],
                       'scan_data': None, }
-    valid_callbacks = ['start', 'stop', 'event', 'descriptor']
+    valid_callbacks = ['start', 'stop', 'event', 'descriptor', 'pre-scan', 'post-scan']
 
     def __init__(self, *args, **kwargs):
         super(Scan, self).__init__(*args, **kwargs)
@@ -224,11 +224,12 @@ class Scan(object):
 
     def pre_scan(self):
         """Routine run before scan starts"""
-        self._plot_mgr.update_positioners(self.positioners)
+        self._scan_cb_registry.process('pre-scan', self.positioners, self.detectors)
         pass
 
     def post_scan(self):
         """Routine run after scan has completed"""
+        self._scan_cb_registry.process('post-scan', self.positioners, self.detectors)
         pass
 
     def configure_detectors(self):
@@ -350,8 +351,12 @@ class Scan(object):
 
         Parameters
         ----------
-        name: {'start', 'stop', 'descriptor', 'event'}
-        func: callable with signature ``f(mongoengine.Document)``
+        name: {'pre-scan', 'start', 'descriptor', 'event', 'stop', 'post-scan'}
+        func: callable
+            start, descriptor, event, stop callbacks expect signature
+            ``f(mongoengine.Document)``
+            pre-scan and post-scan callbacks expect signature
+            ``f(positioners, detectors)``(
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
@@ -404,6 +409,8 @@ class Scan(object):
             cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
             self._plot_callback_ids.append(cid)
             cid = cb_reg.connect('event', self._plot_mgr.update_plot)
+            self._plot_callback_ids.append(cid)
+            cid = cb_reg.connect('pre-scan', self._plot_mgr.update_positioners)
             self._plot_callback_ids.append(cid)
         else:
             [cb_reg.disconnect(cid) for cid in self._plot_callback_ids]

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -356,7 +356,7 @@ class Scan(object):
             start, descriptor, event, stop callbacks expect signature
             ``f(mongoengine.Document)``
             pre-scan and post-scan callbacks expect signature
-            ``f(positioners, detectors)``(
+            ``f(positioners, detectors)``)
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import numpy as np
+import matplotlib.pyplot as plt
 from time import sleep
 import sys
 import collections
@@ -8,6 +9,8 @@ import string
 import traceback
 
 from IPython.utils.coloransi import TermColors as tc
+from filestore.api import retrieve
+from mongoengine import DoesNotExist
 
 from ..runengine import RunEngine
 from ..session import get_session_manager
@@ -151,6 +154,7 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
+        self.autoplot = True
 
         self.paths = list()
         self.positioners = list()
@@ -251,7 +255,7 @@ class Scan(object):
             scan_args['custom'] = kwargs
 
             # Run the scan!
-            data = self._run_eng.start_run(self.scan_id,
+            data = self._run_eng.start_run(self,
                                            scan_args=scan_args)
 
             self._data_buffer.append(Data(data))
@@ -321,6 +325,102 @@ class Scan(object):
         list of OphydObjects
         """
         return self._shared_config['user_detectors'] + self.default_detectors
+
+    def setup_plot(self, event_descriptor):
+        if not self.autoplot:
+            return
+        scalars = []
+        images = []
+        cubes = []
+        for key, val in six.iteritems(event_descriptor.data_keys):
+            if val['shape'] is None:
+                scalars.append(key)
+                continue
+            ndim = len(val['shape'])
+            if ndim == 2:
+                images.append(key)
+            elif ndim == 3:
+                cubes.append(key)
+            else:
+                pass  # >3D data just won't be shown
+
+        if len(positioners) == 1:
+            self._x = positioners[0]
+            if self._x not in scalars:
+                raise NotImplementedError("Not sure how to plot this. Turn of "
+                                          "the scan's autoplot attribute.")
+            scalars.remove(self._x)
+        else:
+            self._x_name = None  # plot against seq_num
+        self._cube_names = cubes
+
+        # Build figures, axes, lines.
+        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
+        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
+        self._scalar_lines = {name: ax.plot([], [])[0]}
+        self._scalar_fig.subplots_adjust()
+        for name, ax in six.iteritems(self._scalar_axes):
+            ax.set(title=name)
+        self._image_figs = {name: plt.figure() for name in in images + cubes}
+        self._image_axes = {fig.add_axes((0, 0, 1, 1)) for fig in self._image_figs}
+        self._img_objs = {}  # will hold AxesImage objects
+        self._img_uids = {name: deque() for name in images + cubes}
+
+    def update_plot(self, event):
+        if not self.autoplot:
+            return
+        # Add a data point to the subplot for each scalar.
+        x_val = event[self._x_name][0]  # unpack value from raw Event
+        for name, ax in self._scalar_axes:
+            y_val = event[name][0]  # unpack value from raw Event
+            line = self._scalar_lines[name]
+            old_x, old_y = line.get_data()
+            x = np.append(old_x, x_val)
+            y = np.append(old_y, y_val)
+            line.set_data(x, y)
+        self._scalar_fig.canvas.draw()
+
+        # Try to get the latest image, or a recent image,
+        # to update each image figure.
+        for name, ax in self._image_axes:
+            datum_uid = event[name][0]
+            img_array = None
+            try:
+                img_array = retrieve(datum_uid)
+            except DoesNotExist:
+                # Data may not be readable yet.
+                # Try uids in cache, starting with the most recent one.
+                uids = self._img_uids[name]
+                for i, datum_uid in enumerate(uids):
+                    try:
+                        img_array = filestore.retrieve(datum_uid)
+                    except filestore.DatumNotFound
+                        continue
+                    else:
+                        # To avoid ever showing an image that is older
+                        # than we one we just found,
+                        # remove all older images from the cache.
+                        for _ in len(uids) - i:
+                            self.uids.pop()
+                        break
+                self._img_uids[name].appendleft(datum_uid)
+
+            # No image available? Skip this update.
+            if img_array is None:
+                continue
+
+            # If this is an image cube, sum along the first axis
+            # and display it like an image.
+            # TODO: Display volumes for real.
+            if name in self._cube_names:
+                img_array = img_array.sum(0)
+
+            # Update the image.
+            if name not in self._img_objs:
+                self._img_obj[name] = ax.imshow(img_array)
+            else:
+                img_obj.set_array(img_array)
+            self._img_figs[name].canvas.draw()
 
 
 class AScan(Scan):
@@ -539,6 +639,10 @@ class Count(Scan):
     A log entry is created if the logbook is setup which records the
     result of the scan.
     """
+    def __init__(self, *args, **kwargs):
+        super(Count, self).__init__(*args, **kwargs)
+        self.autoplot = False
+
     def post_scan(self):
         """Post-scan print data
 

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -1,0 +1,99 @@
+import matplotlib.pyplot as plt
+
+
+class PlotManager(object):
+
+    def update_positioners(self, positioners):
+        if len(positioners) == 1:
+            self._x_name = positioners[0]
+        else:
+            self._x_name = None  # plot against seq_num
+
+    def setup_plot(event_descriptor):
+        scalars = []
+        images = []
+        cubes = []
+        for key, val in six.iteritems(event_descriptor.data_keys):
+            if val['shape'] is None:
+                scalars.append(key)
+                continue
+            ndim = len(val['shape'])
+            if ndim == 2:
+                images.append(key)
+            elif ndim == 3:
+                cubes.append(key)
+            else:
+                pass  # >3D data just won't be shown
+
+            if self._x not in scalars:
+                raise NotImplementedError("Not sure how to plot this. Turn "
+                                          "of the self's autoplot attribute.")
+            scalars.remove(self._x)
+        self._cube_names = cubes
+
+        # Build figures, axes, lines.
+        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
+        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
+        self._scalar_lines = {name: ax.plot([], [])[0]}
+        self._scalar_fig.subplots_adjust()
+        for name, ax in six.iteritems(self._scalar_axes):
+            ax.set(title=name)
+        self._image_figs = {name: plt.figure() for name in in images + cubes}
+        self._image_axes = {fig.add_axes((0, 0, 1, 1))
+                            for fig in self._image_figs}
+        self._img_objs = {}  # will hold AxesImage objects
+        self._img_uids = {name: deque() for name in images + cubes}
+
+    def update_plot(event):
+        # Add a data point to the subplot for each scalar.
+        x_val = event[self._x_name][0]  # unpack value from raw Event
+        for name, ax in self._scalar_axes:
+            y_val = event[name][0]  # unpack value from raw Event
+            line = self._scalar_lines[name]
+            old_x, old_y = line.get_data()
+            x = np.append(old_x, x_val)
+            y = np.append(old_y, y_val)
+            line.set_data(x, y)
+        self._scalar_fig.canvas.draw()
+
+        # Try to get the latest image, or a recent image,
+        # to update each image figure.
+        for name, ax in self._image_axes:
+            datum_uid = event[name][0]
+            img_array = None
+            try:
+                img_array = retrieve(datum_uid)
+            except DoesNotExist:
+                # Data may not be readable yet.
+                # Try uids in cache, starting with the most recent one.
+                uids = self._img_uids[name]
+                for i, datum_uid in enumerate(uids):
+                    try:
+                        img_array = filestore.retrieve(datum_uid)
+                    except filestore.DatumNotFound
+                        continue
+                    else:
+                        # To avoid ever showing an image that is older
+                        # than we one we just found,
+                        # remove all older images from the cache.
+                        for _ in len(uids) - i:
+                            self.uids.pop()
+                        break
+                self._img_uids[name].appendleft(datum_uid)
+
+            # No image available? Skip this update.
+            if img_array is None:
+                continue
+
+            # If this is an image cube, sum along the first axis
+            # and display it like an image.
+            # TODO: Display volumes for real.
+            if name in self._cube_names:
+                img_array = img_array.sum(0)
+
+            # Update the image.
+            if name not in self._img_objs:
+                self._img_obj[name] = ax.imshow(img_array)
+            else:
+                img_obj.set_array(img_array)
+            self._img_figs[name].canvas.draw()

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -8,7 +8,7 @@ class PlotManager(object):
     def __init__(self):
         self._has_figures = False
 
-    def update_positioners(self, positioners):
+    def update_positioners(self, positioners, detectors):
         if len(positioners) == 1:
             self._x_name = positioners[0].name
         else:


### PR DESCRIPTION
This PR adds callbacks to the scan, allowing the user to register functions at the start and stop and after the insertion of each event and event descriptor. I think this is more or less in line with @dchabot's general plans for the flow of ophyd.

There are two callback registries here, a private one that is processed by the Scan thread and a public one that is processed by the main thread. The private callbacks add new data to a Queue, and that Queue is processed by the public callbacks in the main thread.

Here, I use those callbacks to generate live-updating matplotlib figures: one figure with a subplot for each scalar detector, and a separate figure for each image detector. The registries are set up on a per-scan basis, so beamlines can set up special live plotting feedback for their special scans.

*This simple implementation is not a good general solution.* Although matplotlib and the scan are running on separate threads, they are on the same process. If matplotlib cannot do its work in whatever time the scan spends sleeping, it will slow down the scan. In the future, these callbacks could be used to communicate with a separate plotting *process*. All of the matplotlib code is isolate can be neatly excised later.