### PR TITLE
EpicsSignalRO refactor

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,6 +39,7 @@ dependencies:
 
     - conda config --set always_yes true
     - conda config --add channels lightsource2
+    - conda config --add channels conda-forge
 
     - conda install python=$PYTHON_VERSION
   

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -14,7 +14,7 @@ class EpicsSignalWithRBV(EpicsSignal):
     # 'pvname' being the setpoint and 'pvname_RBV' being the read-back
 
     def __init__(self, prefix, **kwargs):
-        super().__init__(prefix + '_RBV', write_pv=prefix, rw=True, **kwargs)
+        super().__init__(prefix + '_RBV', write_pv=prefix, **kwargs)
 
 
 class ADComponent(Component):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -492,7 +492,7 @@ class EpicsSignal(EpicsSignalBase):
         self._setpoint = value
         self._setpoint_ts = timestamp
 
-        if self._read_pv != self._write_pv:
+        if self._read_pv is not self._write_pv:
             self._run_subs(sub_type=self.SUB_SETPOINT,
                            old_value=old_value, value=value,
                            timestamp=self._setpoint_ts, **kwargs)
@@ -525,7 +525,7 @@ class EpicsSignal(EpicsSignalBase):
         old_value = self._setpoint
         self._setpoint = value
 
-        if self._read_pv == self._write_pv:
+        if self._read_pv is self._write_pv:
             # readback and setpoint PV are one in the same, so update the
             # readback as well
             super().put(value, timestamp=time.time(), force=True)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -222,7 +222,9 @@ class EpicsSignalBase(Signal):
         self._read_pv = epics.PV(read_pv, form=pv_form,
                                  auto_monitor=auto_monitor,
                                  **pv_kw)
-        self._read_pv.add_callback(self._read_changed, run_now=True)
+
+        self._read_pv.add_callback(self._read_changed,
+                                   run_now=self._read_pv.connected)
 
     @property
     @raise_if_disconnected
@@ -435,7 +437,8 @@ class EpicsSignal(EpicsSignalBase):
             self._write_pv = epics.PV(write_pv, form=pv_form,
                                       auto_monitor=self._auto_monitor,
                                       **self._pv_kw)
-            self._write_pv.add_callback(self._write_changed, run_now=True)
+            self._write_pv.add_callback(self._write_changed,
+                                        run_now=self._write_pv.connected)
         else:
             self._write_pv = self._read_pv
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -104,7 +104,7 @@ class Signal(OphydObject):
 
     @value.setter
     def value(self, value):
-         self.put(value)
+        self.put(value)
 
     def read(self):
         '''Put the status of the signal into a simple dictionary format

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -59,13 +59,23 @@ class Signal(OphydObject):
         '''The readback value'''
         return self._readback
 
-    def put(self, value, timestamp=None, force=False):
+    def put(self, value, *, timestamp=None, force=False):
         '''Put updates the internal readback value
+
+        The value is optionally checked first, depending on the value of force.
+        In addition, VALUE subscriptions are run.
 
         Parameters
         ----------
-
+        value : any
+            Value to set
+        timestamp : float, optional
+            The timestamp associated with the value, defaults to time.time()
+        force : bool, optional
+            Check the value prior to setting it, defaults to False
         '''
+
+        # TODO: consider adding set_and_wait here as a kwarg
         if not force:
             self.check_value(value)
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -169,6 +169,18 @@ class EpicsSignalBase(Signal):
                  auto_monitor=None,
                  name=None,
                  **kwargs):
+
+        if 'rw' in kwargs:
+            if kwargs['rw']:
+                new_class = EpicsSignal
+            else:
+                new_class = EpicsSignalRO
+
+            raise RuntimeError('rw is no longer an option for EpicsSignal. '
+                               'Based on your setting of `rw`, you should be '
+                               'using this class: {}'
+                               ''.format(new_class.__name__))
+
         if pv_kw is None:
             pv_kw = dict()
 
@@ -375,17 +387,6 @@ class EpicsSignal(EpicsSignalBase):
     def __init__(self, read_pv, write_pv=None, *, pv_kw=None,
                  put_complete=False, string=False, limits=False,
                  auto_monitor=None, name=None, **kwargs):
-
-        if 'rw' in kwargs:
-            if kwargs['rw']:
-                new_class = EpicsSignal
-            else:
-                new_class = EpicsSignalRO
-
-            raise RuntimeError('rw is no longer an option for EpicsSignal. '
-                               'Based on your setting of `rw`, you should be '
-                               'using this class: {}'
-                               ''.format(new_class.__name__))
 
         self._write_pv = None
         self._use_limits = bool(limits)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -350,12 +350,6 @@ class EpicsSignalRO(EpicsSignalBase):
     name : str, optional
         Name of signal.  If not given defaults to read_pv
     '''
