### PR TITLE
ENH/API: Logical operations on StatusObject

### DIFF
--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -96,7 +96,7 @@ class PositionerBase(OphydObject):
         status = MoveStatus(self, position, timeout=timeout)
 
         if moved_cb is not None:
-            status.finished_cb = partial(moved_cb, obj=self)
+            status.add_callback(partial(moved_cb, obj=self))
             # the status object will run this callback when finished
 
         self.subscribe(status._finished, event_type=self._SUB_REQ_DONE,

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -28,13 +28,18 @@ class StatusBase:
         The default timeout to use for a blocking wait, and the amount of time
         to wait to mark the operation as failed
     """
-    def __init__(self, *, timeout=None):
+    def __init__(self, *, timeout=None, timestamp=None):
         super().__init__()
         self._lock = RLock()
-        self._cb = None
+        self._callbacks = set()
         self.done = False
-        self.success = False
+        self.success = None
         self.timeout = None
+        self.finish_ts = None
+
+        if timestamp is None:
+            timestamp = time.time()
+        self.start_ts = timestamp
 
         if timeout is not None:
             self.timeout = float(timeout)
@@ -57,35 +62,85 @@ class StatusBase:
             self._timeout_thread = None
 
     @_locked
-    def _finished(self, success=True, **kwargs):
+    def _finished(self, *, success=True, timestamp=None, **kwargs):
         # args/kwargs are not really used, but are passed - because pyepics
         # gives in a bunch of kwargs that we don't care about
-
         self.success = success
         self.done = True
-
-        if self._cb is not None:
-            self._cb()
-            self._cb = None
+        if timestamp is None:
+            timestamp = time.time()
+        self.finish_ts = timestamp
+        for cb in list(self._callbacks):
+            cb()
+            self._callbacks.remove(cb)
 
     @property
-    def finished_cb(self):
+    def callbacks(self):
         """
-        Callback to be run when the status is marked as finished
+        Callbacks to be run when the status is marked as finished
 
         The call back has no arguments
         """
-        return self._cb
+        return self._callbacks
 
-    @finished_cb.setter
     @_locked
-    def finished_cb(self, cb):
-        if self._cb is not None:
-            raise RuntimeError("Can not change the call back")
+    def add_callback(self, cb):
         if self.done:
             cb()
         else:
-            self._cb = cb
+            self._callbacks.add(cb)
+
+    def __and__(self, other):
+        """
+        Returns a new 'composite' status object, OrStatus,
+        with the same base API.
+
+        It will finish when both `self` or `other` finish.
+        """
+        return AndStatus(self, other)
+
+    @property
+    def elapsed(self):
+        if self.finish_ts is None:
+            return time.time() - self.start_ts
+        else:
+            return self.finish_ts - self.start_ts
+
+    def __repr__(self):
+        return '{0}(done={1.done}, elapsed={1.elapsed:.1f}, ' \
+               'success={1.success})'.format(self.__class__.__name__, self)
+
+
+class AndStatus(StatusBase):
+    "a Status that has composes two other Status objects using logical and"
+    def __init__(self, left, right, *, timestamp=None, timeout=None):
+        super().__init__(timestamp=timestamp, timeout=timeout)
+        self.left = left
+        self.right = right
+
+        def inner():
+            with self._lock:
+                l_success = self.left.success  # alias for readability below
+                r_success = self.right.success
+
+                # At least one is done.
+                # If it failed, do not wait for the second one.
+                if (not l_success) and (l_success is not None):
+                    self._finished(success=False)
+                elif (not r_success) and (r_success is not None):
+                    self._finished(success=False)
+
+                elif l_success and r_success:
+                    # both are done, successfully
+                    success = l_success and r_success
+                    self._finished(success=success)
+                # else one is done, successfully, and we wait for #2
+
+        self.left.add_callback(inner)
+        self.right.add_callback(inner)
+
+    def __repr__(self):
+        return "({self.left!r} & {self.right!r})".format(self=self)
 
 
 class MoveStatus(StatusBase):
@@ -121,19 +176,13 @@ class MoveStatus(StatusBase):
         Motion successfully completed
     '''
 
-    def __init__(self, positioner, target, *, done=False, start_ts=None,
-                 timeout=30.0):
-        # call the base class
-        super().__init__(timeout=timeout)
+    def __init__(self, positioner, target, *, done=False, timestamp=None,
+                 timeout=None):
+        super().__init__(timestamp=timestamp, timeout=timeout)
 
         self.done = done
-        if start_ts is None:
-            start_ts = time.time()
-
         self.pos = positioner
         self.target = target
-        self.start_ts = start_ts
-        self.finish_ts = None
         self.finish_pos = None
 
     @property
@@ -149,34 +198,17 @@ class MoveStatus(StatusBase):
             return None
 
     @_locked
-    def _finished(self, success=True, timestamp=None, **kwargs):
-        if timestamp is None:
-            timestamp = time.time()
-        self.finish_ts = timestamp
+    def _finished(self, *, success=True, timestamp=None, **kwargs):
         self.finish_pos = self.pos.position
         # run super last so that all the state is ready before the
         # callback runs
-        super()._finished(success=success)
-
-    @property
-    def elapsed(self):
-        if self.finish_ts is None:
-            return time.time() - self.start_ts
-        else:
-            return self.finish_ts - self.start_ts
-
-    def __str__(self):
-        return '{0}(done={1.done}, elapsed={1.elapsed:.1f}, ' \
-               'success={1.success})'.format(self.__class__.__name__,
-                                             self)
-
-    __repr__ = __str__
+        super()._finished(success=success, timestamp=timestsamp)
 
 
 class DeviceStatus(StatusBase):
-    '''Device status'''
-    def __init__(self, device, *, timeout=None):
-        super().__init__(timeout=timeout)
+    "A status object that stashes a reference to a device"
+    def __init__(self, device, *, timeout=None, timestamp=None):
+        super().__init__(timeout=timeout, timestamp=timestamp)
         self.device = device
 
 

--- a/tests/test_ophydobj.py
+++ b/tests/test_ophydobj.py
@@ -20,10 +20,13 @@ class StatusTests(unittest.TestCase):
     def test_callback(self):
         st = StatusBase()
         cb = Mock()
+        cb2 = Mock()
 
-        st.finished_cb = cb
-        self.assertIs(st.finished_cb, cb)
-        self.assertRaises(RuntimeError, setattr, st, 'finished_cb', None)
+        st.add_callback(cb)
+        _cb, = st.callbacks
+        self.assertIs(_cb, cb)
+        st.add_callback(cb2)
+        self.assertIn(cb2, st.callbacks)
 
         st._finished()
         cb.assert_called_once_with()

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -60,32 +60,9 @@ def test_and():
     assert 'done' in state3
     assert 'done' in state4
     assert 'done' in state5
-    assert st3.ancestors == set([st1, st2])
-    assert st4.ancestors == set([st1, st2, st3])
-    assert st5.ancestors == set([st1, st2, st3, st4])
-
-def test_or():
-    st1 = StatusBase()
-    st2 = StatusBase()
-    st3 = st1 | st2
-    st4 = st3 | st2
-    st5 = st3 | st4
-    state1, cb1 = _setup_st()
-    state2, cb2 = _setup_st()
-    state3, cb3 = _setup_st()
-    state4, cb4 = _setup_st()
-    state5, cb5 = _setup_st()
-    st1.add_callback(cb1)
-    st2.add_callback(cb2)
-    st3.add_callback(cb3)
-    st4.add_callback(cb4)
-    st5.add_callback(cb5)
-    st1._finished()
-    assert 'done' in state1
-    assert 'done' not in state2
-    assert 'done' in state3
-    assert 'done' in state4
-    assert 'done' in state5
-    assert st3.ancestors == set([st1, st2])
-    assert st4.ancestors == set([st1, st2, st3])
-    assert st5.ancestors == set([st1, st2, st3, st4])
+    assert st3.left is st1
+    assert st3.right is st2
+    assert st4.left is st1
+    assert st4.right is st3
+    assert st5.left is st3
+    assert st5.right is st4

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -2,20 +2,20 @@ from ophyd.status import StatusBase
 
 
 def _setup_st():
-    st = StatusBase()
     state = {}
 
     def cb():
         state['done'] = True
 
-    return st, state, cb
+    return state, cb
 
 
 def test_status_post():
-    st, state, cb = _setup_st()
+    st = StatusBase()
+    state, cb = _setup_st()
 
     assert 'done' not in state
-    st.finished_cb = cb
+    st.add_callback(cb)
     assert 'done' not in state
     st._finished()
     assert 'done' in state
@@ -23,11 +23,69 @@ def test_status_post():
 
 
 def test_status_pre():
-    st, state, cb = _setup_st()
+    st = StatusBase()
+    state, cb = _setup_st()
 
     st._finished()
 
     assert 'done' not in state
-    st.finished_cb = cb
+    st.add_callback(cb)
     assert 'done' in state
     assert state['done']
+
+def test_and():
+    st1 = StatusBase()
+    st2 = StatusBase()
+    st3 = st1 & st2
+    # make sure deep recursion works
+    st4 = st1 & st3
+    st5 = st3 & st4
+    state1, cb1 = _setup_st()
+    state2, cb2 = _setup_st()
+    state3, cb3 = _setup_st()
+    state4, cb4 = _setup_st()
+    state5, cb5 = _setup_st()
+    st1.add_callback(cb1)
+    st2.add_callback(cb2)
+    st3.add_callback(cb3)
+    st4.add_callback(cb4)
+    st5.add_callback(cb5)
+    st1._finished()
+    assert 'done' in state1
+    assert 'done' not in state2
+    assert 'done' not in state3
+    assert 'done' not in state4
+    assert 'done' not in state5
+    st2._finished()
+    assert 'done' in state3
+    assert 'done' in state4
+    assert 'done' in state5
+    assert st3.ancestors == set([st1, st2])
+    assert st4.ancestors == set([st1, st2, st3])
+    assert st5.ancestors == set([st1, st2, st3, st4])
+
+def test_or():
+    st1 = StatusBase()
+    st2 = StatusBase()
+    st3 = st1 | st2
+    st4 = st3 | st2
+    st5 = st3 | st4
+    state1, cb1 = _setup_st()
+    state2, cb2 = _setup_st()
+    state3, cb3 = _setup_st()
+    state4, cb4 = _setup_st()
+    state5, cb5 = _setup_st()
+    st1.add_callback(cb1)
+    st2.add_callback(cb2)
+    st3.add_callback(cb3)
+    st4.add_callback(cb4)
+    st5.add_callback(cb5)
+    st1._finished()
+    assert 'done' in state1
+    assert 'done' not in state2
+    assert 'done' in state3
+    assert 'done' in state4
+    assert 'done' in state5
+    assert st3.ancestors == set([st1, st2])
+    assert st4.ancestors == set([st1, st2, st3])
+    assert st5.ancestors == set([st1, st2, st3, st4])


### PR DESCRIPTION
Here's a start on an idea I had this morning.

Considering the `MergedStatusObject` at SRX -- which fires when both of its "children" are finished -- I thought it might be useful to be able to perform logical AND and OR on status objects, returning a `StatusBase`. With these, we can construct arbitrary combinations without creating a new class for every special case.

Currently, you can only register one callback function on a status object. For this to work, status objects must support multiple callbacks. If this isn't obvious, here's why:

```python
s3 = s1 | s2  # registers a callback on s1 that will fire s3
s4 = s1 | s3  # registers another callback on s1 to fire s4
```

Making this change is straightforward, but unfortunately I think it is not possible to do this with a backward-compatible API. Fortunately, the surface area of this API is not large. No non-test ophyd code (outside of `StatusBase` itself) is affected. About six lines of test code have to be changed, plus three lines downstream in bluesky and one place in the SRX beamline config.

This is still WIP -- just posting it for discussion.