### PR TITLE
FIX: pseudo positioners, again

### DIFF
--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -105,6 +105,7 @@ class PseudoSingle(Positioner):
         pass
 
     def move(self, pos, **kwargs):
+        self._target = pos
         return self._parent.move_single(self, pos, **kwargs)
 
     def read(self):
@@ -248,7 +249,7 @@ class PseudoPositioner(Device, Positioner):
         for pos in self._real:
             pos.stop()
 
-        Positioner.stop(self)
+        super().stop(self)
 
     def check_single(self, pseudo_single, single_pos):
         '''Check if a new position for a single pseudo positioner is valid'''

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -11,7 +11,6 @@
 import logging
 import time
 import threading
-import collections
 
 from collections import (OrderedDict, namedtuple)
 
@@ -269,9 +268,9 @@ class PseudoPositioner(Device, Positioner):
         for pseudo, pos in zip(self._pseudo, pseudo_pos):
             low, high = pseudo.limits
             if (high > low) and not (low <= pos <= high):
-                raise ValueError('Position is outside of pseudo single limits: '
-                                 '%s, %s < %s < %s'.format(pseudo.name, low, pos,
-                                                           high))
+                raise ValueError('Position is outside of pseudo single limits:'
+                                 ' %s, %s < %s < %s'.format(pseudo.name, low,
+                                                            pos, high))
 
         real_pos = self.forward(pseudo_pos)
         for real, pos in zip(self._real, real_pos):
@@ -386,7 +385,8 @@ class PseudoPositioner(Device, Positioner):
 
         for real, value in zip(self._real, real_pos):
             logger.debug('[concurrent] Moving %s to %s', real.name, value)
-            real.move(value, wait=False, moved_cb=self._real_finished, **kwargs)
+            real.move(value, wait=False, moved_cb=self._real_finished,
+                      **kwargs)
 
     def move(self, position, wait=True, timeout=30.0, **kwargs):
         real_pos = self.forward(position)

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -24,44 +24,67 @@ def tearDownModule():
     logger.debug('Cleaning up')
 
 
-class PseudoPosTests(unittest.TestCase):
-    motor_recs = ['XF:31IDA-OP{Tbl-Ax:X1}Mtr',
-                  'XF:31IDA-OP{Tbl-Ax:X2}Mtr',
-                  'XF:31IDA-OP{Tbl-Ax:X3}Mtr',
-                  'XF:31IDA-OP{Tbl-Ax:X4}Mtr',
-                  'XF:31IDA-OP{Tbl-Ax:X5}Mtr',
-                  'XF:31IDA-OP{Tbl-Ax:X6}Mtr',
-                  ]
+motor_recs = ['XF:31IDA-OP{Tbl-Ax:X1}Mtr',
+              'XF:31IDA-OP{Tbl-Ax:X2}Mtr',
+              'XF:31IDA-OP{Tbl-Ax:X3}Mtr',
+              'XF:31IDA-OP{Tbl-Ax:X4}Mtr',
+              'XF:31IDA-OP{Tbl-Ax:X5}Mtr',
+              'XF:31IDA-OP{Tbl-Ax:X6}Mtr',
+              ]
 
