### PR TITLE
Default timeout

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -1,13 +1,3 @@
-# vi: ts=4 sw=4
-'''
-:mod:`ophyd.control.epicsmotor` - Ophyd epics motors
-====================================================
-
-.. module:: ophyd.control.epicsmotor
-   :synopsis:
-'''
-
-
 import logging
 
 from epics.pv import fmt_time
@@ -47,6 +37,8 @@ class EpicsMotor(Device, PositionerBase):
         The instance of the parent device, if applicable
     settle_time : float, optional
         The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
     '''
     user_offset = Cpt(EpicsSignal, '.OFF')
     user_readback = Cpt(EpicsSignalRO, '.RBV')

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -113,6 +113,34 @@ class EpicsMotor(Device, PositionerBase):
 
     @raise_if_disconnected
     def move(self, position, wait=True, **kwargs):
+        '''Move to a specified position, optionally waiting for motion to
+        complete.
+
+        Parameters
+        ----------
+        position
+            Position to move to
+        moved_cb : callable
+            Call this callback when movement has finished. This callback must
+            accept one keyword argument: 'obj' which will be set to this
+            positioner instance.
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+
+        Returns
+        -------
+        status : MoveStatus
+
+        Raises
+        ------
+        TimeoutError
+            When motion takes longer than `timeout`
+        ValueError
+            On invalid positions
+        RuntimeError
+            If motion fails other than timing out
+        '''
         self._started_moving = False
 
         status = super().move(position, **kwargs)

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -27,7 +27,7 @@ class PositionerBase(OphydObject):
     _default_sub = SUB_READBACK
 
     def __init__(self, *, name=None, parent=None, settle_time=0.0,
-                 timeout=30.0, **kwargs):
+                 timeout=None, **kwargs):
         super().__init__(name=name, parent=parent, **kwargs)
 
         self._started_moving = False
@@ -58,7 +58,10 @@ class PositionerBase(OphydObject):
 
     @timeout.setter
     def timeout(self, timeout):
-        self._timeout = float(timeout)
+        if timeout is None:
+            self._timeout = None
+        else:
+            self._timeout = float(timeout)
 
     @property
     def egu(self):

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -46,6 +46,8 @@ class PseudoSingle(SoftPositioner):
         to 'computed'
     settle_time : float, optional
         The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
     '''
 
     def __init__(self, prefix=None, *, limits=None, egu='', parent=None,
@@ -308,6 +310,10 @@ class PseudoPositioner(Device, SoftPositioner):
         The name of the device
     parent : instance or None
         The instance of the parent device, if applicable
+    settle_time : float, optional
+        The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
     '''
     def __init__(self, prefix, *, concurrent=True, read_attrs=None,
                  configuration_attrs=None, monitor_attrs=None, name=None,
@@ -702,7 +708,7 @@ class PseudoPositioner(Device, SoftPositioner):
                       **kwargs)
 
     @pseudo_position_argument
-    def move(self, position, wait=True, timeout=30.0, moved_cb=None):
+    def move(self, position, wait=True, timeout=None, moved_cb=None):
         return super().move(position, wait=wait, timeout=timeout,
                             moved_cb=moved_cb)
 

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -709,6 +709,34 @@ class PseudoPositioner(Device, SoftPositioner):
 
     @pseudo_position_argument
     def move(self, position, wait=True, timeout=None, moved_cb=None):
+        '''Move to a specified position, optionally waiting for motion to
+        complete.
+
+        Parameters
+        ----------
+        position
+            Pseudo position to move to
+        moved_cb : callable
+            Call this callback when movement has finished. This callback must
+            accept one keyword argument: 'obj' which will be set to this
+            positioner instance.
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+
+        Returns
+        -------
+        status : MoveStatus
+
+        Raises
+        ------
+        TimeoutError
+            When motion takes longer than `timeout`
+        ValueError
+            On invalid positions
+        RuntimeError
+            If motion fails other than timing out
+        '''
         return super().move(position, wait=wait, timeout=timeout,
                             moved_cb=moved_cb)
 

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -160,6 +160,34 @@ class PVPositioner(Device, PositionerBase):
             self.actuate.put(self.actuate_value, wait=False)
 
     def move(self, position, wait=True, timeout=None, moved_cb=None):
+        '''Move to a specified position, optionally waiting for motion to
+        complete.
+
+        Parameters
+        ----------
+        position
+            Position to move to
+        moved_cb : callable
+            Call this callback when movement has finished. This callback must
+            accept one keyword argument: 'obj' which will be set to this
+            positioner instance.
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+
+        Returns
+        -------
+        status : MoveStatus
+
+        Raises
+        ------
+        TimeoutError
+            When motion takes longer than `timeout`
+        ValueError
+            On invalid positions
+        RuntimeError
+            If motion fails other than timing out
+        '''
         status = super().move(position, timeout=timeout, moved_cb=moved_cb)
 
         has_done = self.done is not None

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -36,6 +36,8 @@ class PVPositioner(Device, PositionerBase):
         The engineering units (EGU) for the position
     settle_time : float, optional
         The amount of time to wait after moves to report status completion
+    timeout : float, optional
+        The default timeout to use for motion requests, in seconds.
 
     Attributes
     ----------
@@ -157,7 +159,7 @@ class PVPositioner(Device, PositionerBase):
             logger.debug('%s.actuate = %s', self.name, self.actuate_value)
             self.actuate.put(self.actuate_value, wait=False)
 
-    def move(self, position, wait=True, timeout=30.0, moved_cb=None):
+    def move(self, position, wait=True, timeout=None, moved_cb=None):
         status = super().move(position, timeout=timeout, moved_cb=moved_cb)
 
         has_done = self.done is not None

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -152,7 +152,7 @@ class MoveStatus(StatusBase):
     '''
 
     def __init__(self, positioner, target, *, done=False, start_ts=None,
-                 timeout=30.0, settle_time=None):
+                 timeout=None, settle_time=None):
         # call the base class
         super().__init__(timeout=timeout, settle_time=settle_time)
 

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -47,7 +47,7 @@ class StatusBase:
         if timeout is not None:
             self.timeout = float(timeout)
 
