### PR TITLE
WIP: Moar callbacks

### DIFF
--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -1,4 +1,7 @@
-from __future__ import print_function
+from __future__ import print_function, division
+
+import six
+
 import logging
 from warnings import warn
 import getpass
@@ -6,13 +9,13 @@ import os
 import datetime
 import time
 from collections import defaultdict
-from threading import Thread
+from threading import Thread, Timer
 from Queue import Queue, Empty
 import numpy as np
 from ..session import register_object
 from ..controls.detector import Detector
 from metadatastore import api as mds
-import matplotlib.pyplot as plt
+import traceback
 
 
 def _get_info(positioners=None, detectors=None, data=None):
@@ -103,19 +106,64 @@ class Demuxer(object):
         return
 
 
-class RunEngine(object):
-    '''The run engine
+class KillScanException(RuntimeError):
+    """Exception that gets raised when a KillScanCondition is met
 
-    Parameters
+    Attributes
+    ----------
+    killers : list
+        List of callables that told the RunEngine to kill itself
+    """
+    def __init__(self, killers):
+        super(KillScanException, self).__init__("Scan killed: %s" % killers)
+
+
+class RunEngine(object):
+    """The run engine
+
+    Attributes
     ----------
     logger : logging.Logger
-    '''
+    scan : ophyd.scan_api.Scan
+        the ophyd.scan_api.Scan object that called the RunEngine
+    pause : bool
+        True: Pause the scan
+        False: Do not pause the scan
+    _pausers : set
+        Set of callables that have paused the scan
+    pause_time : int
+        If ``self.pause``, wait ``pause_time`` before checking if ``self.pause``
+        is True
+    kill : bool
+        True: kill the scan
+    _killers : set
+        Set of callables that have asked the scan to terminate
+    """
 
-    def __init__(self, logger):
+    def __init__(self, logger, pause_time=.1):
         self._demuxer = Demuxer()
         self._sessionmgr = register_object(self)
         self._scan_state = False
         self.logger = self._sessionmgr._logger
+        self.logger.setLevel(logging.DEBUG)
+
+        # the currently executing scan thread
+        self._scan_thread = None
+        # the ophyd.scan_api.Scan object that called the RunEngine
+        self.scan = None
+
+        # boolean flag to pause the scan
+        self._pause = False
+        self._pausers = set()
+        # if self._pause is True, check with `_pause_time` frequency until
+        # it is False
+        self.pause_time = pause_time  # ms
+        # boolean flag to kill the scan
+        self._kill = False
+        self._killers = set()
+        # lists of threading.Timer objects that set the _pause/_kill attrs
+        self._pause_timers = []
+        self._kill_timers = []
 
     # start/stop/pause/resume are external api methods
     def start(self):
@@ -128,11 +176,41 @@ class RunEngine(object):
     def running(self):
         return self._scan_state
 
-    def pause(self):
-        pass
+    def kill(self, killing_callable):
+        """Kill the scan
 
