### PR TITLE
More stage debug

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -28,7 +28,7 @@ from datetime import datetime
 from collections import defaultdict
 from itertools import count
 
-from ..device import GenerateDatumInterface, BlueskyInterface
+from ..device import GenerateDatumInterface, BlueskyInterface, Staged
 from ..utils import set_and_wait
 
 logger = logging.getLogger(__name__)
@@ -124,7 +124,7 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
     def describe(self):
         # One object has been 'described' once, no new keys can be added
         # during this stage/unstage cycle.
-        self._locked_key_list = self._staged
+        self._locked_key_list = (self._staged == Staged.yes)
         res = super().describe()
         for k in self._datum_uids:
             res[k] = self.parent.make_data_key()  # this is on DetectorBase
@@ -133,7 +133,7 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
     def read(self):
         # One object has been 'read' once, no new keys can be added
         # during this stage/unstage cycle.
-        self._locked_key_list = self._staged
+        self._locked_key_list = (self._staged == Staged.yes)
         res = super().read()
         for k, v in self._datum_uids.items():
             res[k] = v[-1]

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -14,7 +14,7 @@ import logging
 import itertools
 
 from ..ophydobj import DeviceStatus
-from ..device import BlueskyInterface
+from ..device import BlueskyInterface, Staged
 from ..utils import set_and_wait
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class SingleTrigger(TriggerBase):
 
     def trigger(self):
         "Trigger one acquisition."
-        if not self._staged:
+        if self._staged != Staged.yes:
             raise RuntimeError("This detector is not ready to trigger."
                                "Call the stage() method before triggering.")
 
@@ -142,7 +142,7 @@ class MultiTrigger(TriggerBase):
 
     def trigger(self):
         "Trigger one or more acquisitions."
-        if not self._staged:
+        if self._staged != Staged.yes:
             raise RuntimeError("This detector is not ready to trigger."
                                "Call the stage() method before triggering.")
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -356,6 +356,8 @@ class BlueskyInterface:
         # Apply settings.
         try:
             for sig, val in self.stage_sigs.items():
+                logger.debug("Setting %s to %r (original value: %r)", self.name,
+                             val, self._original_vals[sig])
                 set_and_wait(sig, val)
                 # It worked -- now add it to this list of sigs to unstage.
                 self._original_vals[sig] = original_vals[sig]
@@ -390,6 +392,8 @@ class BlueskyInterface:
 
         # Restore original values.
         for sig, val in reversed(list(self._original_vals.items())):
+            logger.debug("Setting %s to %r (original value: %r)", self.name,
+                            val, self._original_vals[sig])
             set_and_wait(sig, val)
             self._original_vals.pop(sig)
 


### PR DESCRIPTION
- debug messages giving old and new values of stage_sigs as they are set
- one more subtlety with stage/unstage logic: a device should not be marked `_staged = False` until unstaging has successfully finished so that you can't stage until everything is unstaged