### PR TITLE
FIX: plugin stage

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -25,11 +25,9 @@ import uuid
 import filestore.api as fs
 
 from datetime import datetime
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from itertools import count
-import os
 
-from ..ophydobj import DeviceStatus
 from ..device import GenerateDatumInterface, BlueskyInterface
 
 logger = logging.getLogger(__name__)
@@ -52,8 +50,8 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
     `datetime.strftime`, which accepts the standard tokens, such as
     %Y-%m-%d.
     """
-    def __init__(self, *args, write_path_template=None, read_path_template=None,
-                 **kwargs):
+    def __init__(self, *args, write_path_template=None,
+                 read_path_template=None, **kwargs):
         # TODO Can we make these args? Depends on plugin details.
         if write_path_template is None:
             raise ValueError("write_path_template is required")
@@ -63,13 +61,12 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
         self._point_counter = None
         self._locked_key_list = False
         self._datum_uids = defaultdict(list)
-        self.stage_sigs.update([
-                                (self.auto_increment, 1),
+        self.stage_sigs.update([(self.auto_increment, 1),
                                 (self.array_counter, 0),
                                 (self.file_number, 0),
                                 (self.auto_save, 'Yes'),
                                 (self.num_capture, 0),
-                               ])
+                                ])
 
     @property
     def read_path_template(self):
@@ -94,7 +91,7 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
         read_path = formatter(self.read_path_template)
         self.stage_sigs.update([(self.file_path, write_path),
                                 (self.file_name, self._filename),
-                               ])
+                                ])
         super().stage()
 
         # AD does this same templating in C, but we can't access it
@@ -104,7 +101,8 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
                                                self.file_number.get())
         self._fp = read_path
         if not self.file_path_exists.get():
-            raise IOError("Path %s does not exist on IOC." % self.file_path.get())
+            raise IOError("Path %s does not exist on IOC."
+                          "" % self.file_path.get())
 
     def generate_datum(self, key, timestamp):
         "Generate a uid and cache it with its key for later insertion."
@@ -148,7 +146,7 @@ class FileStoreHDF5(FileStoreBase):
         self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.h5'),
                                 (self.file_write_mode, 'Stream'),
                                 (self.capture, 1)
-                               ])
+                                ])
         super().stage()
         res_kwargs = {'frame_per_point': self.num_captured.get()}
         self._resource = fs.insert_resource('AD_HDF5', self._fn, res_kwargs)
@@ -160,7 +158,7 @@ class FileStoreTIFF(FileStoreBase):
         # 'num_images' is ignored.
         self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.tiff'),
                                 (self.file_write_mode, 'Single'),
-                               ])
+                                ])
         super().stage()
         res_kwargs = {'template': self.file_template.get(),
                       'filename': self.file_name.get(),
@@ -196,7 +194,7 @@ class FileStoreTIFFSquashing(FileStoreBase):
                                 (proc.num_filter, images_per_set),
                                 (cam.num_images, images_per_set * num_sets),
                                 (self.nd_array_port, proc.port_name.get())
-                               ])
+                                ])
         super().stage()
         res_kwargs = {'template': self.file_template.get(),
                       'filename': self.file_name.get(),

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -63,8 +63,10 @@ class PluginBase(ADBase):
         # Turn array callbacks on during staging.
         # Without this, no array data is sent to the plugins.
         super().__init__(*args, **kwargs)
-        self.stage_sigs.update([(self.parent.cam.array_callbacks, 1),
-                               ])
+
+        if self.parent is not None and hasattr(self.parent, 'cam'):
+            self.stage_sigs.update([(self.parent.cam.array_callbacks, 1),
+                                   ])
 
     _html_docs = ['pluginDoc.html']
     _plugin_type = None

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -15,6 +15,7 @@ import itertools
 
 from ..ophydobj import DeviceStatus
 from ..device import BlueskyInterface
+from ..utils import set_and_wait
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +32,7 @@ class TriggerBase(BlueskyInterface):
         # settings
         self.stage_sigs.update([(self.cam.acquire, 0),  # If acquiring, stop.
                                 (self.cam.image_mode, 1),  # 'Multiple' mode
-                               ])
+                                ])
         self._status = None
         self._acquisition_signal = self.cam.acquire
         self._acquisition_signal.subscribe(self._acquire_changed)
@@ -185,7 +186,8 @@ class MultiTrigger(TriggerBase):
 
     def _acquire_changed(self, value=None, old_value=None, **kwargs):
         "This is called when the 'acquire' signal changes."
-        logger.debug("_acquire_chaged has been called: old_value %r, value %r", old_value, value)
+        logger.debug("_acquire_chaged has been called: old_value %r, value %r",
+                     old_value, value)
         if self._status is None:
             return
         if (old_value == 1) and (value == 0):


### PR DESCRIPTION
* Allow PluginBase to be used outside of Detectors (as can be necessary or desirable) - this comes in the form of just checking to see if parent has a 'cam' attr
* PEP8 cleanups on filestore/trigger_mixins
* Missing import on trigger_mixins shows our tests and coverage are lacking