### PR TITLE
ENH: Add duck-typing namespace scraper.

### DIFF
--- a/ophyd/commands.py
+++ b/ophyd/commands.py
@@ -116,7 +116,7 @@ def _normalize_positioners(positioners):
         res = []
         for device in positioners:
             if not isinstance(device, (Device, Positioner)):
-                raise TypeError("input is not a device")
+                raise TypeError("Input is not a Device: %r" % device)
             res.extend(_recursive_positioner_search(device))
     return res
 

--- a/ophyd/commands.py
+++ b/ophyd/commands.py
@@ -42,6 +42,22 @@ FMT_PREC = 6
 DISCONNECTED = 'disconnected'
 
 
+def scrape_namespace():
+    """
+    Get all public objects from the user namespace, sorted by name.
+
+    If we are not in an IPython session, warn and return an empty list.
+    """
+    ip = IPython.get_ipython()
+    if ip is None:
+        warnings.warn('Unable to inspect Python global namespace; '
+                      'use IPython to enable these features.')
+        return []
+    else:
+        return [val for var, val in sorted(ip.user_ns.items())
+                if not var.startswith('_')]
+
+
 def instances_from_namespace(classes):
     '''Get all instances of `classes` from the user namespace
 
@@ -51,14 +67,7 @@ def instances_from_namespace(classes):
         Passed directly to isinstance(), only instances of these classes
         will be returned.
     '''
-    ip = IPython.get_ipython()
-    if ip is None:
-        warnings.warn('Unable to inspect Python global namespace; '
-                      'use IPython to enable these features.')
-        return []
-    else:
-        return [val for var, val in sorted(ip.user_ns.items())
-                if isinstance(val, classes) and not var.startswith('_')]
+    return [val for val in scrape_namespace() if isinstance(val, classes)]
 
 
 def ducks_from_namespace(attr):
@@ -71,14 +80,7 @@ def ducks_from_namespace(attr):
     attr : str
         name of attribute
     '''
-    ip = IPython.get_ipython()
-    if ip is None:
-        warnings.warn('Unable to inspect Python global namespace; '
-                      'use IPython to enable these features.')
-        return []
-    else:
-        return [val for var, val in sorted(ip.user_ns.items())
-                if hasattr(val, attr) and not var.startswith('_')]
+    return [val for val in scrape_namespace() if hasattr(val, attr)]
 
 
 def get_all_positioners():
@@ -376,6 +378,9 @@ def wh_pos(positioners=None):
 
     >>>wh_pos([m1, m2, m3])
     """
+    if positioners is None:
+        devices = instances_from_namespace(Device)
+    
     _print_pos(positioners, file=sys.stdout)
 
 

--- a/ophyd/commands.py
+++ b/ophyd/commands.py
@@ -61,6 +61,26 @@ def instances_from_namespace(classes):
                 if isinstance(val, classes) and not var.startswith('_')]
 
 
+def ducks_from_namespace(attr):
+    '''Get all instances that have a given attribute.
+
+    "Ducks" is a reference to "duck-typing." If it looks like a duck....
+
+    Parameters
+    ----------
+    attr : str
+        name of attribute
+    '''
+    ip = IPython.get_ipython()
+    if ip is None:
+        warnings.warn('Unable to inspect Python global namespace; '
+                      'use IPython to enable these features.')
+        return []
+    else:
+        return [val for var, val in sorted(ip.user_ns.items())
+                if hasattr(val, attr) and not var.startswith('_')]
+
+
 def get_all_positioners():
     '''Get all positioners defined in the IPython namespace'''
     return instances_from_namespace(Positioner)

--- a/ophyd/commands.py
+++ b/ophyd/commands.py
@@ -95,10 +95,10 @@ def get_all_positioners():
 def _recursive_positioner_search(device):
     "Return a flat list the device and any subdevices that can be 'set'."
     res = []
+    if hasattr(device, 'set'):
+        res.append(device)
     for d in device._signals.values():
         if isinstance(d, (Device, Positioner)):
-            if hasattr(d, 'set'):
-                res.append(d)
             res.extend(_recursive_positioner_search(d))
     return res
 


### PR DESCRIPTION
This device does not get collected by `get_all_positioners`:

```python
class XYMotor(Device):
    x = Cpt(EpicsMotor, ...)
    y = Cpt(EpicsMotor, ...)

Should we add a `set` method and use duck-typing to identify positioners? See attached function.