### PR TITLE
FIX: Remove attrs that do not belong to plugins.

### DIFF
--- a/ophyd/controls/areadetector/plugins.py
+++ b/ophyd/controls/areadetector/plugins.py
@@ -66,13 +66,6 @@ class PluginBase(ADBase):
     asyn_io = C(EpicsSignal, 'AsynIO')
 
     nd_attributes_file = C(EpicsSignal, 'NDAttributesFile', string=True)
-    pool_alloc_buffers = C(EpicsSignalRO, 'PoolAllocBuffers')
-    pool_free_buffers = C(EpicsSignalRO, 'PoolFreeBuffers')
-    pool_max_buffers = C(EpicsSignalRO, 'PoolMaxBuffers')
-    pool_max_mem = C(EpicsSignalRO, 'PoolMaxMem')
-    pool_used_buffers = C(EpicsSignalRO, 'PoolUsedBuffers')
-    pool_used_mem = C(EpicsSignalRO, 'PoolUsedMem')
-    port_name = C(EpicsSignalRO, 'PortName_RBV', string=True)
 
     @property
     def array_pixels(self):
@@ -122,12 +115,6 @@ class PluginBase(ADBase):
     ndimensions = C(EpicsSignalRO, 'NDimensions_RBV')
     plugin_type = C(EpicsSignalRO, 'PluginType_RBV')
 
-    queue_free = C(EpicsSignal, 'QueueFree')
-    queue_free_low = C(EpicsSignal, 'QueueFreeLow')
-    queue_size = C(EpicsSignal, 'QueueSize')
-    queue_use = C(EpicsSignal, 'QueueUse')
-    queue_use_high = C(EpicsSignal, 'QueueUseHIGH')
-    queue_use_hihi = C(EpicsSignal, 'QueueUseHIHI')
     time_stamp = C(EpicsSignalRO, 'TimeStamp_RBV')
     unique_id = C(EpicsSignalRO, 'UniqueId_RBV')
 


### PR DESCRIPTION
This is after length discussion with and assistance from @dchabot and @arkilic. We are pretty sure that these fields do not *belong* to the plugins; they are just used by them. They should not be exposed per-plugin.

Also see:

```python
In [42]: for attr in dir(det.tiff1):
    try:
            getattr(det.tiff1, attr)
                except ophyd.utils.TimeoutError:
                        print(attr)
                           ....:
pool_alloc_buffers
pool_free_buffers
pool_max_buffers
pool_max_mem
pool_used_buffers
pool_used_mem
queue_free
queue_free_low
queue_size
queue_use
queue_use_high
queue_use_hihi
write_message
write_status
```

Those last two actually *do* belong to the fileplugin -- they are just failing because of an issue with the test IOC.