### PR TITLE
[FIX] CA (dis)connection management

### DIFF
--- a/ophyd/controls/positioner.py
+++ b/ophyd/controls/positioner.py
@@ -17,7 +17,7 @@ from epics.pv import fmt_time
 
 from .signal import (EpicsSignal, SignalGroup)
 from ..utils import TimeoutError
-from ..utils.epics_pvs import record_field
+from ..utils.epics_pvs import record_field, raise_if_disconnected
 from .ophydobj import MoveStatus
 
 logger = logging.getLogger(__name__)
@@ -176,6 +176,7 @@ class Positioner(SignalGroup):
         self._reset_sub(self._SUB_REQ_DONE)
 
     @property
+    @raise_if_disconnected
     def position(self):
         '''The current position of the motor in its engineering units
 
@@ -263,20 +264,24 @@ class EpicsMotor(Positioner):
         self._user_readback.subscribe(self._pos_changed)
 
     @property
+    @raise_if_disconnected
     def precision(self):
         '''The precision of the readback PV, as reported by EPICS'''
         return self._user_readback.precision
 
     @property
+    @raise_if_disconnected
     def egu(self):
         '''Engineering units'''
         return self._egu.value
 
     @property
+    @raise_if_disconnected
     def limits(self):
         return self._user_setpoint.limits
 
     @property
+    @raise_if_disconnected
     def moving(self):
         '''Whether or not the motor is moving
 
@@ -286,6 +291,7 @@ class EpicsMotor(Positioner):
         '''
         return bool(self._is_moving.get(use_monitor=False))
 
+    @raise_if_disconnected
     def stop(self):
         self._stop.put(1, wait=False)
         Positioner.stop(self)
@@ -299,6 +305,7 @@ class EpicsMotor(Positioner):
         '''Return a full PV from the field name'''
         return record_field(self._record, field)
 
+    @raise_if_disconnected
     def move(self, position, wait=True,
              **kwargs):
 
@@ -346,6 +353,7 @@ class EpicsMotor(Positioner):
             self._done_moving(timestamp=timestamp, value=value)
 
     @property
+    @raise_if_disconnected
     def report(self):
         return {self._name: self.position,
                 'pv': self._user_readback.pvname}
@@ -453,6 +461,7 @@ class PVPositioner(Positioner):
         self._setpoint.check_value(pos)
 
     @property
+    @raise_if_disconnected
     def moving(self):
         '''Whether or not the motor is moving
 
@@ -545,6 +554,7 @@ class PVPositioner(Positioner):
             self._setpoint.put(position, wait=False,
                                callback=done_moving)
 
+    @raise_if_disconnected
     def move(self, position, wait=True, **kwargs):
         if wait:
             try:

--- a/ophyd/controls/positioner.py
+++ b/ophyd/controls/positioner.py
@@ -259,11 +259,8 @@ class EpicsMotor(Positioner):
         for signal in signals:
             self.add_signal(signal)
 
-        self._moving = bool(self._is_moving.value)
         self._done_move.subscribe(self._move_changed)
         self._user_readback.subscribe(self._pos_changed)
-
-        self._set_position(self._user_readback.value)
 
     @property
     def precision(self):
@@ -291,7 +288,6 @@ class EpicsMotor(Positioner):
 
     def stop(self):
         self._stop.put(1, wait=False)
-
         Positioner.stop(self)
 
     @property
@@ -425,8 +421,6 @@ class PVPositioner(Positioner):
                                         name=self.name))
 
             self._readback.subscribe(self._pos_changed)
-
-            self._set_position(self._readback.value)
         else:
             self._setpoint.subscribe(self._pos_changed)
 

--- a/ophyd/controls/scaler.py
+++ b/ophyd/controls/scaler.py
@@ -3,7 +3,7 @@ import logging
 
 from .signal import EpicsSignal
 from .detector import SignalDetector
-from ..utils.epics_pvs import record_field
+from ..utils.epics_pvs import record_field, raise_if_disconnected
 
 logger = logging.getLogger(__name__)
 
@@ -60,19 +60,23 @@ class EpicsScaler(SignalDetector):
         self.add_acquire_signal(self._count)
 
     @property
+    @raise_if_disconnected
     def count_time(self):
         return self._preset_time.value
 
     @count_time.setter
+    @raise_if_disconnected
     def count_time(self, val):
         self._preset_time.put(val)
 
     @property
+    @raise_if_disconnected
     def auto_count(self):
         """Return the autocount status"""
         return (self._count_mode.value == 1)
 
     @auto_count.setter
+    @raise_if_disconnected
     def auto_count(self, val):
         """Set the autocount status"""
         if val:
@@ -85,6 +89,7 @@ class EpicsScaler(SignalDetector):
                 'numchan={0._numchan!r}'.format(self)]
         return self._get_repr(repr)
 
+    @raise_if_disconnected
     def configure(self, **kwargs):
         """Configure Scaler
 
@@ -95,6 +100,7 @@ class EpicsScaler(SignalDetector):
         self._autocount = self._count_mode.value
         self._count_mode.value = 0
 
+    @raise_if_disconnected
     def deconfigure(self, **kwargs):
         """Deconfigure Scaler
 

--- a/ophyd/controls/signal.py
+++ b/ophyd/controls/signal.py
@@ -15,7 +15,8 @@ import time
 import epics
 
 from ..utils import (ReadOnlyError, TimeoutError, LimitError)