-    def resume(self):
-        pass
+        Set the kill instance attribute to True so that the next time the flag
+        is checked, the scan will raise a ``ScanKilledException`` and exit
+        """
+        self._killers.add(killing_callable)
+        self._kill = True
+
+    def pause(self, pausing_callable):
+        """Pause the scan.
+
+        Set the pause instance attribute to True so that the next time the flag
+        is checked, the scan will wait until it is False
+        """
+        self.logger.info("Scan is being paused by: {}"
+                         "".format(pausing_callable))
+        self.logger.info("Scan is additionally waiting on {}"
+                         "".format(self._pausers))
+        self._pausers.add(pausing_callable)
+        self._pause = True
+
+    def resume(self, pausing_callable):
+        """Resume the scan
+
+        Set the pause instance attribute to False so that the next time the
+        flag is checked, the scan will resume
+        """
+        # remove the pausing_callable from the list
+        self._pausers.remove(pausing_callable.name)
+        self.logger.info("Scan no longer paused by: %s" % pausing_callable)
+        if self._pausers:
+            self.logger.info("Scan is still waiting on %s" % self._pausers)
+        else:
+            self._pause = False
 
     def _run_start(self, arg):
         # run any registered user functions
@@ -140,14 +218,38 @@ class RunEngine(object):
         self.logger.info('Begin Run...')
 
     def _end_run(self, arg):
+        # start up the pause scan conditions
+        for pause_scan_condition in self.scan.pause_scan_conditions:
+            pause_scan_condition.stop_checking()
+
         state = arg.get('state', 'success')
         bre = arg['run_start']
-        scan = arg['scan']
-        rs = mds.insert_run_stop(bre, time.time(), exit_status=state)
-        scan.emit_stop(rs)
+        reason = arg.pop('verbose_end_condition', '')
+        rs = mds.insert_run_stop(bre, time.time(), exit_status=state,
+                                 reason=reason)
+        self.scan.emit_stop(rs)
         self.logger.info('End Run...')
 
+    def _check_scan_status(self):
+        """Helper function to check kill/pause statuses
+
+        """
+        # check for a kill signal first
+        def kill():
+            if self._kill:
+                raise KillScanException(self._killers)
+        kill()
+        # keep checking until the scan is unpaused
+        while self._pause:
+            self.logger.info("in _check_scan_status waiting for self.pause to "
+                             "be False. It's value is currently %s" % self._pause)
+            kill()
+            time.sleep(self.pause_time)
+
     def _move_positioners(self, positioners=None, settle_time=None):
+        self.logger.info('pre-move')
+        self._check_scan_status()
+        self.scan.cb_registry.process('pre-move',  self)
         try:
             status = [pos.move_next(wait=False)[1] for pos in positioners]
         except StopIteration:
@@ -157,12 +259,17 @@ class RunEngine(object):
         time.sleep(0.05)
         # TODO: this should iterate at most N times to catch hangups
         while not all(s.done for s in status):
+            self.logger.info('during move')
             time.sleep(0.1)
+
         if settle_time is not None:
             time.sleep(settle_time)
 
         # use metadatastore to format the events so that ophyd is insulated
         # from metadatastore spec changes
+        self._check_scan_status()
+        self.logger.info('post-move')
+        self.scan.cb_registry.process('post-move',  self)
         return {
             pos.name: {
                 'timestamp': pos.timestamp[pos.pvname.index(pos.report['pv'])],
@@ -171,7 +278,7 @@ class RunEngine(object):
 
     def _start_scan(self, run_start=None, detectors=None,
                     data=None, positioners=None, settle_time=None,
-                    scan=None, **kw):
+                    **kw):
         dets = detectors
         triggers = [det for det in dets if isinstance(det, Detector)]
 
@@ -188,32 +295,45 @@ class RunEngine(object):
         self.logger.info(self._demunge_names(names))
         seq_num = 0
         while self._scan_state is True:
-            self.logger.debug(
-                'self._scan_state is True in self._start_scan')
+            self.logger.debug('self._scan_state is still True in self._start_scan')
             posvals = self._move_positioners(positioners, settle_time)
             self.logger.debug('moved positioners')
             # if we're done iterating over positions, get outta Dodge
             if posvals is None:
+                self.logger.debug('posvals is None. Breaking out.')
                 break
 
             # Trigger detector acquisision
+            self._check_scan_status()
+            self.logger.info('processing pre-trigger callbacks')
+            self.scan.cb_registry.process('pre-trigger',  self)
+            self.logger.debug('gathering acquire status')
             acq_status = [trig.acquire() for trig in triggers]
 
             while any([not stat.done for stat in acq_status]):
+                self.logger.info('waiting for acquisition to be finished')
                 time.sleep(0.05)
-
-            time.sleep(0.05)
+            self.logger.info('acquisition finished')
+            self._check_scan_status()
+            self.logger.debug('processing post-trigger callbacks')
+            self.scan.cb_registry.process('post-trigger',  self)
             # Read detector values
             tmp_detvals = {}
+            self.logger.debug('gathering detector values')
             for det in dets + positioners:
-                tmp_detvals.update(det.read())
+                read_val = det.read()
+                self.logger.debug('updating temp vals: {}'.format(read_val))
+                tmp_detvals.update(read_val)
 
+
+            self.logger.debug('formatting event for mds')
             detvals = mds.format_events(tmp_detvals)
 
-            # pass data onto Demuxer for distribution
+            self.logger.debug('passing data onto Demuxer for distribution')
             self.logger.info(self._demunge_values(detvals, names))
             # grab the current time as a timestamp that describes when the
             # event data was bundled together
+            self.logger.debug('grabbing bundle time')
             bundle_time = time.time()
             # actually insert the event into metadataStore
             try:
@@ -237,7 +357,7 @@ class RunEngine(object):
                     data_keys=mds.format_data_keys(data_key_info))
                 self.logger.debug(
                     'event_descriptor: %s', vars(event_descriptor))
-                scan.emit_descriptor(event_descriptor)
+                self.scan.emit_descriptor(event_descriptor)
                 # insert the event again. this time it better damn well work
                 self.logger.debug(
                     'inserting event %d------------------', seq_num)
@@ -247,7 +367,7 @@ class RunEngine(object):
             self.logger.debug('event %d--------', seq_num)
             self.logger.debug('%s', vars(event))
 
-            scan.emit_event(event)
+            self.scan.emit_event(event)
 
             seq_num += 1
             # update the 'data' object from detvals dict
@@ -309,7 +429,9 @@ class RunEngine(object):
         data : dict
             {data_name: []}
         """
-        runid = scan.scan_id
+        # stash the current scan
+        self.scan = scan
+        runid = self.scan.scan_id
         if start_args is None:
             start_args = {}
         if end_args is None:
@@ -334,7 +456,7 @@ class RunEngine(object):
         run_start = mds.insert_run_start(
             time=recorded_time, beamline_id=beamline_id, owner=owner,
             beamline_config=blc, scan_id=runid, custom=custom)
-        scan.emit_start(run_start)
+        self.scan.emit_start(run_start)
         pretty_time = datetime.datetime.fromtimestamp(
             recorded_time).isoformat()
         self.logger.info("Scan ID: %s", runid)
@@ -361,25 +483,47 @@ class RunEngine(object):
         self._scan_state = True
         self._scan_thread.start()
         end_args['scan'] = scan
+        # start up the pause scan conditions
+        for pause_scan_condition in scan.pause_scan_conditions:
+            pause_scan_condition(self)
         try:
             while self._scan_state is True:
+                self.logger.debug('scan state is still true')
+                if np.random.random() < 0.05:
+                    self._pause = True
+                    self.logger.warning("Pausing run engine")
+                elif self._pause:
+                    self._pause = False
+                    self.logger.warning("Releasing pause on run engine")
                 try:
-                    descriptor = scan.desc_queue.get(timeout=0.05)
+                    while True:
+                        self.logger.debug('trying to get something from the '
+                                          'scan.desc_queue')
+                        descriptor = self.scan.desc_queue.get(timeout=0.05)
+                        self.logger.debug('processing the event-descriptor signal')
+                        self.scan.cb_registry.process('event-descriptor',
+                                                      descriptor)
+                except Empty as e:
+                    pass
+                try:
+                    while True:
+                        self.logger.debug('trying to get something from the '
+                                          'scan.ev_queue')
+                        event = self.scan.ev_queue.get(timeout=0.05)
+                        self.logger.debug('processing the event signal')
+                        self.scan.cb_registry.process('event', event)
                 except Empty:
                     pass
-                else:
-                    scan.cb_registry.process('event-descriptor',  descriptor)
-                try:
-                    event = scan.ev_queue.get(timeout=0.05)
-                except Empty:
-                    pass
-                else:
-                    scan.cb_registry.process('event', event)
-        except KeyboardInterrupt:
+                self.logger.debug('sleeping for 1 second')
+                time.sleep(1)
+        except (KeyboardInterrupt, KillScanException):
             self._scan_state = False
             self._scan_thread.join()
             end_args['state'] = 'abort'
+            end_args['verbose_end_condition'] = traceback.format_exc()
         finally:
             self._end_run(end_args)