+
+class Pseudo3x3(PseudoPositioner):
+    pseudo1 = C(PseudoSingle, '', limits=(-10, 10))
+    pseudo2 = C(PseudoSingle, '', limits=(-10, 10))
+    pseudo3 = C(PseudoSingle, '', limits=(-10, 10))
+    real1 = C(EpicsMotor, motor_recs[0])
+    real2 = C(EpicsMotor, motor_recs[1])
+    real3 = C(EpicsMotor, motor_recs[2])
+
+    def forward(self, pseudo_pos):
+        pseudo_pos = self.PseudoPosition(*pseudo_pos)
+        logger.debug('forward %s', pseudo_pos)
+        return self.RealPosition(real1=-pseudo_pos.pseudo1,
+                                 real2=-pseudo_pos.pseudo2,
+                                 real3=-pseudo_pos.pseudo3)
+
+    def inverse(self, real_pos):
+        real_pos = self.RealPosition(*real_pos)
+        logger.debug('inverse %s', real_pos)
+        return self.PseudoPosition(pseudo1=real_pos.real1,
+                                   pseudo2=real_pos.real2,
+                                   pseudo3=real_pos.real3)
+
+
+class Pseudo1x3(PseudoPositioner):
+    pseudo1 = C(PseudoSingle, '', limits=(-10, 10))
+    real1 = C(EpicsMotor, motor_recs[0])
+    real2 = C(EpicsMotor, motor_recs[1])
+    real3 = C(EpicsMotor, motor_recs[2])
+
+    def forward(self, pseudo_pos):
+        pseudo_pos = self.PseudoPosition(*pseudo_pos)
+        logger.debug('forward %s', pseudo_pos)
+        return self.RealPosition(real1=-pseudo_pos.pseudo1,
+                                 real2=-pseudo_pos.pseudo1,
+                                 real3=-pseudo_pos.pseudo1)
+
+    def inverse(self, real_pos):
+        real_pos = self.RealPosition(*real_pos)
+        logger.debug('inverse %s', real_pos)
+        return self.PseudoPosition(pseudo1=-real_pos.real1)
+
+
+class PseudoPosTests(unittest.TestCase):
     def test_onlypseudo(self):
         # can't instantiate it on its own
         self.assertRaises(TypeError, PseudoPositioner, 'prefix')
 
-    def test_multi_pseudo(self):
-        class MyPseudo(PseudoPositioner):
-            pseudo1 = C(PseudoSingle, '', limits=(-10, 10))
-            pseudo2 = C(PseudoSingle, '', limits=(-10, 10))
-            pseudo3 = C(PseudoSingle, '', limits=(-10, 10))
-            real1 = C(EpicsMotor, self.motor_recs[0])
-            real2 = C(EpicsMotor, self.motor_recs[1])
-            real3 = C(EpicsMotor, self.motor_recs[2])
-
-            def forward(self, pseudo_pos):
-                logger.debug('forward %s', pseudo_pos)
-                return self.RealPosition(real1=-pseudo_pos.pseudo1,
-                                         real2=-pseudo_pos.pseudo2,
-                                         real3=-pseudo_pos.pseudo3)
-
-            def inverse(self, real_pos):
-                logger.debug('inverse %s', real_pos)
-                return self.PseudoPosition(pseudo1=real_pos.real1,
-                                           pseudo2=real_pos.real2,
-                                           pseudo3=real_pos.real3)
-
+    def test_multi_sequential(self):
         def done(**kwargs):
-            logger.debug('** Finished moving (%s)' % (kwargs, ))
+            logger.debug('** Finished moving (%s)', kwargs)
 
-        pseudo = MyPseudo('', name='mypseudo', concurrent=False)
+        pseudo = Pseudo3x3('', name='mypseudo', concurrent=False)
         pseudo.wait_for_connection()
 
         print('real1', pseudo.real1.prefix)
@@ -86,133 +109,104 @@ class PseudoPosTests(unittest.TestCase):
         pseudo.real1.move(0, wait=True)
         pseudo.real2.move(0, wait=True)
         pseudo.real3.move(0, wait=True)
-        # raise
 
