### PR TITLE
API: Change default name of user_readback.

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -62,6 +62,10 @@ class EpicsMotor(Device, Positioner):
                          monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)
 
+        # Make the default alias for the user_readback the name of the
+        # motor itself.
+        self.user_readback.name = self.name
+
         self.settle_time = float(settle_time)
         # TODO: settle_time is unused?
 


### PR DESCRIPTION
Reasons:

* Backward compatibility with routines developed when motors only returned one value
* The vast majority of the time, people want the user_readback, and if they need to check the user_setpoint of course they can still access it.

We talked about doing this in #170 but it seemed like a small detail at the time. Don't worry: this is is not the first wave in a deluge of naming-related PRs into ophyd Device attribute names. EpicsMotor is the only place where I would advocate for overriding the verbose (if nicely explicit) default. Just as users like the special `position` and `value` attributes, they want their `eta` data to show up as "eta," not "eta_user_readback." We might as well make this a facility-wide standard; we are already writing this into most of the beamline configs by hand