+        # clear the stashed scan
+        self.scan = None
 
         return data

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -205,7 +205,7 @@ class RunEngine(object):
         flag is checked, the scan will resume
         """
         # remove the pausing_callable from the list
-        self._pausers.remove(pausing_callable.name)
+        self._pausers.remove(pausing_callable)
         self.logger.info("Scan no longer paused by: %s" % pausing_callable)
         if self._pausers:
             self.logger.info("Scan is still waiting on %s" % self._pausers)
@@ -241,8 +241,9 @@ class RunEngine(object):
         kill()
         # keep checking until the scan is unpaused
         while self._pause:
-            self.logger.info("in _check_scan_status waiting for self.pause to "
-                             "be False. It's value is currently %s" % self._pause)
+            self.logger.info("in _check_scan_status waiting for self._pause to "
+                             "be False. It's value is currently %s" %
+                             self._pause)
             kill()
             time.sleep(self.pause_time)
 

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -248,10 +248,6 @@ class RunEngine(object):
             self.logger.debug('%s', vars(event))
 
             scan.emit_event(event)
-            for f_mgr in plt._pylab_helpers.Gcf.get_all_fig_managers():
-                # TODO Use this in the future, or just plt.draw_all I guess?
-                # if force or f_mgr.canvas.figure.stale:
-                f_mgr.canvas.draw()
 
             seq_num += 1
             # update the 'data' object from detvals dict
@@ -364,7 +360,6 @@ class RunEngine(object):
         self._scan_thread.start()
         end_args['scan'] = scan
         try:
-            setup = False
             while self._scan_state is True:
                 try:
                     descriptor = scan.desc_queue.get(timeout=0.05)
@@ -372,21 +367,12 @@ class RunEngine(object):
                     pass
                 else:
                     scan.cb_registry.process('descriptor',  descriptor)
-                    setup = True
-                if not setup:
-                    continue
                 try:
                     event = scan.ev_queue.get(timeout=0.05)
                 except Empty:
                     pass
                 else:
-                    scan.cb_registry.process('descriptor',  descriptor)
                     scan.cb_registry.process('event', event)
-            	for f_mgr in plt._pylab_helpers.Gcf.get_all_fig_managers():
-                    print(f_mgr)
-                    f_mgr.canvas.figure.show()
-                    f_mgr.canvas.draw()
-                    f_mgr.canvas.flush_events()
         except KeyboardInterrupt:
             self._scan_state = False
             self._scan_thread.join()

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -368,7 +368,7 @@ class RunEngine(object):
                 except Empty:
                     pass
                 else:
-                    scan.cb_registry.process('descriptor',  descriptor)
+                    scan.cb_registry.process('event-descriptor',  descriptor)
                 try:
                     event = scan.ev_queue.get(timeout=0.05)
                 except Empty:

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -171,7 +171,7 @@ class RunEngine(object):
 
     def _start_scan(self, run_start=None, detectors=None,
                     data=None, positioners=None, settle_time=None,
-                    **kwargs):
+                    scan=None, **kw):
         dets = detectors
         triggers = [det for det in dets if isinstance(det, Detector)]
 
@@ -336,7 +336,7 @@ class RunEngine(object):
             beamline_config=blc, scan_id=runid, custom=custom)
         scan.emit_start(run_start)
         pretty_time = datetime.datetime.fromtimestamp(
-                                          recorded_time).isoformat()
+            recorded_time).isoformat()
         self.logger.info("Scan ID: %s", runid)
         self.logger.info("Time: %s", pretty_time)
         self.logger.info("uid: %s", str(run_start.uid))

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -147,7 +147,7 @@ class RunEngine(object):
         scan.emit_stop(rs)
         self.logger.info('End Run...')
 
-    def _move_positioners(self, positioners=None, settle_time=None, **kwargs):
+    def _move_positioners(self, positioners=None, settle_time=None):
         try:
             status = [pos.move_next(wait=False)[1] for pos in positioners]
         except StopIteration:
@@ -169,9 +169,9 @@ class RunEngine(object):
                 'value': pos.position}
             for pos in positioners}
 
-    def _start_scan(self, scan=None, run_start=None, detectors=None,
-                    data=None, positioners=None, **kwargs):
-
+    def _start_scan(self, run_start=None, detectors=None,
+                    data=None, positioners=None, settle_time=None,
+                    **kwargs):
         dets = detectors
         triggers = [det for det in dets if isinstance(det, Detector)]
 
@@ -190,7 +190,7 @@ class RunEngine(object):
         while self._scan_state is True:
             self.logger.debug(
                 'self._scan_state is True in self._start_scan')
-            posvals = self._move_positioners(**kwargs)
+            posvals = self._move_positioners(positioners, settle_time)
             self.logger.debug('moved positioners')
             # if we're done iterating over positions, get outta Dodge
             if posvals is None:
@@ -345,7 +345,9 @@ class RunEngine(object):
         scan_args['run_start'] = run_start
         end_args['run_start'] = run_start
 
-        keys = self._get_data_keys(**scan_args)
+        keys = self._get_data_keys(
+            positioners=scan_args.get('positioners', None),
+            detectors=scan_args.get('detectors', None))
         data = defaultdict(list)
 
         scan_args['data'] = data

--- a/ophyd/session/__init__.py
+++ b/ophyd/session/__init__.py
@@ -4,7 +4,7 @@ import sys
 import logging
 import warnings
 
-LOG_FORMAT = "%(asctime)-15s [%(name)5s:%(levelname)s] %(message)s"
+LOG_FORMAT = "%(asctime)-15s [%(levelname)s] %(message)s"
 OPHYD_LOGGER = 'ophyd_session'
 
 

--- a/ophyd/session/__init__.py
+++ b/ophyd/session/__init__.py
@@ -4,7 +4,7 @@ import sys
 import logging
 import warnings
 
-LOG_FORMAT = "%(asctime)-15s [%(levelname)s] %(message)s"
+LOG_FORMAT = "thread %(thread)d: %(asctime)-15s [%(levelname)s] %(message)s"
 OPHYD_LOGGER = 'ophyd_session'
 
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 from time import sleep
 import sys
 import collections
+from Queue import Queue
 import itertools
 import string
 import traceback
@@ -36,7 +37,7 @@ def estimate(x, y):
     stats['x_at_ymax'] = x[y.argmax()]
     # Calculate CEN from derivative
     zero_cross = np.where(np.diff(np.sign(y - (stats['ymax']
-                                               + stats['ymin']) / 2)))[0]
+                                               + stats['ymin'])/2)))[0]
     if zero_cross.size == 2:
         stats['cen'] = (x[zero_cross].sum() / 2,
                         (stats['ymax'] + stats['ymin']) / 2)
@@ -157,9 +158,11 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
-        self._cb_registry = CallbackRegistry()
-        self.autoplot = True
+        self._scan_cb_registry = CallbackRegistry()  # process on scan thread
+        self.cb_registry = CallbackRegistry()  # process on main thread
         self._plot_mgr = PlotManager()
+        self._autoplot = None
+        self.autoplot = True
 
         self.paths = list()
         self.positioners = list()
@@ -354,23 +357,23 @@ class Scan(object):
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
-        self._cb_registry.connect(name, func)
+        self._scan_cb_registry.connect(name, func)
 
     def emit_event(self, event):
         "Called by the Run Engine after each new event is created."
-        self._cb_registry.process('event', event)
+        self._scan_cb_registry.process('event', event)
 
     def emit_descriptor(self, descriptor):
         "Called by the Run Engine after each new event desc is created."
-        self._cb_registry.process('descriptor', descriptor)
+        self._scan_cb_registry.process('descriptor', descriptor)
 
     def emit_start(self, start):
         "Called by the Run Engine after a scan is started."
-        self._cb_registry.process('start', start)
+        self._scan_cb_registry.process('start', start)
 
     def emit_stop(self, stop):
         "Called by the Run Engine after a scan is stopped."
-        self._cb_registry.process('stop', stop)
+        self._scan_cb_registry.process('stop', stop)
 
     @property
     def autoplot(self):
@@ -378,7 +381,7 @@ class Scan(object):
 
     @autoplot.setter
     def autoplot(self, val):
-        if bool(val) = self._autoplot:
+        if bool(val) == self._autoplot:
             return
         self._autoplot = bool(val)
         cb_reg = self._cb_registry  # for brevity
@@ -386,12 +389,12 @@ class Scan(object):
             # when a callback is registered, it returns an integer ID
             # that can be used to deregister it.
             self._plot_callback_ids = []
-            cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
+            cid = cb_reg.connect('descriptor', self.add_to_queue)
             self._plot_callback_ids.append(cid)
-            cid = cb_reg.connect('event', self._plot_mgr.update_plot)
+            cid = cb_reg.connect('event', self.add_to_queue)
             self._plot_callback_ids.append(cid)
         else:
-            [cg_reg.disconnect(cid) for cid in self._plot_callback_ids]
+            [cb_reg.disconnect(cid) for cid in self._plot_callback_ids]
 
 
 class AScan(Scan):

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -172,6 +172,8 @@ class Scan(object):
         self.paths = list()
         self.positioners = list()
 
+        self.pause_scan_conditions = []
+
         try:
             self.logbook = session_manager['olog_client']
         except KeyError:
@@ -346,6 +348,9 @@ class Scan(object):
         """
         return self._shared_config['user_detectors'] + self.default_detectors
 
