### PR TITLE
ENH: Settle time for all positioners, and more

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -39,6 +39,8 @@ class EpicsMotor(Device, PositionerBase):
         The name of the device
     parent : instance or None
         The instance of the parent device, if applicable
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
     '''
     user_readback = Cpt(EpicsSignalRO, '.RBV')
     user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
@@ -164,6 +166,3 @@ class EpicsMotor(Device, PositionerBase):
 
         return {self.name: position,
                 'pv': self.user_readback.pvname}
-
-    def _repr_info(self):
-        yield from super()._repr_info()

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -104,7 +104,8 @@ class PositionerBase(OphydObject):
         self._run_subs(sub_type=self._SUB_REQ_DONE, success=False)
         self._reset_sub(self._SUB_REQ_DONE)
 
-        status = MoveStatus(self, position, timeout=timeout)
+        status = MoveStatus(self, position, timeout=timeout,
+                            settle_time=self._settle_time)
 
         if moved_cb is not None:
             status.finished_cb = partial(moved_cb, obj=self)

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -36,12 +36,23 @@ class PositionerBase(OphydObject):
     _SUB_REQ_DONE = '_req_done'  # requested move finished subscription
     _default_sub = SUB_READBACK
 
-    def __init__(self, *, name=None, parent=None, **kwargs):
+    def __init__(self, *, name=None, parent=None, settle_time=0.0, **kwargs):
         super().__init__(name=name, parent=parent, **kwargs)
 
         self._started_moving = False
         self._moving = False
         self._position = None
+        self._settle_time = settle_time
+
+    @property
+    def settle_time(self):
+        '''The amount of time to wait after moves to report status completion'''
+        return self._settle_time
+
+    @settle_time.setter
+    def settle_time(self, settle_time):
+        '''The amount of time to wait after moves to report status completion'''
+        self._settle_time = float(settle_time)
 
     @property
     def egu(self):
@@ -160,6 +171,10 @@ class PositionerBase(OphydObject):
         """
         return self.move(new_position, wait=wait, moved_cb=moved_cb,
                          timeout=timeout)
+
+    def _repr_info(self):
+        yield from super()._repr_info()
+        yield ('settle_time', self._settle_time)
 
 
 class SoftPositioner(PositionerBase):

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -1,13 +1,3 @@
-# vi: ts=4 sw=4
-'''
-:mod:`ophyd.control.positioner` - Ophyd positioners
-===================================================
-
-.. module:: ophyd.control.positioner
-   :synopsis:
-'''
-
-
 import logging
 import time
 from functools import partial
@@ -46,12 +36,11 @@ class PositionerBase(OphydObject):
 
     @property
     def settle_time(self):
-        '''The amount of time to wait after moves to report status completion'''
+        '''Amount of time to wait after moves to report status completion'''
         return self._settle_time
 
     @settle_time.setter
     def settle_time(self, settle_time):
-        '''The amount of time to wait after moves to report status completion'''
         self._settle_time = float(settle_time)
 
     @property

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -44,6 +44,8 @@ class PseudoSingle(SoftPositioner):
     source : str, optional
         Metadata indicating the source of this positioner's position. Defaults
         to 'computed'
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
     '''
 
     def __init__(self, prefix=None, *, limits=None, egu='', parent=None,

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -34,6 +34,8 @@ class PVPositioner(Device, PositionerBase):
         The device name
     egu : str, optional
         The engineering units (EGU) for the position
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
 
     Attributes
     ----------

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -90,7 +90,8 @@ class PositionerTests(unittest.TestCase):
         self.assertEqual(pc.limits, p.limits)
 
     def test_epicsmotor(self):
-        m = EpicsMotor(self.sim_pv, name='epicsmotor')
+        m = EpicsMotor(self.sim_pv, name='epicsmotor',
+                       settle_time=0.1)
         print('epicsmotor', m)
         m.wait_for_connection()
 
@@ -125,6 +126,7 @@ class PositionerTests(unittest.TestCase):
         self.assertEqual(mc.prefix, m.prefix)
 
         res = m.move(0.2, wait=False)
+        assert res.settle_time == 0.1
 
         while not res.done:
             time.sleep(0.1)
@@ -138,6 +140,9 @@ class PositionerTests(unittest.TestCase):
 
         m.read()
         m.report
+
+        m.settle_time = 0.2
+        assert m.settle_time == 0.2
 
 
 from . import main

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -6,10 +6,7 @@ import unittest
 from copy import copy
 from unittest.mock import Mock
 
-import epics
-from ophyd import (SoftPositioner, PVPositioner, EpicsMotor)
-from ophyd import (EpicsSignal, EpicsSignalRO)
-from ophyd import (Component as C)
+from ophyd import (SoftPositioner, EpicsMotor)
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +21,13 @@ def tearDownModule():
 
 class PositionerTests(unittest.TestCase):
     sim_pv = 'XF:31IDA-OP{Tbl-Ax:X1}Mtr'
+
+    def test_positioner_settle(self):
+        p = SoftPositioner(name='test', egu='egu', limits=(-10, 10),
+                           settle_time=0.1)
+        self.assertEqual(p.settle_time, 0.1)
+        st = p.move(0.0, wait=False)
+        self.assertEqual(st.settle_time, 0.1)
 
     def test_positioner(self):
         p = SoftPositioner(name='test', egu='egu', limits=(-10, 10))
@@ -90,8 +94,7 @@ class PositionerTests(unittest.TestCase):
         self.assertEqual(pc.limits, p.limits)
 
     def test_epicsmotor(self):
-        m = EpicsMotor(self.sim_pv, name='epicsmotor',
-                       settle_time=0.1)
+        m = EpicsMotor(self.sim_pv, name='epicsmotor', settle_time=0.1)
         print('epicsmotor', m)
         m.wait_for_connection()
 
@@ -126,7 +129,7 @@ class PositionerTests(unittest.TestCase):
         self.assertEqual(mc.prefix, m.prefix)
 
         res = m.move(0.2, wait=False)
-        assert res.settle_time == 0.1
+        self.assertEqual(res.settle_time, 0.1)
 
         while not res.done:
             time.sleep(0.1)
@@ -142,7 +145,7 @@ class PositionerTests(unittest.TestCase):
         m.report
 
         m.settle_time = 0.2
-        assert m.settle_time == 0.2
+        self.assertEqual(m.settle_time, 0.2)
 
 
 from . import main

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -176,9 +176,11 @@ class PseudoPosTests(unittest.TestCase):
         def done(**kwargs):
             logger.debug('** Finished moving (%s)', kwargs)
 
-        pseudo = Pseudo3x3('', name='mypseudo', concurrent=True)
+        pseudo = Pseudo3x3('', name='mypseudo', concurrent=True,
+                           settle_time=0.1)
         self.assertIs(pseudo.sequential, False)
         self.assertIs(pseudo.concurrent, True)
+        self.assertEqual(pseudo.settle_time, 0.1)
         pseudo.wait_for_connection()
 
         self.assertTrue(pseudo.connected)
@@ -209,6 +211,7 @@ class PseudoPosTests(unittest.TestCase):
             logger.info('Check value failed, as expected (%s)', ex)
 
         ret = pseudo.move((2, 2, 2), wait=False, moved_cb=done)
+        self.assertEqual(ret.settle_time, 0.1)
         while not ret.done:
             logger.info('Pos=%s %s (err=%s)', pseudo.position, ret, ret.error)
             time.sleep(0.1)

--- a/tests/test_pvpositioner.py
+++ b/tests/test_pvpositioner.py
@@ -131,10 +131,12 @@ class PVPosTest(unittest.TestCase):
             done_value = 0
 
         motor_record = self.sim_pv
-        pos = MyPositioner(motor_record, name='pos_no_put_compl')
+        pos = MyPositioner(motor_record, name='pos_no_put_compl',
+                           settle_time=0.1)
         print(pos.describe())
         pos.wait_for_connection()
 
+        self.assertEqual(pos.settle_time, 0.1)
         pos.read()
         high_lim = pos.setpoint.high_limit
         try:


### PR DESCRIPTION
Proposed fix for #279

`settle_time` is added at the lowest level possible, making it possible to use throughout the hierarchy.
I think this is the cleanest it can possibly be done. Commence the bikeshedding.

If we can agree this isn't a terrible idea, I'll add it to `Device` as a kwarg as well.