### PR TITLE
FIX: more careful recursion that works on PseudoSingle

### DIFF
--- a/ophyd/commands.py
+++ b/ophyd/commands.py
@@ -94,12 +94,14 @@ def get_all_positioners():
 
 def _recursive_positioner_search(device):
     "Return a flat list the device and any subdevices that can be 'set'."
+    # TODO Refactor this as a method on Device.
     res = []
-    if hasattr(device, 'set'):
+    if hasattr(device, 'position'):  # duck-typed as a Positioner
         res.append(device)
-    for d in device._signals.values():
-        if isinstance(d, (Device, Positioner)):
-            res.extend(_recursive_positioner_search(d))
+    if isinstance(device, Device):  # only Devices have `_signals`
+        for d in device._signals.values():
+            if isinstance(d, (Device, Positioner)):
+                res.extend(_recursive_positioner_search(d))
     return res
 
 


### PR DESCRIPTION
`wh_pos()` died when it tries to call `_signals` on a PseudoSingle. We should only be recursing through Devices, not Positioners.

All of this will go away later -- just trying to make something reasonably clean that works for this cycle.