-from ..utils.epics_pvs import (get_pv_form, waveform_to_string)
+from ..utils.epics_pvs import (get_pv_form,
+                               waveform_to_string, raise_if_disconnected)
 from .ophydobj import OphydObject, DetectorStatus
 
 logger = logging.getLogger(__name__)
@@ -227,11 +228,13 @@ class EpicsSignal(Signal):
             self._write_pv = self._read_pv
 
     @property
+    @raise_if_disconnected
     def precision(self):
         '''The precision of the read PV, as reported by EPICS'''
         return self._read_pv.precision
 
     @property
+    @raise_if_disconnected
     def setpoint_ts(self):
         '''Timestamp of setpoint PV, according to EPICS'''
         if self._write_pv is None:
@@ -240,6 +243,7 @@ class EpicsSignal(Signal):
         return self._write_pv.timestamp
 
     @property
+    @raise_if_disconnected
     def timestamp(self):
         '''Timestamp of readback PV, according to EPICS'''
         return self._read_pv.timestamp
@@ -292,6 +296,7 @@ class EpicsSignal(Signal):
             return self._read_pv.connected and self._write_pv.connected
 
     @property
+    @raise_if_disconnected
     def limits(self):
         pv = self._write_pv
         pv.get_ctrlvars()
@@ -345,6 +350,7 @@ class EpicsSignal(Signal):
         else:
             return ret
 
+    @raise_if_disconnected
     def get_setpoint(self, **kwargs):
         '''Get the setpoint value (use only if the setpoint PV and the readback
         PV differ)
@@ -410,6 +416,7 @@ class EpicsSignal(Signal):
         Signal.put(self, value, timestamp=timestamp)
 
     @property
+    @raise_if_disconnected
     def report(self):
         # FIXME:
         if self._read_pv == self._write_pv:
@@ -438,6 +445,7 @@ class EpicsSignal(Signal):
                             'dtype': 'number',
                             'shape': []}}
 
+    @raise_if_disconnected
     def read(self):
         """Read the signal and format for data collection
 

--- a/ophyd/controls/signal.py
+++ b/ophyd/controls/signal.py
@@ -54,6 +54,11 @@ class Signal(OphydObject):
         self._separate_readback = separate_readback
 
     @property
+    def connected(self):
+        '''Subclasses should override this'''
+        return True
+
+    @property
     def recordable(self):
         """Return if this signal is recordable by the DAQ"""
         return self._recordable

--- a/ophyd/session/sessionmgr.py
+++ b/ophyd/session/sessionmgr.py
@@ -228,7 +228,7 @@ class SessionManager(object):
             self._run_engine.stop()
 
         for pos in self._registry['positioners'].values():
-            if pos.moving is True:
+            if pos.connected and pos.moving is True:
                 pos.stop()
                 self._logger.debug('Stopped %s' % pos)
 

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -17,7 +17,7 @@ import functools
 import epics
 from boltons.cacheutils import cached, LRU
 
-from . import errors
+from .errors import MinorAlarmError, get_alarm_class, DisconnectedError
 
 __all__ = ['split_record_field',
            'strip_field',
@@ -64,7 +64,7 @@ def record_field(record, field):
 
 def check_alarm(base_pv, stat_field='STAT', severity_field='SEVR',
                 reason_field=None, reason_pv=None,
-                min_severity=errors.MinorAlarmError.severity):
+                min_severity=MinorAlarmError.severity):
     """Raise an exception if an alarm is set
 
     Raises
@@ -81,7 +81,7 @@ def check_alarm(base_pv, stat_field='STAT', severity_field='SEVR',
 
     if severity >= min_severity:
         try:
-            error_class = errors.get_alarm_error(severity)
+            error_class = get_alarm_class(severity)
         except KeyError:
             pass
         else:
@@ -334,5 +334,5 @@ def raise_if_disconnected(fcn):
         if self.connected:
             return fcn(self, *args, **kwargs)
         else:
-            raise Exception('{} is not connected'.format(self.name))
+            raise DisconnectedError('{} is not connected'.format(self.name))
     return wrapper

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -12,6 +12,7 @@ import ctypes
 import threading
 import queue
 import warnings
+import functools
 
 import epics
 from boltons.cacheutils import cached, LRU
@@ -325,3 +326,13 @@ def records_from_db(fn):
         ret.append((rtype, record))
 
     return ret
+
+def raise_if_disconnected(fcn):
+    '''Decorator to catch attempted access to disconnected EPICS channels.'''
+    @functools.wraps(fcn)
+    def wrapper(self, *args, **kwargs):
+        if self.connected:
+            return fcn(self, *args, **kwargs)
+        else:
+            raise Exception('{} is not connected'.format(self.name))
+    return wrapper

--- a/ophyd/utils/errors.py
+++ b/ophyd/utils/errors.py
@@ -27,6 +27,10 @@ class LimitError(ValueError, OpException):
     '''Value is outside of defined limits'''
     pass
 
+class DisconnectedError(OpException):
+    '''Signal or SignalGroup is not connected to EPICS'''
+    pass
+
 
 # - Alarms
 


### PR DESCRIPTION
Addresses #136 and #90

Basically, avoids the assumption in a couple of `__init__`-ializers that a connection to the controls layer has been made.

This means reads/writes to disconnected channels will `raise`, and loading of startup configuration files will not stall if channels cannot be reached initially. Need to have a think about how best to inform users that only M out of N of their devices made a connection by the time the __In [1]:__ prompt lands. Suggestions welcome.

NOTE: this does _not_ include more graceful handling of swarms of (dis)connects.