### PR TITLE
MNT: Remove six as a dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
 
 install:
   # INSTALL OPHYD
-  - conda install numpy pyepics prettytable filestore six ipython pyolog
+  - conda install numpy pyepics prettytable filestore ipython pyolog
   - pip install coveralls pytest pytest-cov
   - python setup.py develop
 

--- a/circle.yml
+++ b/circle.yml
@@ -47,7 +47,7 @@ dependencies:
     - env
     - caget XF:31IDA-OP{Tbl-Ax:X1}Mtr
 
-    - conda install numpy pyepics prettytable filestore six ipython pyolog
+    - conda install numpy pyepics prettytable filestore ipython pyolog
     - conda install nose coverage
     - $CONDA_ROOT/bin/pip install codecov
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -38,7 +38,6 @@ requirements:
     - pyepics
     - prettytable
     - filestore
-    - six
     - ipython
     - pyolog
 


### PR DESCRIPTION
six is no longer a dep of ophyd.

Before this PR
```
$ git grep six
.travis.yml:  - conda install numpy pyepics prettytable filestore six ipython pyolog
circle.yml:    - conda install numpy pyepics prettytable filestore six ipython pyolog
conda-recipe/meta.yaml:    - six
```