### PR TITLE
WIP: Dispatcher, a framework for callbacks that consume Documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,9 @@ target/
 # PyCharm
 .idea/
 .ropeproject
+
+# notebook checkpoints
+.ipynb_checkpoints
+
+# generated docs
+doc/source/generated

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - python
     - pyepics
     - pcaspy
-    - metadatastore
     - six
     - ipython
     - pyolog

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -133,10 +133,9 @@ class RunEngine(object):
     def resume(self):
         pass
 
-
     def _end_run(self, run_start_uid, exit_status):
-        doc = {run_start=run_start_id, time=time.time(),
-               exit_status=exit_status}
+        doc = dict(run_start=run_start_uid, time=time.time(),
+                   exit_status=exit_status)
         scan.emit_stop(doc)
         self.logger.info('End of Run.')
 
@@ -206,14 +205,17 @@ class RunEngine(object):
                 data_key_info = _get_info(
                     positioners=positioners,
                     detectors=dets, data=detvals)
-                doc = dict(run_start=run_start, time=evdesc_creation_time,
-                           data_keys=data_key_info)
+                evdesc_uid = uuid.uuid4()
+                doc = dict(run_start=run_start_uid, time=evdesc_creation_time,
+                           data_keys=data_key_info, uid=evdesc_uid)
                 scan.emit_descriptor(doc)
                 self.logger.debug('Emitted Event Descriptor:\n%s', vars(doc))
             # Build and emit and Event.
             bundle_time = time.time()
