### PR TITLE
ENH/API: stage and unstage report objects they touched

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -348,7 +348,14 @@ class BlueskyInterface:
         return OrderedDict()
 
     def stage(self):
-        "Prepare the device to be triggered."
+        """
+        Prepare the device to be triggered.
+
+        Returns
+        -------
+        devices : list
+            list including self and all child devices staged
+        """
         if self._staged == Staged.no:
             pass  # to short-circuit checking individual cases
         elif self._staged == Staged.yes:
@@ -400,6 +407,11 @@ class BlueskyInterface:
         Restore the device to 'standby'.
 
         Multiple calls (without a new call to 'stage') have no effect.
+
+        Returns
+        -------
+        devices : list
+            list including self and all child devices unstaged
         """
         logger.debug("Unstaging %s", self.name)
         self._staged = Staged.partially


### PR DESCRIPTION
I think this will give us the information we need to address https://github.com/NSLS-II/bluesky/issues/343. Without a reproducible bug report it's hard to be sure, but either way this is useful. Now a plan can know what children have been staged to avoid staging a parent and then redundantly trying to stage its child.