### PR TITLE
FIX: minor mca tweaks

### DIFF
--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -68,7 +68,7 @@ class EpicsMCARecord(Device):
     background = C(EpicsSignalRO, '.BG')
     mode = C(EpicsSignal, '.MODE', string=True)
 
-    rois = DDC(add_rois(range(0, 31)))
+    rois = DDC(add_rois(range(0, 32)))
 
     def __init__(self, prefix, *, read_attrs=None,
                  configuration_attrs=None, monitor_attrs=None, name=None,

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -62,8 +62,11 @@ def add_rois(range_, **kwargs):
 class EpicsMCARecord(Device):
     '''SynApps MCA Record interface'''
     stop_signal = C(EpicsSignal, '.STOP')
-    preset_real_time = C(EpicsSignal, '.ERTM', write_pv='.PRTM')
-    preset_live_time = C(EpicsSignal, '.ELTM', write_pv='.PLTM')
+    preset_real_time = C(EpicsSignal, '.PRTM')
+    preset_live_time = C(EpicsSignal, '.PLTM')
+    elapsed_real_time = C(EpicsSignalRO, '.ERTM')
+    elapsed_live_time = C(EpicsSignalRO, '.ELTM')
+
     spectrum = C(EpicsSignalRO, '.VAL')
     background = C(EpicsSignalRO, '.BG')
     mode = C(EpicsSignal, '.MODE', string=True)
@@ -74,7 +77,8 @@ class EpicsMCARecord(Device):
                  configuration_attrs=None, monitor_attrs=None, name=None,
                  parent=None, **kwargs):
 
-        default_read_attrs = ['spectrum', 'preset_real_time']
+        default_read_attrs = ['spectrum', 'preset_real_time',
+                              'elapsed_real_time']
         default_configuration_attrs = ['preset_real_time']
 
         if read_attrs is None:

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -59,12 +59,8 @@ def add_rois(range_, **kwargs):
     return defn
 
 
-class EpicsMCA(Device):
+class EpicsMCARecord(Device):
     '''SynApps MCA Record interface'''
-
-    start = C(EpicsSignal, 'Start')
-    erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1)
-
     stop_signal = C(EpicsSignal, '.STOP')
     preset_real_time = C(EpicsSignal, '.ERTM', write_pv='.PRTM')
     preset_live_time = C(EpicsSignal, '.ELTM', write_pv='.PLTM')
@@ -97,6 +93,11 @@ class EpicsMCA(Device):
 
     def stop(self):
         self.stop_signal.put(1)
+
+
+class EpicsMCA(EpicsMCARecord):
+    start = C(EpicsSignal, 'Start')
+    erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1)
 
 
 class EpicsDXP(Device):

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -65,7 +65,7 @@ class EpicsMCA(Device):
     start = C(EpicsSignal, 'Start')
     erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1)
 
-    _stop = C(EpicsSignal, '.STOP')
+    stop_signal = C(EpicsSignal, '.STOP')
     preset_real_time = C(EpicsSignal, '.ERTM', write_pv='.PRTM')
     preset_live_time = C(EpicsSignal, '.ELTM', write_pv='.PLTM')
     spectrum = C(EpicsSignalRO, '.VAL')
@@ -96,7 +96,7 @@ class EpicsMCA(Device):
         self.stage_sigs.update([(self.mode, 'PHA')])
 
     def stop(self):
-        self._stop.put(1)
+        self.stop_signal.put(1)
 
 
 class EpicsDXP(Device):

--- a/tests/test_mca.py
+++ b/tests/test_mca.py
@@ -71,7 +71,7 @@ class MCATests(unittest.TestCase):
         mca.mode.put(MCAMode.PHA)
         mca.stage()
         mca.start.put(1)
-        mca._stop.put(1)
+        mca.stop_signal.put(1)
         mca.preset_real_time.put(3.14)
         mca.preset_live_time.put(3.14)
         mca.erase_start.put(1)


### PR DESCRIPTION
* Split mca record class into just the EPICS mca record and the other one with additional Start and EraseStart records (@dchabot thoughts about naming this better, or if those separate records belong on the subclassed `Device`s instead?)
* Can't have namedtuple keys with leading underscores - as such, no components with leading underscores ( :( )

Use case is the (mca-mode) Struck SIS3820 scaler, used on the vast majority of beamlines: (config ref [struck_scaler.py](https://github.com/klauer/hxntools/blob/84c8f2831b23475e229d206ba16b49eebc3b31d6/hxntools/struck_scaler.py))