### PR TITLE
MNT: Add a .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Ken Lauer <klauer@bnl.gov> Ken L <klauer@bnl.gov>
+Ken Lauer <klauer@bnl.gov> K Lauer <klauer@bnl.gov>
+Ken Lauer <klauer@bnl.gov> K Lauer <klauer@users.noreply.github.com>
+Ken Lauer <klauer@bnl.gov> Kenneth Lauer <klauer@bnl.gov>
+Thomas A Caswell <tcaswell@bnl.gov> Thomas A Caswell <tcaswell@bnl.gov>
+Dan Allan <dallan@bnl.gov> danielballan <daniel.b.allan@gmail.com>
+Daron Chabot <dchabot@bnl.gov> Daron Chabot <dchabot@bnl.gov>
+Daron Chabot <dchabot@bnl.gov> dchabot <daron.chabot@gmail.com>
+Stuart Wilkins <swilkins@bnl.gov> Stuart Wilkins <swilkins@bnl.gov>
+Stuart Wilkins <swilkins@bnl.gov> Stuart B. Wilkins <swilkins@bnl.gov>
+Eric Dill <edill@bnl.gov> Eric Dill <edill@bnl.gov>
+Eric Dill <edill@bnl.gov> ericdill <edill@bnl.gov>
+Eric Dill <edill@bnl.gov> Eric Dill <thedizzle@gmail.com>
+Eric Dill <edill@bnl.gov> CSX-1 Operator <xf23id1@xf23id1-srv1.cs.nsls2.local>
+Eric Dill <edill@bnl.gov> CSX-1 Operator <xf23id1@xf23id1-ws3.cs.nsls2.local>
+Eric Dill <edill@bnl.gov> CSX-1 Operator <xf23id1@xf23id-ws3.cs.nsls2.local>
+Eric Dill <edill@bnl.gov> HXN Operator <xf03id@xf03id-srv1.cs.nsls2.local>
+Eric Dill <edill@bnl.gov> XPD Operator <xf28id1@xf28id1-ws2.cs.nsls2.local>


### PR DESCRIPTION
The commit history of this project is littered with various names for a
number of people (I am the worst offender here!)  The mailmap blames the
correct people for the commits that were made. Again, this is mostly so
that I can be blamed for the commits that are my fault :)