+    def add_scan_condition(self, scan_condition):
+        self.pause_scan_conditions.append(scan_condition)
+        
     def register_callback(self, name, func):
         """
         Register a callback function to be processed by the main thread.
@@ -356,13 +361,17 @@ class Scan(object):
 
         Parameters
         ----------
-        name: {'pre-scan', 'run-start', 'event-descriptor', 'event', 'run-stop',
-               'post-scan'}
+        name: {'pre-scan', 'post-scan'.
+               'run-start', 'event-descriptor', 'event', 'run-stop',
+               'pre-move', 'during-move', 'post-move', 'pre-trigger',
+               'during-trigger', 'post-trigger'
+               }
         func: callable
             run-start, event-descriptor, event, run-stop callbacks expect
-            signature ``f(mongoengine.Document)``
+                signature ``f(mongoengine.Document)``
             pre-scan and post-scan callbacks expect signature
-            ``f(ScanObject)``)
+                ``f(ScanObject)``)
+            move and trigger callbacks expect signature ``f(RunEngineInstance)``
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: %s" % self.valid_callbacks)

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -9,12 +9,14 @@ import string
 import traceback
 
 from IPython.utils.coloransi import TermColors as tc
+from matplotlib.cbook import CallbackRegistry
 from filestore.api import retrieve
 from mongoengine import DoesNotExist
 
 from ..runengine import RunEngine
 from ..session import get_session_manager
 from ..utils import LimitError
+from ..utils.plotting import PlotManager
 from ..controls import Detector
 
 session_manager = get_session_manager()
@@ -143,6 +145,7 @@ class Scan(object):
     _shared_config = {'default_detectors': [],
                       'user_detectors': [],
                       'scan_data': None, }
+    valid_callbacks = ['start', 'stop', 'event', 'descriptor']
 
     def __init__(self, *args, **kwargs):
         super(Scan, self).__init__(*args, **kwargs)
@@ -154,7 +157,9 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
+        self._cb_registry = CallbackRegistry()
         self.autoplot = True
+        self._plot_mgr = PlotManager()
 
         self.paths = list()
         self.positioners = list()
@@ -211,6 +216,7 @@ class Scan(object):
 
     def pre_scan(self):
         """Routine run before scan starts"""
+        self._plot_mgr.update_positioners(self.positioners)
         pass
 
     def post_scan(self):
@@ -333,101 +339,59 @@ class Scan(object):
         """
         return self._shared_config['user_detectors'] + self.default_detectors
 
