### PR TITLE
ENH: Derived signal

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -7,7 +7,7 @@ from . import *
 
 
 # Signals
-from .signal import (Signal, EpicsSignal, EpicsSignalRO)
+from .signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)
 
 # Positioners
 from .positioner import (PositionerBase, SoftPositioner)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -198,6 +198,11 @@ class DerivedSignal(Signal):
         '''Mirrors the connection state of the original signal'''
         return self._derived_from.connected
 
+    @property
+    def limits(self):
+        '''Limits from the original signal'''
+        return self._derived_from.limits
+
     def _repr_info(self):
         yield from super()._repr_info()
         yield ('derived_from', self._derived_from)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -146,6 +146,26 @@ class Signal(OphydObject):
         return self.limits[1]
 
 
+class DerivedSignal(Signal):
+    '''A signal which is derived from another one'''
+    def __init__(self, derived_from, **kwargs):
+        self._derived_from = derived_from
+        super().__init__(**kwargs)
+
+    def describe(self):
+        '''Description based on the original signal description'''
+        desc = self._derived_from.describe()[self._derived_from.name]
+        return {self.name: desc}
+
+    def get(self, **kwargs):
+        '''Get the value from the original signal'''
+        return self._derived_from.get(**kwargs)
+
+    def put(self, value, **kwargs):
+        '''Put the value to the original signal'''
+        return self._derived_from.put(value, **kwargs)
+
+
 class EpicsSignalBase(Signal):
     '''A read-only EpicsSignal -- that is, one with no `write_pv`
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -531,6 +531,7 @@ class DerivedSignalTests(unittest.TestCase):
         self.assertEqual(original.get(), new_value)
         self.assertEqual(derived.get(), new_value)
         self.assertEqual(derived.timestamp, original.timestamp)
+        self.assertEqual(derived.limits, original.limits)
 
         copied = copy.copy(derived)
         self.assertEqual(copied.derived_from.value, original.value)


### PR DESCRIPTION
The concept of a 'derived signal' with a value and description based on another.

Submitting to see what people think - not saying this has to go in or necessarily even should. 

As an example, I've used this in an ROI's low and high eV `Component`s, which calculate user-friendly eV units from bin numbers.:

```python
class EvSignal(DerivedSignal):
    '''A signal that converts a bin number into electron volts'''
    def __init__(self, parent_attr, *, parent=None, **kwargs):
        bin_signal = getattr(parent, parent_attr)
        super().__init__(derived_from=bin_signal, parent=parent, **kwargs)

    def get(self, **kwargs):
        bin_ = super().get(**kwargs)
        return bin_to_ev(bin_)

    def put(self, ev_value, **kwargs):
        bin_value = ev_to_bin(ev_value)
        return super().put(bin_value, **kwargs)

    def describe(self):
        desc = super().describe()
        desc[self.name]['units'] = 'eV'
        return desc
```
Note that this inherits from DerivedSignal and gets a component from its parent, so in a way this example is `DerivedFromSibling`, I suppose.

Pluses
* Stands out from other signals - `isinstance()` indicates it's a soft signal based on another one
* May save a couple lines of code here or there
* `describe` could do something special to indicate from where it was derived

Minuses
* How's it any different from just passing in the `Signal` and working with it in any other class?
* More classes = more confusion
* Discussion, blah