### PR TITLE
ENH: Successful test on HDF5 SimDetector with AD 2.2

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -145,8 +145,8 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
 class FileStoreHDF5(FileStoreBase):
     def stage(self):
         self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.h5'),
-                                (self.file_write_mode, 'Capture'),
-                                (self.capture, 1),
+                                (self.file_write_mode, 'Stream'),
+                                (self.capture, 1)
                                ])
         super().stage()
         res_kwargs = {'frame_per_point': self.num_captured.get()}
@@ -161,11 +161,11 @@ class FileStoreTIFF(FileStoreBase):
         self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.tiff'),
                                 (self.file_write_mode, 'Single'),
                                ])
-        super().stage()
         res_kwargs = {'template': self.file_template.get(),
                       'filename': self.file_name.get(),
                       'frame_per_point': self.parent.cam.num_images.get()}
         self._resource = fs.insert_resource('AD_TIFF', self._fn, res_kwargs)
+        super().stage()
 
 
 class FileStoreIterativeWrite(FileStoreBase):

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -653,7 +653,9 @@ class HDF5Plugin(FilePlugin):
         The plugin has to 'see' one acquisition before it is ready to capture.
         This sets the array size, etc.
         """
-        sigs = OrderedDict([(self.parent.cam.image_mode, 'Single'),
+        set_and_wait(self.enable, 1)
+        sigs = OrderedDict([(self.parent.cam.array_callbacks, 1),
+                            (self.parent.cam.image_mode, 'Single'),
                             (self.parent.cam.trigger_mode, 'Internal'),
                             # just in case tha acquisition time is set very long...
                             (self.parent.cam.acquire_time , 1),
@@ -661,8 +663,6 @@ class HDF5Plugin(FilePlugin):
                             (self.parent.cam.acquire, 1)])
 
         original_vals = {sig: sig.get() for sig in sigs}
-
-        set_and_wait(self.capture, 0)
 
         for sig, val in sigs.items():
             ttime.sleep(0.1)  # abundance of caution
@@ -673,8 +673,6 @@ class HDF5Plugin(FilePlugin):
         for sig, val in reversed(list(original_vals.items())):
             ttime.sleep(0.1)
             set_and_wait(sig, val)
-
-        set_and_wait(self.capture, 1)
 
 class MagickPlugin(FilePlugin):
     _default_suffix = 'Magick1:'


### PR DESCRIPTION
This uses Stream mode, which allows us to write one HDF5 file per *run* (strictly speaking, per stage/unstage), not per acquisition.

I executed [this script](https://gist.github.com/danielballan/42e854fdb5e65f2cb809), accessing a SimDetector IOC running AD 2.2 at xf23id (actual 2.2, not the customized branch run in production at CSX).