-            doc = dict(event_descriptor_uid=event_descriptor_uid,
-                       time=bundle_time, data=detvals, seq_num=seq_num)
+            ev_uid = uuid.uuid4()
+            doc = dict(event_descriptor=evdesc_uid,
+                       time=bundle_time, data=detvals, seq_num=seq_num,
+                       uid=ev_uid)
             self.emit_event(doc)
             self.logger.debug('Emitted Event %d:\n%s' % (seq_num, vars(doc)))
 

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -155,7 +155,7 @@ class RunEngine(object):
 
         return {
             pos.name: (pos.timestamp[pos.pvname.index(pos.report['pv'])],
-                       pos.position}
+                       pos.position)
             for pos in positioners}
 
     def _start_scan(self, scan, run_start_uid, detectors=None,
@@ -312,12 +312,12 @@ class RunEngine(object):
         keys = self._get_data_keys(**scan_kwargs)
         data = defaultdict(list)
 
-        scan_kwargs = {data=data)
+        scan_kwargs = dict(data=data)
 
         self.logger.info('Beginning Run...')
         self._scan_thread = Thread(target=self._start_scan,
                                    name='Scanner',
-                                   args=(scan, run_start_uid)
+                                   args=(scan, run_start_uid),
                                    kwargs=scan_kwargs)
         self._scan_thread.daemon = True
         self._scan_state = True

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -248,10 +248,6 @@ class RunEngine(object):
             self.logger.debug('%s', vars(event))
 
             scan.emit_event(event)
-            for f_mgr in plt._pylab_helpers.Gcf.get_all_fig_managers():
-                # TODO Use this in the future, or just plt.draw_all I guess?
-                # if force or f_mgr.canvas.figure.stale:
-                f_mgr.canvas.draw()
 
             seq_num += 1
             # update the 'data' object from detvals dict
@@ -364,7 +360,6 @@ class RunEngine(object):
         self._scan_thread.start()
         end_args['scan'] = scan
         try:
-            setup = False
             while self._scan_state is True:
                 try:
                     descriptor = scan.desc_queue.get(timeout=0.05)
@@ -372,21 +367,12 @@ class RunEngine(object):
                     pass
                 else:
                     scan.cb_registry.process('descriptor',  descriptor)
-                    setup = True
-                if not setup:
-                    continue
                 try:
                     event = scan.ev_queue.get(timeout=0.05)
                 except Empty:
                     pass
                 else:
-                    scan.cb_registry.process('descriptor',  descriptor)
                     scan.cb_registry.process('event', event)
-            	for f_mgr in plt._pylab_helpers.Gcf.get_all_fig_managers():
-                    print(f_mgr)
-                    f_mgr.canvas.figure.show()
-                    f_mgr.canvas.draw()
-                    f_mgr.canvas.flush_events()
         except KeyboardInterrupt:
             self._scan_state = False
             self._scan_thread.join()

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -262,7 +262,7 @@ class RunEngine(object):
 
         return names
 
-    def start_run(self, scan, start_args=None, end_args=None, scan_args=None):
+    def start_run(self, scan, start_args=None, end_args=None, scan_kwargs=None):
         """
 
         Parameters
@@ -270,7 +270,7 @@ class RunEngine(object):
         scan : Scan instance
         start_args
         end_args
-        scan_args
+        scan_kwargs
 
         Returns
         -------
@@ -282,15 +282,15 @@ class RunEngine(object):
             start_args = {}
         if end_args is None:
             end_args = {}
-        if scan_args is None:
-            scan_args = {}
+        if scan_kwargs is None:
+            scan_kwargs = {}
 
         # format the begin run event information
-        beamline_id = scan_args.get('beamline_id', None)
+        beamline_id = scan_kwargs.get('beamline_id', None)
         if beamline_id is None:
             beamline_id = os.uname()[1].split('-')[0]
-        custom = scan_args.get('custom', None)
-        owner = scan_args.get('owner', None)
+        custom = scan_kwargs.get('custom', None)
+        owner = scan_kwargs.get('owner', None)
         if owner is None:
             owner = getpass.getuser()
         scan_id= str(runid)
@@ -307,7 +307,7 @@ class RunEngine(object):
         self.logger.info("Time: %s", pretty_time)
         self.logger.info("uid: %s", str(run_start.uid))
 
-        keys = self._get_data_keys(**scan_args)
+        keys = self._get_data_keys(**scan_kwargs)
         data = defaultdict(list)
 
         scan_kwargs = {data=data)

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -361,18 +361,7 @@ class RunEngine(object):
         end_args['scan'] = scan
         try:
             while self._scan_state is True:
-                try:
-                    descriptor = scan.desc_queue.get(timeout=0.05)
-                except Empty:
-                    pass
-                else:
-                    scan.cb_registry.process('descriptor',  descriptor)
-                try:
-                    event = scan.ev_queue.get(timeout=0.05)
-                except Empty:
-                    pass
-                else:
-                    scan.cb_registry.process('event', event)
+                scan.dispatcher.process()
         except KeyboardInterrupt:
             self._scan_state = False
             self._scan_thread.join()

--- a/ophyd/runengine/runengine.py
+++ b/ophyd/runengine/runengine.py
@@ -206,10 +206,7 @@ class RunEngine(object):
 
             seq_num += 1
             # update the 'data' object from readings dict
-            print('values', readings)
             for name, payload in readings.items():
-                print('name', name, 'payload', payload)
-                print('data', data)
                 data[name].append(payload)
 
             if not positioners:

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -9,12 +9,14 @@ import string
 import traceback
 
 from IPython.utils.coloransi import TermColors as tc
+from matplotlib.cbook import CallbackRegistry
 from filestore.api import retrieve
 from mongoengine import DoesNotExist
 
 from ..runengine import RunEngine
 from ..session import get_session_manager
 from ..utils import LimitError
+from ..utils.plotting import PlotManager
 from ..controls import Detector
 
 session_manager = get_session_manager()
@@ -143,6 +145,7 @@ class Scan(object):
     _shared_config = {'default_detectors': [],
                       'user_detectors': [],
                       'scan_data': None, }
+    valid_callbacks = ['start', 'stop', 'event', 'descriptor']
 
     def __init__(self, *args, **kwargs):
         super(Scan, self).__init__(*args, **kwargs)
@@ -154,7 +157,9 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
+        self._cb_registry = CallbackRegistry()
         self.autoplot = True
+        self._plot_mgr = PlotManager()
 
         self.paths = list()
         self.positioners = list()
@@ -211,6 +216,7 @@ class Scan(object):
 
     def pre_scan(self):
         """Routine run before scan starts"""
+        self._plot_mgr.update_positioners(self.positioners)
         pass
 
     def post_scan(self):
@@ -333,101 +339,59 @@ class Scan(object):
         """
         return self._shared_config['user_detectors'] + self.default_detectors
 
-    def setup_plot(self, event_descriptor):
-        if not self.autoplot:
-            return
-        scalars = []
-        images = []
-        cubes = []
-        for key, val in six.iteritems(event_descriptor.data_keys):
-            if val['shape'] is None:
-                scalars.append(key)
-                continue
-            ndim = len(val['shape'])
-            if ndim == 2:
-                images.append(key)
-            elif ndim == 3:
-                cubes.append(key)
-            else:
-                pass  # >3D data just won't be shown
+    def register_callback(self, name, func):
+        """
+        Register a callback function.
 
-        if len(positioners) == 1:
-            self._x = positioners[0]
-            if self._x not in scalars:
-                raise NotImplementedError("Not sure how to plot this. Turn of "
-                                          "the scan's autoplot attribute.")
-            scalars.remove(self._x)
+        The Run Engine will execute callback functions at the start and end
+        of a scan, and after the insertion of new Event Descriptors
+        and Events.
+
+        Parameters
+        ----------
+        name: {'start', 'stop', 'descriptor', 'event'}
+        func: callable with signature f(Scan, mongoengine.Document)
+        """
+        if name not in self.valid_callbacks:
+            raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
+        self._cb_registry.connect(name, func)
+
+    def emit_event(self, event):
+        "Called by the Run Engine after each new event is created."
+        self._cb_registry.process('event', event)
+
+    def emit_descriptor(self, descriptor):
+        "Called by the Run Engine after each new event desc is created."
+        self._cb_registry.process('descriptor', descriptor)
+
+    def emit_start(self, start):
+        "Called by the Run Engine after a scan is started."
+        self._cb_registry.process('start', start)
+
+    def emit_stop(self, stop):
+        "Called by the Run Engine after a scan is stopped."
+        self._cb_registry.process('stop', stop)
+
+    @property
+    def autoplot(self):
+        return self._autoplot
+
+    @autoplot.setter
+    def autoplot(self, val):
+        if bool(val) = self._autoplot:
+            return
+        self._autoplot = bool(val)
+        cb_reg = self._cb_registry  # for brevity
+        if val:
+            # when a callback is registered, it returns an integer ID
+            # that can be used to deregister it.
+            self._plot_callback_ids = []
+            cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
+            self._plot_callback_ids.append(cid)
+            cid = cb_reg.connect('event', self._plot_mgr.update_plot)
+            self._plot_callback_ids.append(cid)
         else:
-            self._x_name = None  # plot against seq_num
-        self._cube_names = cubes
-
-        # Build figures, axes, lines.
-        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
-        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
-        self._scalar_lines = {name: ax.plot([], [])[0]}
-        self._scalar_fig.subplots_adjust()
-        for name, ax in six.iteritems(self._scalar_axes):
-            ax.set(title=name)
-        self._image_figs = {name: plt.figure() for name in in images + cubes}
-        self._image_axes = {fig.add_axes((0, 0, 1, 1)) for fig in self._image_figs}
-        self._img_objs = {}  # will hold AxesImage objects
-        self._img_uids = {name: deque() for name in images + cubes}
-
-    def update_plot(self, event):
-        if not self.autoplot:
-            return
-        # Add a data point to the subplot for each scalar.
-        x_val = event[self._x_name][0]  # unpack value from raw Event
-        for name, ax in self._scalar_axes:
-            y_val = event[name][0]  # unpack value from raw Event
-            line = self._scalar_lines[name]
-            old_x, old_y = line.get_data()
-            x = np.append(old_x, x_val)
-            y = np.append(old_y, y_val)
-            line.set_data(x, y)
-        self._scalar_fig.canvas.draw()
-
-        # Try to get the latest image, or a recent image,
-        # to update each image figure.
-        for name, ax in self._image_axes:
-            datum_uid = event[name][0]
-            img_array = None
-            try:
-                img_array = retrieve(datum_uid)
-            except DoesNotExist:
-                # Data may not be readable yet.
-                # Try uids in cache, starting with the most recent one.
-                uids = self._img_uids[name]
-                for i, datum_uid in enumerate(uids):
-                    try:
-                        img_array = filestore.retrieve(datum_uid)
-                    except filestore.DatumNotFound
-                        continue
-                    else:
-                        # To avoid ever showing an image that is older
-                        # than we one we just found,
-                        # remove all older images from the cache.
-                        for _ in len(uids) - i:
-                            self.uids.pop()
-                        break
-                self._img_uids[name].appendleft(datum_uid)
-
-            # No image available? Skip this update.
-            if img_array is None:
-                continue
-
-            # If this is an image cube, sum along the first axis
-            # and display it like an image.
-            # TODO: Display volumes for real.
-            if name in self._cube_names:
-                img_array = img_array.sum(0)
-
-            # Update the image.
-            if name not in self._img_objs:
-                self._img_obj[name] = ax.imshow(img_array)
-            else:
-                img_obj.set_array(img_array)
-            self._img_figs[name].canvas.draw()
+            [cg_reg.disconnect(cid) for cid in self._plot_callback_ids]
 
 
 class AScan(Scan):

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -363,10 +363,10 @@ class Scan(object):
         return self._scan_cb_registry.connect(name, func)
 
     def _push_to_event_queue(self, event):
-        self.ev_queue.put(event)
+        self.event_queue.put(event)
 
     def _push_to_descriptor_queue(self, descriptor):
-        self.desc_queue.put(descriptor)
+        self.descriptor_queue.put(descriptor)
 
     def _push_to_start_queue(self, start):
         self.start_queue.put(start)

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -776,6 +776,12 @@ class Dispatcher(object):
     def process_stop_queue(self):
         self.process_if_available(self.scan.stop_queue, 'stop')
 
+    def process_all(self):
+        self.process_start_queue()
+        self.process_descriptor_queue()
+        self.process_event_queue()
+        self.process_stop_queue()
+
     def subscribe(self, name, func):
         """
         Register a function to consume Event documents.

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -375,6 +375,8 @@ class Scan(object):
             self._plot_callback_ids.append(cid)
             cid = self.subscribe('event', self._plot_mgr.update_plot)
             self._plot_callback_ids.append(cid)
+            cid = self.subscribe('stop', self._plot_mgr.reset)
+            self._plot_callback_ids.append(cid)
         else:
             [self.unsubscribe(cid) for cid in self._plot_callback_ids]
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -146,8 +146,7 @@ class Scan(object):
     _shared_config = {'default_detectors': [],
                       'user_detectors': [],
                       'scan_data': None, }
-    valid_callbacks = ['start', 'stop', 'event', 'descriptor',
-                       'pre-scan', 'post-scan']
+    valid_callbacks = ['start', 'stop', 'event', 'descriptor']
 
     def __init__(self, *args, **kwargs):
         super(Scan, self).__init__(*args, **kwargs)
@@ -229,14 +228,10 @@ class Scan(object):
 
     def pre_scan(self):
         """Routine run before scan starts"""
-        self._scan_cb_registry.process('pre-scan',
-                                       self.positioners, self.detectors)
         pass
 
     def post_scan(self):
         """Routine run after scan has completed"""
-        self._scan_cb_registry.process('post-scan',
-                                       self.positioners, self.detectors)
         pass
 
     def configure_detectors(self):
@@ -411,8 +406,6 @@ class Scan(object):
             cid = self.subscribe('descriptor', self._plot_mgr.setup_plot)
             self._plot_callback_ids.append(cid)
             cid = self.subscribe('event', self._plot_mgr.update_plot)
-            self._plot_callback_ids.append(cid)
-            cid = self.subscribe('pre-scan', self._plot_mgr.update_positioners)
             self._plot_callback_ids.append(cid)
         else:
             [self.unsubscribe(cid) for cid in self._plot_callback_ids]
@@ -795,10 +788,7 @@ class Dispatcher(object):
         ----------
         name: {'start', 'descriptor', 'event', 'stop'}
         func: callable
-            start, descriptor, event, stop callbacks expect signature
-            ``f(mongoengine.Document)``
-            pre-scan and post-scan callbacks expect signature
-            ``f(positioners, detectors)``)
+            expecting signature like ``f(mongoengine.Document)``
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -146,7 +146,8 @@ class Scan(object):
     _shared_config = {'default_detectors': [],
                       'user_detectors': [],
                       'scan_data': None, }
-    valid_callbacks = ['start', 'stop', 'event', 'descriptor', 'pre-scan', 'post-scan']
+    valid_callbacks = ['start', 'stop', 'event', 'descriptor',
+                       'pre-scan', 'post-scan']
 
     def __init__(self, *args, **kwargs):
         super(Scan, self).__init__(*args, **kwargs)

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -159,7 +159,9 @@ class Scan(object):
 
         self.settle_time = 0
         self._scan_cb_registry = CallbackRegistry()  # process on scan thread
-        self.dispatcher = Dispatcher(scan)
+        self.dispatcher = Dispatcher(self)
+    	self.subscribe = self.dispatcher.subscribe  # pass through
+    	self.unsubscribe = self.dispatcher.unsubscribe  # pass through
         self._plot_mgr = PlotManager()
         self._autoplot = None
         self.autoplot = True
@@ -350,7 +352,6 @@ class Scan(object):
         """
         return self._shared_config['user_detectors'] + self.default_detectors
 
-    self.subscribe = self.dispatcher.subscribe  # pass through
 
     def _register_scan_callback(self, name, func):
         """Register a callback to be processed by the scan thread.

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import numpy as np
+import matplotlib.pyplot as plt
 from time import sleep
 import sys
 import collections
@@ -8,6 +9,8 @@ import string
 import traceback
 
 from IPython.utils.coloransi import TermColors as tc
+from filestore.api import retrieve
+from mongoengine import DoesNotExist
 
 from ..runengine import RunEngine
 from ..session import get_session_manager
@@ -151,6 +154,7 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
+        self.autoplot = True
 
         self.paths = list()
         self.positioners = list()
@@ -257,7 +261,7 @@ class Scan(object):
             scan_args['custom'] = kwargs
 
             # Run the scan!
-            data = self._run_eng.start_run(self.scan_id,
+            data = self._run_eng.start_run(self,
                                            scan_args=scan_args)
 
             self._data_buffer.append(Data(data))
@@ -328,6 +332,102 @@ class Scan(object):
         list of OphydObjects
         """
         return self._shared_config['user_detectors'] + self.default_detectors
+
+    def setup_plot(self, event_descriptor):
+        if not self.autoplot:
+            return
+        scalars = []
+        images = []
+        cubes = []
+        for key, val in six.iteritems(event_descriptor.data_keys):
+            if val['shape'] is None:
+                scalars.append(key)
+                continue
+            ndim = len(val['shape'])
+            if ndim == 2:
+                images.append(key)
+            elif ndim == 3:
+                cubes.append(key)
+            else:
+                pass  # >3D data just won't be shown
+
+        if len(positioners) == 1:
+            self._x = positioners[0]
+            if self._x not in scalars:
+                raise NotImplementedError("Not sure how to plot this. Turn of "
+                                          "the scan's autoplot attribute.")
+            scalars.remove(self._x)
+        else:
+            self._x_name = None  # plot against seq_num
+        self._cube_names = cubes
+
+        # Build figures, axes, lines.
+        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
+        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
+        self._scalar_lines = {name: ax.plot([], [])[0]}
+        self._scalar_fig.subplots_adjust()
+        for name, ax in six.iteritems(self._scalar_axes):
+            ax.set(title=name)
+        self._image_figs = {name: plt.figure() for name in in images + cubes}
+        self._image_axes = {fig.add_axes((0, 0, 1, 1)) for fig in self._image_figs}
+        self._img_objs = {}  # will hold AxesImage objects
+        self._img_uids = {name: deque() for name in images + cubes}
+
+    def update_plot(self, event):
+        if not self.autoplot:
+            return
+        # Add a data point to the subplot for each scalar.
+        x_val = event[self._x_name][0]  # unpack value from raw Event
+        for name, ax in self._scalar_axes:
+            y_val = event[name][0]  # unpack value from raw Event
+            line = self._scalar_lines[name]
+            old_x, old_y = line.get_data()
+            x = np.append(old_x, x_val)
+            y = np.append(old_y, y_val)
+            line.set_data(x, y)
+        self._scalar_fig.canvas.draw()
+
+        # Try to get the latest image, or a recent image,
+        # to update each image figure.
+        for name, ax in self._image_axes:
+            datum_uid = event[name][0]
+            img_array = None
+            try:
+                img_array = retrieve(datum_uid)
+            except DoesNotExist:
+                # Data may not be readable yet.
+                # Try uids in cache, starting with the most recent one.
+                uids = self._img_uids[name]
+                for i, datum_uid in enumerate(uids):
+                    try:
+                        img_array = filestore.retrieve(datum_uid)
+                    except filestore.DatumNotFound
+                        continue
+                    else:
+                        # To avoid ever showing an image that is older
+                        # than we one we just found,
+                        # remove all older images from the cache.
+                        for _ in len(uids) - i:
+                            self.uids.pop()
+                        break
+                self._img_uids[name].appendleft(datum_uid)
+
+            # No image available? Skip this update.
+            if img_array is None:
+                continue
+
+            # If this is an image cube, sum along the first axis
+            # and display it like an image.
+            # TODO: Display volumes for real.
+            if name in self._cube_names:
+                img_array = img_array.sum(0)
+
+            # Update the image.
+            if name not in self._img_objs:
+                self._img_obj[name] = ax.imshow(img_array)
+            else:
+                img_obj.set_array(img_array)
+            self._img_figs[name].canvas.draw()
 
 
 class AScan(Scan):
@@ -547,6 +647,10 @@ class Count(Scan):
     A log entry is created if the logbook is setup which records the
     result of the scan.
     """
+    def __init__(self, *args, **kwargs):
+        super(Count, self).__init__(*args, **kwargs)
+        self.autoplot = False
+
     def post_scan(self):
         """Post-scan print data
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -280,7 +280,7 @@ class Scan(object):
             scan_kwargs['custom'] = kwargs
 
             # Run the scan!
-            data = self._run_eng.start_run(self, **kwargs)
+            data = self._run_eng.start_run(self, **scan_kwargs)
 
             self._data_buffer.append(Data(data))
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -631,7 +631,7 @@ class Count(Scan):
         d = {}
         d['id'] = self.scan_id
         d['detectors'] = repr(self.detectors)
-        d['values'] = repr(self.last_data.data_dict)
+        d['values'] = repr(self.last_data[0]['data'])
         if self.logbook is not None:
             self.logbook.log('\n'.join(lmsg), ensure=True,
                              properties={'OphydCount': d},
@@ -650,9 +650,8 @@ class Count(Scan):
         rtn.append('\n')
         rtn.append('{:<28} | {}'.format('Detector', 'Value'))
         rtn.append('{0:=^60}'.format(''))
-        data = collections.OrderedDict(sorted(self.last_data.data_dict.items()))
-        for x, y in data.iteritems():
-            rtn.append('{:<30} {}'.format(x, y))
+        for data_key, payload in self.last_data[0]['data'].items():
+            rtn.append('{:<30} {}'.format(data_key, payload['value']))
         rtn.append('')
         return '\n'.join(rtn)
 

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -225,12 +225,14 @@ class Scan(object):
 
     def pre_scan(self):
         """Routine run before scan starts"""
-        self._scan_cb_registry.process('pre-scan', self.positioners, self.detectors)
+        self._scan_cb_registry.process('pre-scan',
+                                       self.positioners, self.detectors)
         pass
 
     def post_scan(self):
         """Routine run after scan has completed"""
-        self._scan_cb_registry.process('post-scan', self.positioners, self.detectors)
+        self._scan_cb_registry.process('post-scan',
+                                       self.positioners, self.detectors)
         pass
 
     def configure_detectors(self):

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -167,8 +167,12 @@ class Scan(object):
 
         self.ev_queue = Queue()
         self.desc_queue = Queue()
+        self.start_queue = Queue()
+        self.stop_queue = Queue()
         self._register_scan_callback('event', self._push_to_ev_queue)
         self._register_scan_callback('descriptor', self._push_to_desc_queue)
+        self._register_scan_callback('run_start', self._push_to_start_queue)
+        self._register_scan_callback('run_stop', self._push_to_stop_queue)
 
         self.paths = list()
         self.positioners = list()
@@ -385,6 +389,12 @@ class Scan(object):
 
     def _push_to_desc_queue(self, descriptor):
         self.desc_queue.put(descriptor)
+
+    def _push_to_start_queue(self, start):
+        self.start_queue.put(start)
+
+    def _push_to_stop_queue(self, stop):
+        self.stop_queue.put(stop)
 
     def emit_event(self, event):
         "Called by the Run Engine after each new event is created."

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -363,7 +363,7 @@ class Scan(object):
             start, descriptor, event, stop callbacks expect signature
             ``f(mongoengine.Document)``
             pre-scan and post-scan callbacks expect signature
-            ``f(positioners, detectors)``(
+            ``f(positioners, detectors)``)
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))