-    def setup_plot(self, event_descriptor):
-        if not self.autoplot:
-            return
-        scalars = []
-        images = []
-        cubes = []
-        for key, val in six.iteritems(event_descriptor.data_keys):
-            if val['shape'] is None:
-                scalars.append(key)
-                continue
-            ndim = len(val['shape'])
-            if ndim == 2:
-                images.append(key)
-            elif ndim == 3:
-                cubes.append(key)
-            else:
-                pass  # >3D data just won't be shown
+    def register_callback(self, name, func):
+        """
+        Register a callback function.
 
-        if len(positioners) == 1:
-            self._x = positioners[0]
-            if self._x not in scalars:
-                raise NotImplementedError("Not sure how to plot this. Turn of "
-                                          "the scan's autoplot attribute.")
-            scalars.remove(self._x)
+        The Run Engine will execute callback functions at the start and end
+        of a scan, and after the insertion of new Event Descriptors
+        and Events.
+
+        Parameters
+        ----------
+        name: {'start', 'stop', 'descriptor', 'event'}
+        func: callable with signature f(Scan, mongoengine.Document)
+        """
+        if name not in self.valid_callbacks:
+            raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
+        self._cb_registry.connect(name, func)
+
+    def emit_event(self, event):
+        "Called by the Run Engine after each new event is created."
+        self._cb_registry.process('event', event)
+
+    def emit_descriptor(self, descriptor):
+        "Called by the Run Engine after each new event desc is created."
+        self._cb_registry.process('descriptor', descriptor)
+
+    def emit_start(self, start):
+        "Called by the Run Engine after a scan is started."
+        self._cb_registry.process('start', start)
+
+    def emit_stop(self, stop):
+        "Called by the Run Engine after a scan is stopped."
+        self._cb_registry.process('stop', stop)
+
+    @property
+    def autoplot(self):
+        return self._autoplot
+
+    @autoplot.setter
+    def autoplot(self, val):
+        if bool(val) = self._autoplot:
+            return
+        self._autoplot = bool(val)
+        cb_reg = self._cb_registry  # for brevity
+        if val:
+            # when a callback is registered, it returns an integer ID
+            # that can be used to deregister it.
+            self._plot_callback_ids = []
+            cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
+            self._plot_callback_ids.append(cid)
+            cid = cb_reg.connect('event', self._plot_mgr.update_plot)
+            self._plot_callback_ids.append(cid)
         else:
-            self._x_name = None  # plot against seq_num
-        self._cube_names = cubes
-
-        # Build figures, axes, lines.
-        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
-        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
-        self._scalar_lines = {name: ax.plot([], [])[0]}
-        self._scalar_fig.subplots_adjust()
-        for name, ax in six.iteritems(self._scalar_axes):
-            ax.set(title=name)
-        self._image_figs = {name: plt.figure() for name in in images + cubes}
-        self._image_axes = {fig.add_axes((0, 0, 1, 1)) for fig in self._image_figs}
-        self._img_objs = {}  # will hold AxesImage objects
-        self._img_uids = {name: deque() for name in images + cubes}
-
-    def update_plot(self, event):
-        if not self.autoplot:
-            return
-        # Add a data point to the subplot for each scalar.
-        x_val = event[self._x_name][0]  # unpack value from raw Event
-        for name, ax in self._scalar_axes:
-            y_val = event[name][0]  # unpack value from raw Event
-            line = self._scalar_lines[name]
-            old_x, old_y = line.get_data()
-            x = np.append(old_x, x_val)
-            y = np.append(old_y, y_val)
-            line.set_data(x, y)
-        self._scalar_fig.canvas.draw()
-
-        # Try to get the latest image, or a recent image,
-        # to update each image figure.
-        for name, ax in self._image_axes:
-            datum_uid = event[name][0]
-            img_array = None
-            try:
-                img_array = retrieve(datum_uid)
-            except DoesNotExist:
-                # Data may not be readable yet.
-                # Try uids in cache, starting with the most recent one.
-                uids = self._img_uids[name]
-                for i, datum_uid in enumerate(uids):
-                    try:
-                        img_array = filestore.retrieve(datum_uid)
-                    except filestore.DatumNotFound
-                        continue
-                    else:
-                        # To avoid ever showing an image that is older
-                        # than we one we just found,
-                        # remove all older images from the cache.
-                        for _ in len(uids) - i:
-                            self.uids.pop()
-                        break
-                self._img_uids[name].appendleft(datum_uid)
-
-            # No image available? Skip this update.
-            if img_array is None:
-                continue
-
-            # If this is an image cube, sum along the first axis
-            # and display it like an image.
-            # TODO: Display volumes for real.
-            if name in self._cube_names:
-                img_array = img_array.sum(0)
-
-            # Update the image.
-            if name not in self._img_objs:
-                self._img_obj[name] = ax.imshow(img_array)
-            else:
-                img_obj.set_array(img_array)
-            self._img_figs[name].canvas.draw()
+            [cg_reg.disconnect(cid) for cid in self._plot_callback_ids]
 
 
 class AScan(Scan):

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import numpy as np
+import matplotlib.pyplot as plt
 from time import sleep
 import sys
 import collections
@@ -8,6 +9,8 @@ import string
 import traceback
 
 from IPython.utils.coloransi import TermColors as tc
+from filestore.api import retrieve
+from mongoengine import DoesNotExist
 
 from ..runengine import RunEngine
 from ..session import get_session_manager
@@ -151,6 +154,7 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
+        self.autoplot = True
 
         self.paths = list()
         self.positioners = list()
@@ -257,7 +261,7 @@ class Scan(object):
             scan_args['custom'] = kwargs
 
             # Run the scan!