-    def __init__(self, read_pv, *, pv_kw=None, string=False, auto_monitor=None,
-                 name=None, **kwargs):
-        super().__init__(read_pv, pv_kw=pv_kw, string=string,
-                         auto_monitor=auto_monitor, name=name,
-                         **kwargs)
-
     def put(self, *args, **kwargs):
         raise ReadOnlyError('Read-only signals cannot be put to')
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -63,9 +63,14 @@ class SignalBase(OphydObject):
         '''Override to specify put behavior'''
         raise NotImplementedError()
 
-    value = property(lambda self: self.get(),
-                     lambda self, value: self.put(value),
-                     doc='The value associated with the signal')
+    @property
+    def value(self):
+        '''The signal's value'''
+        return self.get()
+
+    @value.setter
+    def value(self, value):
+         self.put(value)
 
     def _set_readback(self, value, **kwargs):
         '''Set the readback value internally'''
@@ -487,11 +492,14 @@ class EpicsSignal(EpicsSignalBase):
                            old_value=old_value, value=value,
                            timestamp=time.time(), **kwargs)
 
-    # getters/setters of properties are defined as lambdas so subclasses
-    # can override them without redefining the property
-    setpoint = property(lambda self: self.get_setpoint(),
-                        lambda self, value: self.put(value),
-                        doc='The setpoint value for the signal')
+    @property
+    def setpoint(self):
+        '''The setpoint PV value'''
+        return self.get_setpoint()
+
+    @setpoint.setter
+    def setpoint(self, value):
+        self.put(value)
 
 
 # Backward compatibility

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -36,6 +36,14 @@ class Signal(OphydObject):
 
         self._timestamp = timestamp
 
+    def trigger(self):
+        '''Call that is used by bluesky prior to read()'''
+        # NOTE: this is a no-op that exists here for bluesky purposes
+        #       it may need to be moved in the future
+        d = DeviceStatus(self)
+        d._finished()
+        return d
+
     @property
     def connected(self):
         '''Subclasses should override this'''
@@ -488,14 +496,6 @@ class EpicsSignal(EpicsSignalBase):
             self._run_subs(sub_type=self.SUB_SETPOINT,
                            old_value=old_value, value=value,
                            timestamp=self._setpoint_ts, **kwargs)
-
-    def trigger(self):
-        try:
-            return super().trigger()
-        except AttributeError:
-            d = DeviceStatus(self)
-            d._finished()
-            return d
 
     def put(self, value, force=False, **kwargs):
         '''Using channel access, set the write PV to `value`.

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -157,6 +157,11 @@ class EpicsSignalBase(Signal):
                                    run_now=self._read_pv.connected)
 
     @property
+    def as_string(self):
+        '''Attempt to cast the EPICS PV value to a string by default'''
+        return self._string
+
+    @property
     @raise_if_disconnected
     def precision(self):
         '''The precision of the read PV, as reported by EPICS'''
@@ -219,7 +224,27 @@ class EpicsSignalBase(Signal):
         '''
         pass
 
