### PR TITLE
FIX: make Device.configuration_attrs include data

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -529,8 +529,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             obj = getattr(self, attr)
             if config:
                 values.update(obj.read_configuration())
-            else:
-                values.update(obj.read())
+
+            values.update(obj.read())
 
         return values
 
@@ -559,8 +559,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             obj = getattr(self, attr)
             if config:
                 desc.update(obj.describe_configuration())
-            else:
-                desc.update(obj.describe())
+
+            desc.update(obj.describe())
 
         return desc
 


### PR DESCRIPTION
During an offline discussion, we found that if a component is listed in the configuration_attrs list, we want both its metadata and its values.

For example, if component 'a' is in a device's read_configuration list, calling device.describe_configuration() will return an aggregate of both device.a.describe_configuration() and device.a.describe().