### PR TITLE
Allow truncation of EpicsSignal read() values

### DIFF
--- a/ophyd/controls/signal.py
+++ b/ophyd/controls/signal.py
@@ -177,29 +177,17 @@ class EpicsSignal(Signal):
         Check limits prior to writing value
     auto_monitor : bool, optional
         Use automonitor with epics.PV
-    dtype : type, optional
+    dtype : {float, int, string}
         Defaults to float.
-        This is the datatype that the value from epics will be returned as.
-        Note that this says nothing about the precision of the value, simply
-        what its type should be.
-        Can be any valid python or numpy type. Some examples to get you
-        started...
-        `complex`, `float`, `int`, `uint`, `byte`, `bool`, `string`
-        {'complex': [numpy.complex64, numpy.complex128, numpy.complex256],
-         'float': [numpy.float16, numpy.float32, numpy.float64, numpy.float128],
-         'int': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
-         'others': [bool, object, str, str, numpy.void],
-         'uint': [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]}
+        This is the type that read() will be return.
     formatter : str, optional
-        - Defaults to '%f'
-        - The old-style python format that this number should use.
-        - Use case: Truncate the measurement to a physically reasonable
-        value. Consider a motor whose encoder has a minimum step size of
-        0.001 units.  Epics will return a value with >10 decimal places,
-        7 of which are meaningless.  Passing '%.3f' will result in a value
-        rounded to the nearest thousandth. E.g., if epics returns 1.0017,
-        and you provide a value of '%.3f', the read() method will now return
-        1.002
+        Defaults to '%f'
+        The primary use case of `formatter` is to truncate decimals. Consider a
+        motor whose encoder moves in steps of 0.001 units.  Epics will often
+        return a value with >10 decimal places, 7 of which are meaningless.
+        Passing '%.3f' will result in a value rounded to the nearest
+        thousandth. E.g., if epics returns 1.0017, and you provide a value of
+        '%.3f', the read() method will now return 1.002.
         See https://docs.python.org/2/library/stdtypes.html#string-formatting-operations
         for the exact detail of how % string formatting works in python.
     """
@@ -213,6 +201,8 @@ class EpicsSignal(Signal):
                  formatter=None,
                  **kwargs):
 
+        if pv_kw is None:
+            pv_kw = dict()
         self._read_pv = None
         self._write_pv = None
         self._put_complete = put_complete
@@ -224,6 +214,10 @@ class EpicsSignal(Signal):
 
         if dtype is None:
             dtype = float
+        valid_dtypes = ['float', 'int', 'str']
+        if dtype.__name__ not in valid_dtypes:
+            raise ValueError("dtype must be one of {}. You provided {"
+                             "}".format(valid_dtypes, dtype))
         self.dtype = dtype
         if formatter is None:
             formatter = '%f'

--- a/ophyd/controls/signal.py
+++ b/ophyd/controls/signal.py
@@ -150,7 +150,7 @@ class Signal(OphydObject):
 
 
 class EpicsSignal(Signal):
-    '''An EPICS signal, comprised of either one or two EPICS PVs
+    """An EPICS signal, comprised of either one or two EPICS PVs
 
     =======  =========  =====  ==========================================
     read_pv  write_pv   rw     Result
@@ -177,13 +177,40 @@ class EpicsSignal(Signal):
         Check limits prior to writing value
     auto_monitor : bool, optional
         Use automonitor with epics.PV