-        if self.timeout is not None:
+        if self.timeout is not None and self.timeout > 0.0:
             thread = threading.Thread(target=self._timeout_thread, daemon=True)
             self._timeout_thread = thread
             self._timeout_thread.start()

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -1,6 +1,6 @@
 import time
 from threading import RLock
-from functools import (wraps, partial)
+from functools import wraps
 
 import threading
 import numpy as np

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -30,6 +30,7 @@ def test_positioner_settle():
     assert p.settle_time == 0.1
     st = p.move(0.0, wait=False)
     assert st.settle_time == 0.1
+    assert st.timeout == 10.0
 
     assert p.timeout == 10.0
     p.timeout = 20.0

--- a/tests/test_pseudopos.py
+++ b/tests/test_pseudopos.py
@@ -177,10 +177,11 @@ class PseudoPosTests(unittest.TestCase):
             logger.debug('** Finished moving (%s)', kwargs)
 
         pseudo = Pseudo3x3('', name='mypseudo', concurrent=True,
-                           settle_time=0.1)
+                           settle_time=0.1, timeout=25.0)
         self.assertIs(pseudo.sequential, False)
         self.assertIs(pseudo.concurrent, True)
         self.assertEqual(pseudo.settle_time, 0.1)
+        self.assertEqual(pseudo.timeout, 25.0)
         pseudo.wait_for_connection()
 
         self.assertTrue(pseudo.connected)
@@ -242,6 +243,7 @@ class PseudoPosTests(unittest.TestCase):
         pseudo1.subscribe(single_sub, pseudo1.SUB_READBACK)
 
         ret = pseudo1.move(1, wait=False)
+        self.assertEqual(pseudo.timeout, ret.timeout)
         while not ret.done:
             logger.info('pseudo1.pos=%s Pos=%s %s (err=%s)', pseudo1.position,
                         pseudo.position, ret, ret.error)

--- a/tests/test_pvpositioner.py
+++ b/tests/test_pvpositioner.py
@@ -132,11 +132,12 @@ class PVPosTest(unittest.TestCase):
 
         motor_record = self.sim_pv
         pos = MyPositioner(motor_record, name='pos_no_put_compl',
-                           settle_time=0.1)
+                           settle_time=0.1, timeout=25.0)
         print(pos.describe())
         pos.wait_for_connection()
 
         self.assertEqual(pos.settle_time, 0.1)
+        self.assertEqual(pos.timeout, 25.0)
         pos.read()
         high_lim = pos.setpoint.high_limit
         try:
@@ -147,6 +148,7 @@ class PVPosTest(unittest.TestCase):
             raise ValueError('check_value should have failed')
 
         stat = pos.move(1, wait=False)
+        self.assertEqual(stat.timeout, pos.timeout)
         logger.info('--> post-move request, moving=%s', pos.moving)
 
         while not stat.done:


### PR DESCRIPTION
This is #297 (due to @klauer) plus one small commit that gives `move` no timeout by default. Other timeouts in the codebase (like `wait_for_connection`) are left as is.