-#         logger.info('------- Sequential pseudo positioner')
-#         pos = PseudoPositioner('',
-#                                real=[real0, real1, real2],
-#                                forward=calc_fwd, reverse=calc_rev,
-#                                pseudo=['pseudo0', 'pseudo1', 'pseudo2'],
-#                                concurrent=False
-#                                )
-#
-#         logger.info('Move to (.2, .2, .2), which is (-.2, -.2, -.2) for real motors')
-#         pos.move((.2, .2, .2), wait=True)
-#         logger.info('Position is: %s (moving=%s)' % (pos.position, pos.moving))
-#
-#         if 0:
-#             logger.info('Move to (-.2, -.2, -.2), which is (.2, .2, .2) for real motors')
-#             pos.move((-.2, -.2, -.2), wait=True, moved_cb=done)
-#
-#             logger.info('Position is: %s (moving=%s)' % (pos.position, pos.moving))
-#
-#             # No such thing as a non-blocking move for a sequential
-#             # pseudo positioner
-#
-#             # Create another one and give that a try
-#
-#         pos = PseudoPositioner('conc',
-#                                [real0, real1, real2],
-#                                forward=calc_fwd, reverse=calc_rev,
-#                                pseudo=['pseudo0', 'pseudo1', 'pseudo2'],
-#                                concurrent=True
-#                                )
-#
-#         logger.info('------- concurrent pseudo positioner')
-#         logger.info('Move to (2, 2, 2), which is (-2, -2, -2) for real motors')
-#
-#         pos.check_value((2, 2, 2))
-#         try:
-#             pos.check_value((2, 2, 2, 3))
-#         except ValueError as ex:
-#             logger.info('Check value failed, as expected (%s)' % ex)
-#
-#         try:
-#             pos.check_value((real0.high_limit + 1, 2, 2))
-#         except ValueError as ex:
-#             logger.info('Check value failed, as expected (%s)' % ex)
-#
-#         ret = pos.move((2, 2, 2), wait=False, moved_cb=done)
-#         while not ret.done:
-#             logger.info('Pos=%s %s (err=%s)' % (pos.position, ret, ret.error))
-#             time.sleep(0.1)
-#
-#         pseudo0 = pos['pseudo0']
-#         logger.info('Single pseudo axis: %s' % pseudo0)
-#
-#         pseudo0.move(0, wait=True)
-#
-#         try:
-#             pseudo0.check_value(real0.high_limit + 1)
-#         except ValueError as ex:
-#             logger.info('Check value for single failed, as expected (%s)' % ex)
-#
-#         logger.info('Move pseudo0 to 0, position=%s' % (pos.position, ))
-#         logger.info('pseudo0 = %s' % pseudo0.position)
-#
-#         def single_sub(**kwargs):
-#             # logger.info('Single sub: %s' % (kwargs, ))
-#             pass
-#
-#         pseudo0.subscribe(single_sub, pseudo0.SUB_READBACK)
-#
-#         ret = pseudo0.move(1, wait=False)
-#         while not ret.done:
-#             logger.info('Pseudo0.pos=%s Pos=%s %s (err=%s)' % (pseudo0.position,
-#                                                                pos.position, ret, ret.error))
-#             time.sleep(0.1)
-#
-#         logger.info('Pseudo0.pos=%s Pos=%s %s (err=%s)' % (pseudo0.position,
-#                                                            pos.position, ret, ret.error))
-#
-#         # pos['pseudo0'] = 2
-#         assert('pseudo0' in pos)
-#         assert('real0' in pos)
-#
-#         copy(pos)
-#         pos.report
-#         pos.read()
-#         repr(pos)
-#         str(pos)
-#
-#     def test_single_pseudo(self):
-#         def calc_fwd(pseudo=0.0):
-#             return [-pseudo, -pseudo, -pseudo]
-#
-#         def calc_rev(real0=0.0, real1=0.0, real2=0.0):
-#             return -real0
-#
-#         def done(**kwargs):
-#             logger.debug('** Finished moving (%s)' % (kwargs, ))
-#
-#         real0 = EpicsMotor(self.motor_recs[0], name='real0')
-#         real1 = EpicsMotor(self.motor_recs[1], name='real1')
-#         real2 = EpicsMotor(self.motor_recs[2], name='real2')
-#
-#         reals = [real0, real1, real2]
-#
-#         logger.info('------- Sequential, single pseudo positioner')
-#         pos = PseudoPositioner('seq',
-#                                reals,
-#                                forward=calc_fwd, reverse=calc_rev,
-#                                concurrent=False
-#                                )
-#
-#         logger.info('Move to .2, which is (-.2, -.2, -.2) for real motors')
-#         pos.move(.2, wait=True)
-#         logger.info('Position is: %s (moving=%s)' % (pos.position, pos.moving))
-#         logger.info('Real positions: %s' % ([real.position for real in reals], ))
-#
-#         logger.info('Move to -.2, which is (.2, .2, .2) for real motors')
-#         pos.move(-.2, wait=True)
-#         logger.info('Position is: %s (moving=%s)' % (pos.position, pos.moving))
-#         logger.info('Real positions: %s' % ([real.position for real in reals], ))
-#
-#         copy(pos)
-#         pos.report
-#         pos.read()
-#         repr(pos)
-#         str(pos)
+    def test_multi_concurrent(self):
+        def done(**kwargs):
+            logger.debug('** Finished moving (%s)', kwargs)
+
+        pseudo = Pseudo3x3('', name='mypseudo', concurrent=True)
+        pseudo.wait_for_connection()
+        logger.info('Move to (.2, .2, .2), which is (-.2, -.2, -.2) for real '
+                    'motors')
+        pseudo.move(pseudo.PseudoPosition(.2, .2, .2), wait=True)
+        logger.info('Position is: %s (moving=%s)', pseudo.position,
+                    pseudo.moving)
+
+        pseudo.check_value((2, 2, 2))
+        pseudo.check_value(pseudo.PseudoPosition(2, 2, 2))
+        try:
+            pseudo.check_value((2, 2, 2, 3))
+        except ValueError as ex:
+            logger.info('Check value failed, as expected (%s)', ex)
+
+        real1 = pseudo.real1
+        pseudo1 = pseudo.pseudo1
+
+        try:
+            pseudo.check_value((real1.high_limit + 1, 2, 2))
+        except ValueError as ex:
+            logger.info('Check value failed, as expected (%s)', ex)
+
+        ret = pseudo.move((2, 2, 2), wait=False, moved_cb=done)
+        while not ret.done:
+            logger.info('Pos=%s %s (err=%s)', pseudo.position, ret, ret.error)
+            time.sleep(0.1)
+
+        logger.info('Single pseudo axis: %s', pseudo1)
+
+        pseudo1.move(0, wait=True)
+
+        try:
+            pseudo1.check_value(real1.high_limit + 1)
+        except ValueError as ex:
+            logger.info('Check value for single failed, as expected (%s)', ex)
+
+        logger.info('Move pseudo1 to 0, position=%s', pseudo.position)
+        logger.info('pseudo1 = %s', pseudo1.position)
+
+        def single_sub(**kwargs):
+            # logger.info('Single sub: %s', kwargs)
+            pass
+
+        pseudo1.subscribe(single_sub, pseudo1.SUB_READBACK)
+
+        ret = pseudo1.move(1, wait=False)
+        while not ret.done:
+            logger.info('pseudo1.pos=%s Pos=%s %s (err=%s)', pseudo1.position,
+                        pseudo.position, ret, ret.error)
+            time.sleep(0.1)
+
+        logger.info('pseudo1.pos=%s Pos=%s %s (err=%s)', pseudo1.position,
+                    pseudo.position, ret, ret.error)
+
+        copy(pseudo)
+        pseudo.read()
+        pseudo.describe()
+        pseudo.read_configuration()
+        pseudo.describe_configuration()
+        repr(pseudo)
+        str(pseudo)
+
+        pseudo.pseudo1.read()
+        pseudo.pseudo1.describe()
+        pseudo.pseudo1.read_configuration()
+        pseudo.pseudo1.describe_configuration()
+
+    def test_single_pseudo(self):
+        def done(**kwargs):
+            logger.debug('** Finished moving (%s)', kwargs)
+
+        logger.info('------- Sequential, single pseudo positioner')
+        pos = Pseudo1x3('', name='mypseudo', concurrent=False)
+
+        reals = pos._real
+
+        logger.info('Move to .2, which is (-.2, -.2, -.2) for real motors')
+        pos.move((.2, ), wait=True)
+        logger.info('Position is: %s (moving=%s)', pos.position, pos.moving)
+        logger.info('Real positions: %s', [real.position for real in reals])
+
+        logger.info('Move to -.2, which is (.2, .2, .2) for real motors')
+        pos.move((-.2, ), wait=True)
+        logger.info('Position is: %s (moving=%s)', pos.position, pos.moving)
+        logger.info('Real positions: %s', [real.position for real in reals])
+
+        copy(pos)
+        pos.read()
+        pos.describe()
+        repr(pos)
+        str(pos)
+
 
 from . import main
 is_main = (__name__ == '__main__')


### PR DESCRIPTION
* Complete round of tests post-ophyd0 refactor (at least coverage is up to 90% or so)
* Add describe(), read() on pseudosingle (from @tacaswell 's srx config)
* Fix for some namedtuple-related bugs (I consistently get  `namedtuple(a, b, c)` works the same as `tuple((a, b, c))`)
* Fix target position for PseudoSingle
* Fix check_value for PseudoPositioner
* Refactor move, breaking into sequential and concurrent cases