-    '''
+    dtype : type, optional
+        Defaults to float.
+        This is the datatype that the value from epics will be returned as.
+        Note that this says nothing about the precision of the value, simply
+        what its type should be.
+        Can be any valid python or numpy type. Some examples to get you
+        started...
+        `complex`, `float`, `int`, `uint`, `byte`, `bool`, `string`
+        {'complex': [numpy.complex64, numpy.complex128, numpy.complex256],
+         'float': [numpy.float16, numpy.float32, numpy.float64, numpy.float128],
+         'int': [numpy.int8, numpy.int16, numpy.int32, numpy.int64],
+         'others': [bool, object, str, str, numpy.void],
+         'uint': [numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64]}
+    formatter : str, optional
+        - Defaults to '%f'
+        - The old-style python format that this number should use.
+        - Use case: Truncate the measurement to a physically reasonable
+        value. Consider a motor whose encoder has a minimum step size of
+        0.001 units.  Epics will return a value with >10 decimal places,
+        7 of which are meaningless.  Passing '%.3f' will result in a value
+        rounded to the nearest thousandth. E.g., if epics returns 1.0017,
+        and you provide a value of '%.3f', the read() method will now return
+        1.002
+        See https://docs.python.org/2/library/stdtypes.html#string-formatting-operations
+        for the exact detail of how % string formatting works in python.
+    """
     def __init__(self, read_pv, write_pv=None,
                  rw=True, pv_kw={},
                  put_complete=False,
                  string=False,
                  limits=False,
                  auto_monitor=None,
+                 dtype=None,
+                 formatter=None,
                  **kwargs):
 
         self._read_pv = None
@@ -194,6 +221,13 @@ class EpicsSignal(Signal):
         self._rw = rw
         self._pv_kw = pv_kw
         self._auto_monitor = auto_monitor
+
+        if dtype is None:
+            dtype = float
+        self.dtype = dtype
+        if formatter is None:
+            formatter = '%f'
+        self.formatter = formatter
 
         separate_readback = False
 
@@ -420,18 +454,25 @@ class EpicsSignal(Signal):
         dict
             Dictionary of name and formatted description string
         """
-        return {self.name: {'source': 'PV:{}'.format(self._read_pv.pvname)}}
+        return {self.name: {'source': 'PV:%s' % self._read_pv.pvname,
+                            'dtype': self.dtype,
+                            'formatter': self.formatter,
+                            'shape': []}}
 
     def read(self):
-        """Read the signal and format for data collection
+        """Read the signal and combine it with its timestamp.
+
+        This value is formatted according to the values in self.dtype and
+        self.format
 
         Returns
         -------
         dict
             Dictionary of value timestamp pairs
+            {'value': value, 'timestamp': timestamp}
         """
-
-        return {self.name: {'value': self.value,
+        value = self.describe()['dtype'](self.formatter % self.value)
+        return {self.name: {'value': value,
                             'timestamp': self.timestamp}}
 
 

--- a/ophyd/controls/signal.py
+++ b/ophyd/controls/signal.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 import logging
 import time
 
+import numpy as np
 import epics
 
 from ..utils import (ReadOnlyError, TimeoutError, LimitError)
@@ -180,16 +181,10 @@ class EpicsSignal(Signal):
     dtype : {float, int, string}
         Defaults to float.
         This is the type that read() will be return.
-    formatter : str, optional
-        Defaults to '%f'
-        The primary use case of `formatter` is to truncate decimals. Consider a
-        motor whose encoder moves in steps of 0.001 units.  Epics will often
-        return a value with >10 decimal places, 7 of which are meaningless.
-        Passing '%.3f' will result in a value rounded to the nearest
-        thousandth. E.g., if epics returns 1.0017, and you provide a value of
-        '%.3f', the read() method will now return 1.002.
-        See https://docs.python.org/2/library/stdtypes.html#string-formatting-operations
-        for the exact detail of how % string formatting works in python.
+    num_decimals : int, optional
+        Round the value of this signal.
+        if num_decimals < 0, round to that many decimals before the '.'
+        if num_decimals > 0, round to that many decimals after the '.'
     """
     def __init__(self, read_pv, write_pv=None,
                  rw=True, pv_kw={},
@@ -198,7 +193,7 @@ class EpicsSignal(Signal):
                  limits=False,
                  auto_monitor=None,
                  dtype=None,
-                 formatter=None,
+                 num_decimals=None,
                  **kwargs):
 
         if pv_kw is None:
@@ -219,9 +214,9 @@ class EpicsSignal(Signal):
             raise ValueError("dtype must be one of {}. You provided {"
                              "}".format(valid_dtypes, dtype))
         self.dtype = dtype
-        if formatter is None:
-            formatter = '%f'
-        self.formatter = formatter
+        if num_decimals is None:
+            num_decimals = 'all'
+        self.num_decimals = num_decimals
 
         separate_readback = False
 
@@ -450,7 +445,7 @@ class EpicsSignal(Signal):
         """
         return {self.name: {'source': 'PV:%s' % self._read_pv.pvname,
                             'dtype': self.dtype,
-                            'formatter': self.formatter,
+                            'num_decimals': self.num_decimals,
                             'shape': []}}
 
     def read(self):
@@ -465,7 +460,9 @@ class EpicsSignal(Signal):
             Dictionary of value timestamp pairs
             {'value': value, 'timestamp': timestamp}
         """
-        value = self.describe()['dtype'](self.formatter % self.value)
+        if self.num_decimals != 'all':
+            value = np.round(self.value, self.num_decimals)
+        value = self.describe()['dtype'](value)
         return {self.name: {'value': value,
                             'timestamp': self.timestamp}}
 


### PR DESCRIPTION
This PR adds two kwargs to the instantiation of the EpicsSignal
class: `dtype` and `num_decimals`.
- `dtype` can be a float, int or string
- `num_decimals` is the decimal position to round the return value
  to. Negative numbers will round to that many digits before the 
  `.` and positive numbers will round to that many digits after
  the `.`.

Use case: The encoder for a motor (e.g., theta) is known
to be sensitive to the millidegree (0.001). As such, having the
read() function return a number like 1.031239867892734 is 
unnecessary, but also misleading. Instead, allow the beamline
scientist to denote that the read value should return a float with
three decimal points. For example:
```python
eta = EpicsMotor('XF:23ID1-ES{Diag:1-Ax:Eta}Mtr', name='eta',
                 dtype='float', num_decimals=3)
```
will return a float with 3 decimals when eta.read() is called.
eta.describe() will contain the extra field `num_decimals` that
shows how many decimals the number is being rounded to.