### PR TITLE
ENH: flesh out Device.stop

### DIFF
--- a/ophyd/utils/errors.py
+++ b/ophyd/utils/errors.py
@@ -27,9 +27,17 @@ class LimitError(ValueError, OpException):
     '''Value is outside of defined limits'''
     pass
 
+
 class DisconnectedError(OpException):
     '''Signal or SignalGroup is not connected to EPICS'''
     pass
+
+
+class ExceptionBundle(RuntimeError, OpException):
+    '''One or more exceptions was raised during a loop of try/except blocks'''
+    def __init__(self, msg, exceptions):
+        super().__init__(msg)
+        self.exceptions = exceptions
 
 
 # - Alarms


### PR DESCRIPTION
stop is called on all Devices in the hierarchy. Calls to sub-class stop() are error-tolerant such as to not cause the top-level stop() call to die prematurely.

ExceptionBundle contains all of the exceptions that were caught during a stop() call.

Example Exception message for the test:
```
ExceptionBundle: 2 exception(s) were raised during stop:
sub2.subsub raised Exception('stop failed for some reason',)
sub3.subsub raised Exception('stop failed for some reason',)
```