### PR TITLE
FIX: If a sub-device is staged, the entire device is staged.

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -18,7 +18,7 @@ from .pseudopos import (PseudoPositioner, PseudoSingle)
 # Devices
 from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
-                     DynamicDeviceComponent)
+                     DynamicDeviceComponent, RedundantStaging)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -372,7 +372,6 @@ class BlueskyInterface:
         if self.parent is not None and self._defer_stage_to_parent:
             # Stage parent, which will then stage self.
             return self.parent.stage()
-        self._defer_stage_to_parent = True  # reset for next time
         logger.debug("Staging %s", self.name)
         self._staged = Staged.partially
 
@@ -401,9 +400,8 @@ class BlueskyInterface:
                     try:
                         device._defer_stage_to_parent = False
                         device.stage()
-                    except Exception:
+                    finally:
                         device._defer_stage_to_parent = True
-                        raise
                     devices_staged.append(device)
         except Exception:
             logger.debug("An exception was raised while staging %s or "
@@ -430,7 +428,6 @@ class BlueskyInterface:
         if self.parent is not None and self._defer_unstage_to_parent:
             # Stage parent, which will then stage self.
             return self.parent.unstage()
-        self._defer_unstage_to_parent = True  # reset for next time
         logger.debug("Unstaging %s", self.name)
         self._staged = Staged.partially
         devices_unstaged = []
@@ -442,9 +439,8 @@ class BlueskyInterface:
                 try:
                     device._defer_unstage_to_parent = False
                     device.unstage()
-                except Exception:
+                finally:
                     device._defer_unstage_to_parent = True
-                    raise
                 devices_unstaged.append(device)
 
         # Restore original values.

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -362,11 +362,13 @@ class BlueskyInterface:
         if self._staged == Staged.no:
             pass  # to short-circuit checking individual cases
         elif self._staged == Staged.yes:
-            raise RedundantStaging("Device is already staged. Unstage it first.")
+            raise RedundantStaging("Device {!r} is already staged. "
+                                   "Unstage it first.".format(self))
         elif self._staged == Staged.partially:
-            raise RedundantStaging("Device has been partially staged. Maybe the "
-                               "most recent unstaging encountered an error "
-                               "before finishing. Try unstaging again.")
+            raise RedundantStaging("Device {!r} has been partially staged. "
+                                   "Maybe the most recent unstaging "
+                                   "encountered an error before finishing. "
+                                   "Try unstaging again.".format(self))
         if self.parent is not None and self._defer_stage_to_parent:
             # Stage parent, which will then stage self.
             return self.parent.stage()

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,0 +1,40 @@
+import pytest
+from ophyd import Device, Component as Cpt, RedundantStaging
+
+
+class A(Device):
+    pass
+
+
+class B(Device):
+    a = Cpt(A, '')
+
+
+def test_whole_device_always_staged():
+    b = B('')
+    staged_by_b = b.stage()
+    unstaged_by_b = b.unstage()
+    staged_by_ba = b.a.stage()
+    unstaged_by_ba = b.a.unstage()
+    assert set(staged_by_b) == set(staged_by_ba) == set([b, b.a])
+    assert set(unstaged_by_b) == set(unstaged_by_ba) == set([b, b.a])
+
+    staged_by_b = b.stage()
+    unstaged_by_ba = b.a.unstage()
+    assert set(staged_by_b) == set(unstaged_by_ba) == set([b, b.a])
+
+
+def test_illegal_operations():
+    b = B('')
+    b.stage()
+    with pytest.raises(RedundantStaging):
+        b.stage()
+    b.unstage()
+    b.a.stage()
+    with pytest.raises(RedundantStaging):
+        b.a.stage()
+    with pytest.raises(RedundantStaging):
+        b.stage()
+    b.unstage()
+    b.stage()
+    b.unstage()

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,5 +1,6 @@
 import pytest
 from ophyd import Device, Component as Cpt, RedundantStaging
+from ophyd.device import Staged
 
 
 class A(Device):
@@ -38,3 +39,150 @@ def test_illegal_operations():
     b.unstage()
     b.stage()
     b.unstage()
+
+
+class SpecialException(Exception):
+    pass
+
+
+class BrokenStage1(Device):
+    def stage(self):
+        super().stage()
+        raise SpecialException
+
+
+class BrokenStage2(Device):
+
+    def stage(self):
+        raise SpecialException
+
+
+class BrokenUnstage1(Device):
+    def __init__(self, *args, **kwargs):
+        self.broken = True
+        super().__init__(*args, **kwargs)
+
+    def unstage(self):
+        super().unstage()
+        if self.broken:
+            raise SpecialException
+
+
+class BrokenUnstage2(Device):
+    def __init__(self, *args, **kwargs):
+        self.broken = True
+        super().__init__(*args, **kwargs)
+
+    def unstage(self):
+        if self.broken:
+            raise SpecialException
+        super().unstage()
+
+
+class ParentOfBrokenStage1(Device):
+    b = Cpt(BrokenStage1, '')
+
+
+class ParentOfBrokenStage2(Device):
+    b = Cpt(BrokenStage2, '')
+
+
+class ParentOfBrokenUnstage1(Device):
+    b = Cpt(BrokenUnstage1, '')
+
+
+class ParentOfBrokenUnstage2(Device):
+    b = Cpt(BrokenUnstage2, '')
+
+
+class ParentOfBrokenStage1DoubleBroken(ParentOfBrokenStage1):
+    def stage(self):
+        raise SpecialException
+
+
+class ParentOfBrokenStage2DoubleBroken(ParentOfBrokenStage2):
+    def stage(self):
+        raise SpecialException
+
+
+class ParentOfBrokenUnstage1DoubleBroken(ParentOfBrokenUnstage1):
+    def stage(self):
+        raise SpecialException
+
+
+class ParentOfBrokenUnstage2DoubleBroken(ParentOfBrokenUnstage2):
+    def stage(self):
+        raise SpecialException
+
+
+
+def test_interrupted_stage():
+    d1 = ParentOfBrokenStage1('')
+    d2 = ParentOfBrokenStage2('')
+    d1db = ParentOfBrokenStage1DoubleBroken('')
+    d2db = ParentOfBrokenStage2DoubleBroken('')
+    try:
+        d1.stage()
+    except SpecialException:
+        pass
+    assert d1._staged == Staged.no
+    assert d1.b._staged == Staged.no
+    try:
+        d2.stage()
+    except SpecialException:
+        pass
+    assert d2._staged == Staged.no
+    assert d1.b._staged == Staged.no
+    try:
+        d1db.stage()
+    except SpecialException:
+        pass
+    assert d1db._staged == Staged.no
+    assert d1db.b._staged == Staged.no
+    try:
+        d2db.stage()
+    except SpecialException:
+        pass
+    assert d2db._staged == Staged.no
+    assert d2db.b._staged == Staged.no
+
+
+def test_interrupted_unstage():
+    d1 = ParentOfBrokenUnstage1('')
+    d2 = ParentOfBrokenUnstage2('')
+    d3 = ParentOfBrokenUnstage1DoubleBroken('')
+    d4 = ParentOfBrokenUnstage2DoubleBroken('')
+    d1.stage()
+    try:
+        d1.unstage()
+    except SpecialException:
+        pass
+    d1.b.broken = False
+    d1.unstage()
+    assert d1._staged == Staged.no
+    assert d1.b._staged == Staged.no
+    d2.stage()
+    try:
+        d2.unstage()
+    except SpecialException:
+        pass
+    d2.b.broken = False
+    d2.unstage()
+    assert d2._staged == Staged.no
+    assert d2.b._staged == Staged.no
+    try:
+        d3.unstage()
+    except SpecialException:
+        pass
+    d3.b.broken = False
+    d3.unstage()
+    assert d3._staged == Staged.no
+    assert d3.b._staged == Staged.no
+    try:
+        d4.unstage()
+    except SpecialException:
+        pass
+    d4.b.broken = False
+    d4.unstage()
+    assert d4._staged == Staged.no
+    assert d4.b._staged == Staged.no


### PR DESCRIPTION
Consider a device `d` with a subdevice `d.s`.

Before #272, `RE(Count([d, d.s]))` errored because the RunEngine tried to redundantly stage `d.s`. Now that `d.stage()` returns `[d, d.s]`, the RunEngine knows to skip staging `d.s`. But `RE(Count([d.s, d]))` (note the reverse order) still errors. The RunEngine has no way of telling `d` not to stage its child `d.s`. (And that is probably a good thing -- it's not the RunEngine's business.)

Possible solutions:
1. Stop being strict that a device can't be staged redundantly. Downside: the risk of failing to clean up and, say, writing into an old file by mistake.
2. Accept arguments to `stage()` that would affect which child devices get staged.
3. Insist that staging a child causes its parent to staged. Thus, `d.s.stage()` would stage `d` as well and return `[d, d.s]`. Thus the RunEngine knows to skip staging `d`.

This PR is Solution 3. That is to say, you can't stage *part* of a device. That makes sense to me: the device was grouped for a reason. And one could imagine people getting into trouble trying to stage part of an area detector (the file-writer but not the trigger, for example).

Implementation note: The ~~`stage_rachet`~~ [renamed] `_defer_to_parent` flag is way of avoiding this infinite loop: child defers to parent, which tries to stage child, which defers to parent, which tries to stage child.... Credit to @tacaswell for thinking of this pattern.

cc @ambarb @cmazzoli Once this gets merged, you can put detectors into `gs.DETS` in any order.