### PR TITLE
FIX: re-initialize automonitor when an EpicsSignal subscription is made

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -106,11 +106,17 @@ class EpicsMotor(Device, Positioner):
         self._started_moving = False
 
         try:
-            self.user_setpoint.put(position, wait=wait)
-            return super().move(position, wait=wait, **kwargs)
+            if not wait:
+                status = super().move(position, wait=False, **kwargs)
+                self.user_setpoint.put(position, wait=False)
+            else:
+                self.user_setpoint.put(position, wait=True)
+                status = super().move(position, wait=True, **kwargs)
         except KeyboardInterrupt:
             self.stop()
             raise
+
+        return status
 
     @property
     @raise_if_disconnected

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -199,6 +199,8 @@ class FakeEpicsWaveform(FakeEpicsPV):
     strings = ['abcd', 'efgh', 'ijkl']
     fake_values = [[ord(c) for c in s] + [0]
                    for s in strings]
+    auto_monitor = False
+    form = 'time'
 
 
 def setUpModule():


### PR DESCRIPTION
Replaces #248 
Should fix #246 

Tests passing locally, but we should make extra sure the logic is correct for re-initialization of `epics.PV`s