--- a/ophyd/userapi/scan_api.py
+++ b/ophyd/userapi/scan_api.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 from time import sleep
 import sys
 import collections
+from Queue import Queue
 import itertools
 import string
 import traceback
@@ -157,9 +158,11 @@ class Scan(object):
         self._data_buffer = self._shared_config['scan_data']
 
         self.settle_time = 0
-        self._cb_registry = CallbackRegistry()
-        self.autoplot = True
+        self._scan_cb_registry = CallbackRegistry()  # process on scan thread
+        self.cb_registry = CallbackRegistry()  # process on main thread
         self._plot_mgr = PlotManager()
+        self._autoplot = None
+        self.autoplot = True
 
         self.paths = list()
         self.positioners = list()
@@ -354,23 +357,23 @@ class Scan(object):
         """
         if name not in self.valid_callbacks:
             raise ValueError("Valid callbacks: {0}".format(valid_callbacks))
-        self._cb_registry.connect(name, func)
+        self._scan_cb_registry.connect(name, func)
 
     def emit_event(self, event):
         "Called by the Run Engine after each new event is created."
-        self._cb_registry.process('event', event)
+        self._scan_cb_registry.process('event', event)
 
     def emit_descriptor(self, descriptor):
         "Called by the Run Engine after each new event desc is created."
-        self._cb_registry.process('descriptor', descriptor)
+        self._scan_cb_registry.process('descriptor', descriptor)
 
     def emit_start(self, start):
         "Called by the Run Engine after a scan is started."
-        self._cb_registry.process('start', start)
+        self._scan_cb_registry.process('start', start)
 
     def emit_stop(self, stop):
         "Called by the Run Engine after a scan is stopped."
-        self._cb_registry.process('stop', stop)
+        self._scan_cb_registry.process('stop', stop)
 
     @property
     def autoplot(self):
@@ -378,7 +381,7 @@ class Scan(object):
 
     @autoplot.setter
     def autoplot(self, val):
-        if bool(val) = self._autoplot:
+        if bool(val) == self._autoplot:
             return
         self._autoplot = bool(val)
         cb_reg = self._cb_registry  # for brevity
@@ -386,12 +389,12 @@ class Scan(object):
             # when a callback is registered, it returns an integer ID
             # that can be used to deregister it.
             self._plot_callback_ids = []
-            cid = cb_reg.connect('descriptor', self._plot_mgr.setup_plot)
+            cid = cb_reg.connect('descriptor', self.add_to_queue)
             self._plot_callback_ids.append(cid)
-            cid = cb_reg.connect('event', self._plot_mgr.update_plot)
+            cid = cb_reg.connect('event', self.add_to_queue)
             self._plot_callback_ids.append(cid)
         else:
-            [cg_reg.disconnect(cid) for cid in self._plot_callback_ids]
+            [cb_reg.disconnect(cid) for cid in self._plot_callback_ids]
 
 
 class AScan(Scan):

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -1,0 +1,99 @@
+import matplotlib.pyplot as plt
+
+
+class PlotManager(object):
+
+    def update_positioners(self, positioners):
+        if len(positioners) == 1:
+            self._x_name = positioners[0]
+        else:
+            self._x_name = None  # plot against seq_num
+
+    def setup_plot(event_descriptor):
+        scalars = []
+        images = []
+        cubes = []
+        for key, val in six.iteritems(event_descriptor.data_keys):
+            if val['shape'] is None:
+                scalars.append(key)
+                continue
+            ndim = len(val['shape'])
+            if ndim == 2:
+                images.append(key)
+            elif ndim == 3:
+                cubes.append(key)
+            else:
+                pass  # >3D data just won't be shown
+
+            if self._x not in scalars:
+                raise NotImplementedError("Not sure how to plot this. Turn "
+                                          "of the self's autoplot attribute.")
+            scalars.remove(self._x)
+        self._cube_names = cubes
+
+        # Build figures, axes, lines.
+        self._scalar_fig, axes = plt.subplots(len(scalars), sharex=True)
+        self._scalar_axes = {name: ax for name, ax in zip(scalars, axes)}
+        self._scalar_lines = {name: ax.plot([], [])[0]}
+        self._scalar_fig.subplots_adjust()
+        for name, ax in six.iteritems(self._scalar_axes):
+            ax.set(title=name)
+        self._image_figs = {name: plt.figure() for name in in images + cubes}
+        self._image_axes = {fig.add_axes((0, 0, 1, 1))
+                            for fig in self._image_figs}
+        self._img_objs = {}  # will hold AxesImage objects
+        self._img_uids = {name: deque() for name in images + cubes}
+
+    def update_plot(event):
+        # Add a data point to the subplot for each scalar.
+        x_val = event[self._x_name][0]  # unpack value from raw Event
+        for name, ax in self._scalar_axes:
+            y_val = event[name][0]  # unpack value from raw Event
+            line = self._scalar_lines[name]
+            old_x, old_y = line.get_data()
+            x = np.append(old_x, x_val)
+            y = np.append(old_y, y_val)
+            line.set_data(x, y)
+        self._scalar_fig.canvas.draw()
+
+        # Try to get the latest image, or a recent image,
+        # to update each image figure.
+        for name, ax in self._image_axes:
+            datum_uid = event[name][0]
+            img_array = None
+            try:
+                img_array = retrieve(datum_uid)
+            except DoesNotExist:
+                # Data may not be readable yet.
+                # Try uids in cache, starting with the most recent one.
+                uids = self._img_uids[name]
+                for i, datum_uid in enumerate(uids):
+                    try:
+                        img_array = filestore.retrieve(datum_uid)
+                    except filestore.DatumNotFound
+                        continue
+                    else:
+                        # To avoid ever showing an image that is older
+                        # than we one we just found,
+                        # remove all older images from the cache.
+                        for _ in len(uids) - i:
+                            self.uids.pop()
+                        break
+                self._img_uids[name].appendleft(datum_uid)
+
+            # No image available? Skip this update.
+            if img_array is None:
+                continue
+
+            # If this is an image cube, sum along the first axis
+            # and display it like an image.
+            # TODO: Display volumes for real.
+            if name in self._cube_names:
+                img_array = img_array.sum(0)
+
+            # Update the image.
+            if name not in self._img_objs:
+                self._img_obj[name] = ax.imshow(img_array)
+            else:
+                img_obj.set_array(img_array)
+            self._img_figs[name].canvas.draw()

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -14,7 +14,7 @@ class PlotManager(object):
         scalars = []
         images = []
         cubes = []
-        for key, val in six.iteritems(event_descriptor.data_keys):
+        for key, val in six.iteritems(event_descriptor['data_keys']):
             print key, val['shape']
             if not val['shape']:
                 scalars.append(key)
@@ -53,9 +53,9 @@ class PlotManager(object):
             # setup_plot has not been called; we have to wait.
             return
         # Add a data point to the subplot for each scalar.
-        x_val = event.data[self._x_name][0]  # unpack value from raw Event
+        x_val = event['data'][self._x_name][0]  # unpack value from raw Event
         for name, ax in six.iteritems(self._scalar_axes):
-            y_val = event.data[name][0]  # unpack value from raw Event
+            y_val = event['data'][name][0]  # unpack value from raw Event
             line = self._scalar_lines[name]
             old_x, old_y = line.get_data()
             x = np.append(old_x, x_val)
@@ -66,7 +66,7 @@ class PlotManager(object):
         # Try to get the latest image, or a recent image,
         # to update each image figure.
         for name, ax in six.iteritems(self._image_axes):
-            datum_uid = event.data[name][0]
+            datum_uid = event['data'][name][0]
             img_array = None
             try:
                 img_array = retrieve(datum_uid)

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -7,12 +7,7 @@ class PlotManager(object):
 
     def __init__(self):
         self._has_figures = False
-
-    def update_positioners(self, positioners, detectors):
-        if len(positioners) == 1:
-            self._x_name = positioners[0].name
-        else:
-            self._x_name = None  # plot against seq_num
+        self._x_name = None  # plot against seq_num
 
     def setup_plot(self, event_descriptor):
         self._has_figures = True

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -8,7 +8,7 @@ class PlotManager(object):
     def __init__(self):
         self._has_figures = False
 
-    def update_positioners(self, positioners):
+    def update_positioners(self, positioners, detectors):
         if len(positioners) == 1:
             self._x_name = positioners[0].name
         else:

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -1,4 +1,5 @@
 import six
+from itertools import count
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -10,6 +11,7 @@ class PlotManager(object):
         self._x_name = None  # plot against seq_num
 
     def setup_plot(self, event_descriptor):
+        self.point_counter = count()
         self._has_figures = True
         scalars = []
         images = []
@@ -53,9 +55,13 @@ class PlotManager(object):
             # setup_plot has not been called; we have to wait.
             return
         # Add a data point to the subplot for each scalar.
-        x_val = event['data'][self._x_name][0]  # unpack value from raw Event
+        point_num = next(self.point_counter)
+        if self._x_name is not None:
+            x_val = event['data'][self._x_name]['value']
+        else:
+            x_val = point_num
         for name, ax in six.iteritems(self._scalar_axes):
-            y_val = event['data'][name][0]  # unpack value from raw Event
+            y_val = event['data'][name]['value']
             line = self._scalar_lines[name]
             old_x, old_y = line.get_data()
             x = np.append(old_x, x_val)
@@ -66,7 +72,7 @@ class PlotManager(object):
         # Try to get the latest image, or a recent image,
         # to update each image figure.
         for name, ax in six.iteritems(self._image_axes):
-            datum_uid = event['data'][name][0]
+            datum_uid = event['data'][name]['value']
             img_array = None
             try:
                 img_array = retrieve(datum_uid)

--- a/ophyd/utils/plotting.py
+++ b/ophyd/utils/plotting.py
@@ -9,8 +9,16 @@ class PlotManager(object):
     def __init__(self):
         self._has_figures = False
         self._x_name = None  # plot against seq_num
+        # TODO Guess what to plot against.
+
+    def reset(self, doc):
+        # doc is not used, merely conforming to callback signature
+        self._has_figures = False
 
     def setup_plot(self, event_descriptor):
+        # Ignore any event_descriptor other than the first one we see.
+        if self._has_figures:
+            return
         self.point_counter = count()
         self._has_figures = True
         scalars = []

--- a/ophyd/utils/register_mds.py
+++ b/ophyd/utils/register_mds.py
@@ -1,0 +1,24 @@
+import metadatastore.commands as mdscmd
+
+
+def register_mds(scan):
+    """
+    Register metadatastore insert_* functions to consume documents from scan.
+
+    Parameters
+    ----------
+    scan : ophyd.userapi.scan_api.Scan
+    """
+    scan._register_scan_callback('event', mdscmd.insert_event)
+    scan._register_scan_callback('descriptor', mdscmd.insert_event_descriptor)
+    scan._register_scan_callback('stop', mdscmd.insert_run_stop)
+    # 'start' is a special case -- see below
+    scan._register_scan_callback('start', insert_run_start)
+
+def _make_blc():
+    return mdscmd.insert_beamline_config({}, time=time.time())
+
+def insert_run_start(doc):
+    "Add a beamline config that, for now, only knows the time."
+    doc['beamline_config'] = _make_blc()
+    mdscmd.insert_run_start(doc)


### PR DESCRIPTION
As per a discussion with @dchabot, this PR removes the metadatastore dependency from ophyd, making it a generic "consumer" of Documents created during the scan. There are two kinds of consumers:

1. Consumers that consume documents on the Scan Thread, blocking the scan's progress until it has returned successfully.
2. Consumers that consume documents on the Main Thread, reading them out of a queue. This is not as  reliable, but it does not lock up the scan.

Only one consumer is hard-coded: a consumer that consumes Documents on the Scan Thread and pushes them into the queue, where they can be read out by consumers on the Main Thread.

Metadatastore should be registered a Scan Thread consumer in the config file, but it no longer a hard dependency. User code (e.g., live analysis or visualization) should be registered as a Main Thread consumer. Notably, this user code does not have to read the data out of Data Broker; it can get it directly from ophyd.

This PR is feature-complete, but needs to be tested and of course reviewed.