-    def get(self, as_string=None, **kwargs):
+    def get(self, *, as_string=None, **kwargs):
+        '''Get the readback value through an explicit call to EPICS
+
+        Parameters
+        ----------
+        count : int, optional
+            Explicitly limit count for array data
+        as_string : bool, optional
+            Get a string representation of the value, defaults to as_string
+            from this signal, optional
+        as_numpy : bool
+            Use numpy array as the return type for array data.
+        timeout : float, optional
+            maximum time to wait for value to be received.
+            (default = 0.5 + log10(count) seconds)
+        use_monitor : bool, optional
+            to use value from latest monitor callback or to make an
+            explicit CA call for the value. (default: True)
+        '''
+        # NOTE: in the future this should be improved to grab self._readback
+        #       instead, when all of the kwargs match up
         if as_string is None:
             as_string = self._string
 
@@ -232,8 +257,8 @@ class EpicsSignalBase(Signal):
 
         if as_string:
             return waveform_to_string(ret)
-        else:
-            return ret
+
+        return ret
 
     def _fix_type(self, value):
         if self._string:

--- a/tests/coverage_full.sh
+++ b/tests/coverage_full.sh
@@ -39,8 +39,9 @@ cd $script_path/..
 #COVERAGE_HTML=$script_path/doc/coverage
 #rm -rf $COVERAGE_HTML
 #mkdir $COVERAGE_HTML
-nosetests --with-coverage --cover-tests --cover-package=ophyd -v --where=tests
-          # --tests=test.test_cas_function
+nosetests --with-coverage --cover-tests --cover-package=ophyd -v --where=tests --tests=tests.test_signal
 
 #view setup.py -c ":Coveragepy report"
-# view ophyd/controls/cas/function.py -c ":Coveragepy report"
+# view ophyd/signal.py -c ":Coveragepy report"
+nvim ophyd/signal.py -c ":Coveragepy report"
+

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -10,7 +10,7 @@ import copy
 import numpy as np
 import epics
 
-from ophyd.signal import (SoftSignal, EpicsSignal, EpicsSignalRO)
+from ophyd.signal import (Signal, EpicsSignal, EpicsSignalRO)
 from ophyd.utils import (ReadOnlyError, TimeoutError)
 
 logger = logging.getLogger(__name__)
@@ -243,7 +243,7 @@ class SignalTests(unittest.TestCase):
 
         name = 'test'
         value = 10.0
-        signal = SoftSignal(name=name, value=value, timestamp=start_t)
+        signal = Signal(name=name, value=value, timestamp=start_t)
         signal.wait_for_connection()
 
         self.assertTrue(signal.connected)
@@ -278,7 +278,7 @@ class SignalTests(unittest.TestCase):
 
         # readback callback for soft signal
         info = dict(called=False)
-        signal.subscribe(_sub_test, event_type=SoftSignal.SUB_VALUE,
+        signal.subscribe(_sub_test, event_type=Signal.SUB_VALUE,
                          run=False)
         self.assertFalse(info['called'])
         signal.put(value + 1)
@@ -307,7 +307,7 @@ class SignalTests(unittest.TestCase):
 
         name = 'test'
         value = 10.0
-        signal = SoftSignal(name=name, value=value, timestamp=start_t)
+        signal = Signal(name=name, value=value, timestamp=start_t)
         sig_copy = copy.copy(signal)
 
         self.assertEquals(signal.name, sig_copy.name)

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -295,6 +295,7 @@ class SignalTests(unittest.TestCase):
         self.assertEquals(kw['old_value'], value)
         self.assertEquals(kw['timestamp'], signal.timestamp)
 
+        signal.trigger()
         signal.read()
         signal.describe()
         signal.read_configuration()


### PR DESCRIPTION
Should be a backward-compatible refactor

* Both EpicsSignal and EpicsSignalRO inherit from EpicsSignalBase. Some leftovers from Signal still being read-write, but I think it's an improvement. 97% coverage with tests (only trigger is untested)

* Additionally, odd ReadOnlyError bug should be fixed (thanks, @tacaswell). PVs cached and already connected on the pyepics level were calling callback functions prior to the EpicsSignal even getting their instance.