### PR TITLE
MNT: Make acq signal customizable in SignalTrigger subclass.

### DIFF
--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -35,7 +35,6 @@ class TriggerBase(BlueskyInterface):
                                 ])
         self._status = None
         self._acquisition_signal = self.cam.acquire
-        self._acquisition_signal.subscribe(self._acquire_changed)
 
 
 class SingleTrigger(TriggerBase):
@@ -55,6 +54,14 @@ class SingleTrigger(TriggerBase):
         if image_name is None:
             image_name = '_'.join([self.name, 'image'])
         self._image_name = image_name
+
+    def stage(self):
+        self._acquisition_signal.subscribe(self._acquire_changed)
+        super().stage()
+
+    def unstage(self):
+        super().unstage()
+        self._acquisition_signal.clear_sub(self._acquire_changed)
 
     def trigger(self):
         "Trigger one acquisition."
@@ -131,6 +138,14 @@ class MultiTrigger(TriggerBase):
             raise ValueError("must provide trigger_cycle -- see docstring")
         self.trigger_cycle = trigger_cycle
         super().__init__(*args, **kwargs)
+
+    def stage(self):
+        self._acquisition_signal.subscribe(self._acquire_changed)
+        super().stage()
+
+    def unstage(self):
+        super().unstage()
+        self._acquisition_signal.clear_sub(self._acquire_changed)
 
     @property
     def trigger_cycle(self):


### PR DESCRIPTION
In `SingleTrigger`, we expose the `_acquisition_signal` (which is by default `self.cam.acquire`). But then we subscribe to `self.cam.acquire` before the subclass has the opportunity to assign a different signal to that role. I noticed @dchabot working around this like so:

```python

class FastTrigger(SingleTrigger):
    def __init__(*args, **kwargs):
         ...
         # clear parent class subscription
         self._acquisition_signal.clear_sub(self._acquire_changed)
```

I have had to work around the same problem myself at CSX and XPD. This PR allows subclasses to alter `_acquisition_signal` *before* subscriptions are hooked up. Also, it removes the subscriptions upon unstaging, which I probably should have done in the first place. Agree, @dchabot?