### PR TITLE
MNT: if no trigger signal, assume no need

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ before_install:
   - conda update conda --yes
   - conda install conda-build anaconda-client jinja2
   - conda config --add channels lightsource2
+  - conda config --add channels soft-matter
+
 
   # MAKE THE CONDA RECIPE
   - conda create -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -507,11 +507,13 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         if len(signals) > 1:
             raise NotImplementedError('More than one trigger signal is not '
                                       'currently supported')
-        elif not signals:
-            raise RuntimeError('Device has no trigger signal(s)')
-
-        acq_signal = signals[0]
         status = DeviceStatus(self)
+        if not signals:
+            status._finished()
+            return status
+
+        acq_signal, = signals
+
         self.subscribe(status._finished,
                        event_type=self.SUB_ACQ_DONE, run=False)
 


### PR DESCRIPTION
If `self.trigger_signals` is an empty list, assume there is no need to
trigger the device (and it is immediatly done) instead of raising.

My proposal for NSLS-II/bluesky#279