### PR TITLE
Recover from a failed stage

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -338,17 +338,7 @@ class BlueskyInterface:
                          "original settings before re-raising the "
                          "exception.", self.name)
             self.unstage()
-            parent = self.parent
-            if parent is None:
-                # This is no parent to unstage; we are done.
-                raise
-
-            # Recursively unstage parents, who will then unstage children.
-            while True:
-                parent.unstage()
-                parent = parent.parent
-                if parent is None:
-                    raise
+            raise
 
     def unstage(self):
         """
@@ -356,7 +346,7 @@ class BlueskyInterface:
 
         Multiple calls (without a new call to 'stage') have no effect.
         """
-        if not self._original_vals:
+        if not self._staged:
             # Unlike staging, there is no harm in making unstage
             # 'indepotent'.
             logger.debug("Cannot unstage %r; it is not staged. Passing.",


### PR DESCRIPTION
Here, I use `self._original_vals` to keep track of which signals have actually been set in the midst of an ongoing stage. During unstage,  the values are removed. We discussed earlier (nodding to @klauer) that keeping the stash might be useful, but I think this mode of operation is actually the most useful for debugging.

And now, `self._staged` is merely a check on the non-emptiness of `self._original_vals`.

I discovered the problem and tested this solution using the following. As with so much else, an automated test should be made once the deployment is done.

```python
pe1.stage()  # raised IOError -- directory didn't exist
pe1._staged   # should be False
pe1.tiff._staged  # should also be False
pe1.stage()  # should be allowed, and again raise an IOError, not a RuntimError about already being staged
```