### PR TITLE
BLD: dump pyepics version to stdout on Travis blds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,9 @@ script:
 
   # check pyepics
   # - export PYEPICS_LIBCA=$EPICS_BASE/lib/$EPICS_HOST_ARCH/libca.so
-  - python -c "import epics; print(epics.caget('XF:31IDA-OP{Tbl-Ax:X1}Mtr'))"
+  - python -c "import epics; print(epics.__version__)"
   - python -c "import epics.ca; print(epics.ca.find_libca())"
+  - python -c "import epics; print(epics.caget('XF:31IDA-OP{Tbl-Ax:X1}Mtr'))"
 
   # running tests
   - py.test --cov=ophyd --cov-report term-missing


### PR DESCRIPTION
Also, cause Travis to fail sooner if it can't find libca (for some reason)