### PR TITLE
MNT: hook for filestore mixin make_filename

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -126,12 +126,31 @@ class FileStorePluginBase(FileStoreBase):
                                 (self.num_capture, 0),
                                 ])
 
-    def stage(self):
-        # Make a filename.
+    def make_filename(self):
+        '''Make a filename.
+
+        This is a hook so that the read and write paths can either be modified
+        or created on disk prior to configuring the areaDetector plugin.
+
+        Returns
+        -------
+        filename : str
+            The start of the filename
+        read_path : str
+            Path that ophyd can read from
+        write_path : str
+            Path that the IOC can write to
+        '''
         filename = new_short_uid()
         formatter = datetime.now().strftime
         write_path = formatter(self.write_path_template)
         read_path = formatter(self.read_path_template)
+        return filename, read_path, write_path
+
+    def stage(self):
+        # Make a filename.
+        filename, read_path, write_path = self.make_filename()
+
         # Ensure we do not have an old file open.
         set_and_wait(self.capture, 0)
         # These must be set before parent is staged (specifically


### PR DESCRIPTION
Need to be able to:

1. Modify the filenames being saved through FileStoreBase (NFS+PIMS choke with hundreds of thousands of files in one directory)
2. Create the directory and set permissions

With this small change, I can do both in my subclass. For (1) I'm making a subdirectory with the start of the filename uid since I don't have access to any scan information during `stage()`.

P.S. @danielballan here's an opportunity to disagree!