-            data = self._run_eng.start_run(self.scan_id,
+            data = self._run_eng.start_run(self,
                                            scan_args=scan_args)
 
             self._data_buffer.append(Data(data))
@@ -328,6 +332,102 @@ class Scan(object):
         list of OphydObjects
         """
         return self._shared_config['user_detectors'] + self.default_detectors
+
+    def setup_plot(self, event_descriptor):
+        if not self.autoplot:
+            return
+        scalars = []
+        images = []
+        cubes = []
+        for key, val in six.iteritems(event_descriptor.data_keys):
+            if val['shape'] is None:
+                scalars.append(key)
+                continue
+            ndim = len(val['shape'])
+            if ndim == 2:
+                images.append(key)
+            elif ndim == 3:
+                cubes.append(key)
+            else:
+                pass  # >3D data just won't be shown
+
+        if len(positioners) == 1:
+            self._x = positioners[0]
+            if self._x not in scalars:
+                raise NotImplementedError("Not sure how to plot this. Turn of "
+                                          "the scan's autoplot attribute.")
+            scalars.remove(self._x)
+        else:
+            self._x_name = None  # plot against seq_num
+        self._cube_names = cubes
+
+        # Build figures, axes, lines.
+        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
+        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
+        self._scalar_lines = {name: ax.plot([], [])[0]}
+        self._scalar_fig.subplots_adjust()
+        for name, ax in six.iteritems(self._scalar_axes):
+            ax.set(title=name)
+        self._image_figs = {name: plt.figure() for name in in images + cubes}
+        self._image_axes = {fig.add_axes((0, 0, 1, 1)) for fig in self._image_figs}
+        self._img_objs = {}  # will hold AxesImage objects
+        self._img_uids = {name: deque() for name in images + cubes}
+
+    def update_plot(self, event):
+        if not self.autoplot:
+            return
+        # Add a data point to the subplot for each scalar.
+        x_val = event[self._x_name][0]  # unpack value from raw Event
+        for name, ax in self._scalar_axes:
+            y_val = event[name][0]  # unpack value from raw Event
+            line = self._scalar_lines[name]
+            old_x, old_y = line.get_data()
+            x = np.append(old_x, x_val)
+            y = np.append(old_y, y_val)
+            line.set_data(x, y)
+        self._scalar_fig.canvas.draw()
+
+        # Try to get the latest image, or a recent image,
+        # to update each image figure.
+        for name, ax in self._image_axes:
+            datum_uid = event[name][0]
+            img_array = None
+            try:
+                img_array = retrieve(datum_uid)
+            except DoesNotExist:
+                # Data may not be readable yet.
+                # Try uids in cache, starting with the most recent one.
+                uids = self._img_uids[name]
+                for i, datum_uid in enumerate(uids):
+                    try:
+                        img_array = filestore.retrieve(datum_uid)
+                    except filestore.DatumNotFound
+                        continue
+                    else:
+                        # To avoid ever showing an image that is older
+                        # than we one we just found,
+                        # remove all older images from the cache.
+                        for _ in len(uids) - i:
+                            self.uids.pop()
+                        break
+                self._img_uids[name].appendleft(datum_uid)
+
+            # No image available? Skip this update.
+            if img_array is None:
+                continue
+
+            # If this is an image cube, sum along the first axis
+            # and display it like an image.
+            # TODO: Display volumes for real.
+            if name in self._cube_names:
+                img_array = img_array.sum(0)
+
+            # Update the image.
+            if name not in self._img_objs:
+                self._img_obj[name] = ax.imshow(img_array)
+            else:
+                img_obj.set_array(img_array)
+            self._img_figs[name].canvas.draw()
 
 
 class AScan(Scan):
@@ -547,6 +647,10 @@ class Count(Scan):
     A log entry is created if the logbook is setup which records the
     result of the scan.
     """
+    def __init__(self, *args, **kwargs):
+        super(Count, self).__init__(*args, **kwargs)
+        self.autoplot = False
+
     def post_scan(self):
         """Post-scan print data
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -363,7 +363,7 @@ class Scan(object):
             start, descriptor, event, stop callbacks expect signature
             ``f(mongoengine.Document)``
             pre-scan and post-scan callbacks expect signature
-            ``f(positioners, detectors)``(
+            ``f(positioners, detectors)``)
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))

--- a/ophyd/utils/conditions.py
+++ b/ophyd/utils/conditions.py
@@ -1,0 +1,179 @@
+import time as ttime
+from threading import Timer, Thread
+import logging
+logger = logging.getLogger(__name__)
+
+
+class PauseScanCondition(object):
+    """Mechanism to pause the scan while some condition is met
+
+    Note: Callable functions must have a function signature
+        ``f(ophyd.run_engine.RunEngine)`` and it must return the reason
+        for pausing as a string or an empty string to indicate that it should
+        not be paused/resumed/killed
+
+    Parameters
+    ----------
+    pausing_callable : callable
+        The condition that must be met for the scan to resume.
+        Callable must
+    name : str
+        The human-readable name of this ScanCondition for logging purposes
+    resuming_callable : callable, optional
+        A callable that returns True when the scan should resume.
+        Defaults to the inverse of the pausing callable
+        Function Signature: ``f(ophyd.run_engine.RunEngine)``
+    killing_callable : callable, optional
+        A callable that returns True if the scan should be killed. Note that
+        there is no way to undo a kill command
+        Function Signature: ``f(ophyd.run_engine.RunEngine)``
+    pause_timeout : float
+        time in seconds to wait between checks to see if a scan should be paused
+    resume_timeout : float
+        time in seconds to wait after pausing a scan to attempt to revive it
+    kill_timeout : float
+        time in seconds to wait after pausing a scan to kill the scan if it has
+        not resumed
+    """
+
+    def __init__(self, pausing_callable, name, pause_timeout=.5,
+                 resuming_callable=None, resume_timeout=None,
+                 killing_callable=None, kill_timeout=None):
+        self.pausing_callable = pausing_callable
+        # default to the inverse of the pausing callable
+        if not resuming_callable:
+            resuming_callable = lambda run_engine: (
+                "Scan Resuming" if not pausing_callable(run_engine) else "")
+        self.resuming_callable = resuming_callable
+        self.killing_callable = killing_callable
+        self._was_paused = False
+        self.name = name
+        self.pause_message = ""
+        self.killers_note = ""
+        self.resume_message = ""
+        self.pause_timeout = pause_timeout
+        self.resume_timeout = resume_timeout
+        self.kill_timeout = kill_timeout
+        self.pause_timer = None
+        self.resume_timer = None
+        self.doomsday_clock = None
+        self.continue_checking_for_pause = True
+
+    def stop_checking(self):
+
+        def remove_timer(attr):
+            try:
+                attr.cancel()
+                del attr
+            except AttributeError:
+                pass
+
+        remove_timer(self.pause_timer)
+        remove_timer(self.resume_timer)
+        remove_timer(self.doomsday_clock)
+
+        self.continue_checking_for_pause = False
+
+    def __call__(self, run_engine):
+        self.continue_checking_for_pause = True
+        self.pause_timer = Timer(self.pause_timeout, self._pause, args=[run_engine])
+        self.pause_timer.start()
+        self.pause_timer.run()
+
+    def __str__(self):
+        message = self.name
+        if self.pause_message:
+            message += ". Paused because {}".format(self.pause_message)
+        if self.resume_message:
+            message += ". Resumed because {}".format(self.resume_message)
+        if self.killers_note:
+            message += ". Killed because {}".format(self.killers_note)
+        return message
+
+    def __repr__(self):
+        return "PauseScanCondition(pausing_callable={}, name={}".format(
+            self.pausing_callable, self.name)
+
+    def _kill(self, run_engine):
+        """Determine if the scan should be killed
+
+        Parameters
+        ----------
+        run_engine : ophyd.run_engine.run_engine
+            The currently executing run_engine from ophyd
+        """
+        killers_note = self.killing_callable(run_engine)
+        if killers_note:
+            # dont bother continuing to check the resume timer
+            self.resume_timer.cancel()
+            self.killers_note = killers_note
+            run_engine.kill(self)
+            self._was_paused = False
+        else:
+            logger.warning("Kill scan clock expired for {} but the "
+                           "killing_callable returned False. Restarting"
+                           "the doomsday clock".format(self))
+            # clear the doomsday finished status and restart it!
+            self.doomsday_clock.finished.clear()
+            self.doomsday_clock.run()
+
+    def _resume(self, run_engine):
+        """Determine if the scan should be resumed
+
+        Parameters
+        ----------
+        run_engine : ophyd.run_engine.run_engine
+            The currently executing run_engine from ophyd
+        """
+        resume_message = self.resuming_callable(run_engine)
+        if resume_message:
+            # stop the countdown!
+            self.doomsday_clock.cancel()
+            # delete the Timer instances
+            del self.doomsday_clock
+            del self.resume_timer
+            # only stash the resume message if it is True
+            self.resume_message = resume_message
+            run_engine.resume(self)
+            self._was_paused = False
+            self.pause_message = ""
+        else:
+            # clear the resume_timer's status and restart it
+            self.resume_timer.finished.clear()
+            self.resume_timer.run()
+
+    def _pause(self, run_engine):
+        """Determine if the scan should be paused
+
+        Parameters
+        ----------
+        run_engine : ophyd.run_engine.run_engine
+            The currently executing run_engine from ophyd
+        """
+        pause_message = self.pausing_callable(run_engine)
+        if pause_message:
+            # only stash the pause message if is a non-empty string
+            self.pause_message = pause_message
+            # clear the old resume message
+            self.resume_message = ""
+            print("run_engine: %s" % run_engine)
+            run_engine.pause(self)
+            self._was_paused = True
+            # create and start a resume timer
+            self.resume_timer = Timer(self.resume_timeout, self._resume,
+                                      args=[run_engine])
+            self.resume_timer.start()
+            self.resume_timer.run()
+            # create and start a kill timer if there is a kill_timeout
+            # and a killing_callable
+            if self.kill_timeout and self.killing_callable:
+                self.doomsday_clock = Timer(self.kill_timeout, self._kill,
+                                            args=[run_engine])
+                self.doomsday_clock.start()
+                self.doomsday_clock.run()
+
+        if self.continue_checking_for_pause:
+            # clear the pause_timer's status and restart it
+            # clear the resume_timer's status and restart it
+            self.pause_timer.finished.clear()
+            self.pause_timer.run()

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -1,0 +1,99 @@
+import matplotlib.pyplot as plt
+
+
+class PlotManager(object):
+
+    def update_positioners(self, positioners):
+        if len(positioners) == 1:
+            self._x_name = positioners[0]
+        else:
+            self._x_name = None  # plot against seq_num
+
+    def setup_plot(event_descriptor):
+        scalars = []
+        images = []
+        cubes = []
+        for key, val in six.iteritems(event_descriptor.data_keys):
+            if val['shape'] is None:
+                scalars.append(key)
+                continue
+            ndim = len(val['shape'])
+            if ndim == 2:
+                images.append(key)
+            elif ndim == 3:
+                cubes.append(key)
+            else:
+                pass  # >3D data just won't be shown
+
+            if self._x not in scalars:
+                raise NotImplementedError("Not sure how to plot this. Turn "
+                                          "of the self's autoplot attribute.")
+            scalars.remove(self._x)
+        self._cube_names = cubes
+
+        # Build figures, axes, lines.
+        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
+        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
+        self._scalar_lines = {name: ax.plot([], [])[0]}
+        self._scalar_fig.subplots_adjust()
+        for name, ax in six.iteritems(self._scalar_axes):
+            ax.set(title=name)
+        self._image_figs = {name: plt.figure() for name in in images + cubes}
+        self._image_axes = {fig.add_axes((0, 0, 1, 1))
+                            for fig in self._image_figs}
+        self._img_objs = {}  # will hold AxesImage objects
+        self._img_uids = {name: deque() for name in images + cubes}
+
+    def update_plot(event):
+        # Add a data point to the subplot for each scalar.
+        x_val = event[self._x_name][0]  # unpack value from raw Event
+        for name, ax in self._scalar_axes:
+            y_val = event[name][0]  # unpack value from raw Event
+            line = self._scalar_lines[name]
+            old_x, old_y = line.get_data()
+            x = np.append(old_x, x_val)
+            y = np.append(old_y, y_val)
+            line.set_data(x, y)
+        self._scalar_fig.canvas.draw()
+
+        # Try to get the latest image, or a recent image,
+        # to update each image figure.
+        for name, ax in self._image_axes:
+            datum_uid = event[name][0]
+            img_array = None
+            try:
+                img_array = retrieve(datum_uid)
+            except DoesNotExist:
+                # Data may not be readable yet.
+                # Try uids in cache, starting with the most recent one.
+                uids = self._img_uids[name]
+                for i, datum_uid in enumerate(uids):
+                    try:
+                        img_array = filestore.retrieve(datum_uid)
+                    except filestore.DatumNotFound
+                        continue
+                    else:
+                        # To avoid ever showing an image that is older
+                        # than we one we just found,
+                        # remove all older images from the cache.
+                        for _ in len(uids) - i:
+                            self.uids.pop()
+                        break
+                self._img_uids[name].appendleft(datum_uid)
+
+            # No image available? Skip this update.
+            if img_array is None:
+                continue
+
+            # If this is an image cube, sum along the first axis
+            # and display it like an image.
+            # TODO: Display volumes for real.
+            if name in self._cube_names:
+                img_array = img_array.sum(0)
+
+            # Update the image.
+            if name not in self._img_objs:
+                self._img_obj[name] = ax.imshow(img_array)
+            else:
+                img_obj.set_array(img_array)
+            self._img_figs[name].canvas.draw()

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -8,7 +8,7 @@ class PlotManager(object):
     def __init__(self):
         self._has_figures = False
 
-    def update_positioners(self, positioners):
+    def update_positioners(self, positioners, detectors):
         if len(positioners) == 1:
             self._x_name = positioners[0].name
         else:

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -12,9 +12,9 @@ class PlotManager(object):
         self._has_figures = False
         self._x_name = None
 
-    def update_positioners(self, positioners, detectors):
-        if len(positioners) == 1:
-            self._x_name = positioners[0].name
+    def update_positioners(self, scan_obj):
+        if len(scan_obj.positioners) == 1:
+            self._x_name = scan_obj.positioners[0].name
         else:
             self._x_name = None  # plot against seq_num
 

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -1,12 +1,16 @@
 import six
 import numpy as np
 import matplotlib.pyplot as plt
+from filestore.api import retrieve
+from mongoengine import DoesNotExist
+from collections import deque
 
 
 class PlotManager(object):
 
     def __init__(self):
         self._has_figures = False
+        self._x_name = None
 
     def update_positioners(self, positioners, detectors):
         if len(positioners) == 1:
@@ -20,7 +24,6 @@ class PlotManager(object):
         images = []
         cubes = []
         for key, val in six.iteritems(event_descriptor.data_keys):
-            print key, val['shape']
             if not val['shape']:
                 scalars.append(key)
                 continue
@@ -81,8 +84,8 @@ class PlotManager(object):
                 uids = self._img_uids[name]
                 for i, datum_uid in enumerate(uids):
                     try:
-                        img_array = filestore.retrieve(datum_uid)
-                    except filestore.DatumNotFound:
+                        img_array = retrieve(datum_uid)
+                    except DoesNotExist:
                         continue
                     else:
                         # To avoid ever showing an image that is older
@@ -107,7 +110,7 @@ class PlotManager(object):
             if name not in self._img_objs:
                 self._img_obj[name] = ax.imshow(img_array)
             else:
-                img_obj.set_array(img_array)
+                self._img_obj.set_array(img_array)
         draw_all_figures()
 
 


### PR DESCRIPTION
# Note that this supercedes #116

## Commit summary (latest first)

##### Live plotting works again: https://github.com/ericdill/ophyd/commit/ab158662eb24670f72835698f657a27dcf17983f

##### Bugfixes: https://github.com/ericdill/ophyd/commit/eed5b40a35bd4c553f69b72f9e7b7aac20c012bd

Fixes this problem:
```
In [1]: ascan(pos1, 0, 3, 20)
Stored '_scan_id' (int)
2015-04-20 14:37:36,644 [ophyd_session:INFO] Scan ID: 24
2015-04-20 14:37:36,644 [ophyd_session:INFO] Time: 2015-04-20T14:37:36.631464
2015-04-20 14:37:36,645 [ophyd_session:INFO] uid: 0ce7e249-e558-4890-ab2b-2116c4c8c913
  File "/home/edill/dev/python/ophyd/ophyd/userapi/scan_api.py", line 261, in run
    scan_args=scan_args)
  File "/home/edill/dev/python/ophyd/ophyd/runengine/runengine.py", line 339, in start_run
    keys = self._get_data_keys(**scan_args)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-70ff0c2c4c6c> in <module>()
----> 1 ascan(pos1, 0, 3, 20)

/home/edill/dev/python/ophyd/ophyd/userapi/scan_api.pyc in __call__(self, positioners, start, stop, npts, **kwargs)
    437         """
    438         self.setup_scan(positioners, start, stop, npts, **kwargs)
--> 439         self.run(**kwargs)
    440 
    441     def setup_scan(self, positioners, start, stop, npts, **kwargs):

/home/edill/dev/python/ophyd/ophyd/userapi/scan_api.pyc in run(self, *args, **kwargs)
    259             # Run the scan!
    260             data = self._run_eng.start_run(self.scan_id,
--> 261                                            scan_args=scan_args)
    262 
    263             self._data_buffer.append(Data(data))

/home/edill/dev/python/ophyd/ophyd/runengine/runengine.py in start_run(self, runid, start_args, end_args, scan_args)
    337         end_args['run_start'] = run_start
    338 
--> 339         keys = self._get_data_keys(**scan_args)
    340         data = defaultdict(list)
    341 

TypeError: _get_data_keys() got an unexpected keyword argument 'settle_time'
```

which led to this problem:
```
In [1]: ascan(pos1, 0, 3, 20)
Stored '_scan_id' (int)
2015-04-20 14:39:40,727 [ophyd_session:INFO] Scan ID: 25
2015-04-20 14:39:40,728 [ophyd_session:INFO] Time: 2015-04-20T14:39:40.722365
2015-04-20 14:39:40,728 [ophyd_session:INFO] uid: 54a87b44-76da-498e-927c-0e97ce0c0cdb
2015-04-20 14:39:40,728 [ophyd_session:INFO] Begin Run...
2015-04-20 14:39:40,728 [ophyd_session:INFO] pos1	det1	
Exception in thread Scanner:
Traceback (most recent call last):
  File "/home/edill/anaconda/envs/ophyd/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/home/edill/anaconda/envs/ophyd/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/edill/dev/python/ophyd/ophyd/runengine/runengine.py", line 189, in _start_scan
    posvals = self._move_positioners(**kwargs)
  File "/home/edill/dev/python/ophyd/ophyd/runengine/runengine.py", line 148, in _move_positioners
    status = [pos.move_next(wait=False)[1] for pos in positioners]
TypeError: 'NoneType' object is not iterable
```

which has also been fixed

