### PR TITLE
FIX: interpret badly-formed version from pyepics

### DIFF
--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -233,6 +233,8 @@ def get_pv_form():
     -------
     {'native', 'time'}
     '''
+    def _fix_git_versioning(in_str):
+        return in_str.replace('-g', '+g')
 
     def _naive_parse_version(version):
         try:
@@ -253,7 +255,7 @@ def get_pv_form():
     except ImportError:
         parse_version = _naive_parse_version
 
-    version = parse_version(epics.__version__)
+    version = parse_version(_fix_git_versioning(epics.__version__))
 
     if version is None:
         warnings.warn('Unrecognized PyEpics version; using local timestamps',


### PR DESCRIPTION
Not sure how this got buried. This is a fix from @tacaswell, but is really important for ophyd as with the current installation we're getting all local timestamps (i.e., when the monitor update was received).

Alternatively we should just not set 'form' manually anymore. After a lengthy discussion (and some of my fixes) with pyepics-lead @newville, he changed the default to using server-side PV timestamps.