### PR TITLE
REF: remove Device.monitor_attrs

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -328,8 +328,8 @@ class ComponentMeta(type):
         clsobj = super().__new__(cls, name, bases, clsdict)
 
         RESERVED_ATTRS = ['name', 'parent', 'signal_names', '_signals',
-                          'read_attrs', 'configuration_attrs', 'monitor_attrs',
-                          '_sig_attrs', '_sub_devices']
+                          'read_attrs', 'configuration_attrs', '_sig_attrs',
+                          '_sub_devices']
         for attr in RESERVED_ATTRS:
             if attr in clsdict:
                 raise TypeError("The attribute name %r is reserved for "
@@ -525,8 +525,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
     SUB_ACQ_DONE = 'acq_done'  # requested acquire
 
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
-                 monitor_attrs=None, name=None, parent=None,
-                 **kwargs):
+                 name=None, parent=None, **kwargs):
         # Store EpicsSignal objects (only created once they are accessed)
         self._signals = {}
 
@@ -546,12 +545,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         if configuration_attrs is None:
             configuration_attrs = []
 
-        if monitor_attrs is None:
-            monitor_attrs = []
-
         self.read_attrs = list(read_attrs)
         self.configuration_attrs = list(configuration_attrs)
-        self.monitor_attrs = list(monitor_attrs)
 
         # Instantiate non-lazy signals
         [getattr(self, attr) for attr, cpt in self._sig_attrs.items()
@@ -855,4 +850,3 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
 
         yield ('read_attrs', self.read_attrs)
         yield ('configuration_attrs', self.configuration_attrs)
-        yield ('monitor_attrs', self.monitor_attrs)

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -57,9 +57,8 @@ class EpicsMotor(Device, PositionerBase):
     home_reverse = Cpt(EpicsSignal, '.HOMR')
     direction_of_travel = Cpt(EpicsSignal, '.TDIR')
 
-
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
-                 monitor_attrs=None, name=None, parent=None, **kwargs):
+                 name=None, parent=None, **kwargs):
         if read_attrs is None:
             read_attrs = ['user_readback', 'user_setpoint']
 
@@ -68,7 +67,6 @@ class EpicsMotor(Device, PositionerBase):
 
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)
 
         # Make the default alias for the user_readback the name of the

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -24,13 +24,11 @@ class ROI(Device):
     hi_chan = C(EpicsSignal, 'HI', lazy=True)
     lo_chan = C(EpicsSignal, 'LO', lazy=True)
 
-    def __init__(self, prefix, *, read_attrs=None,
-                 configuration_attrs=None, monitor_attrs=None, name=None,
-                 parent=None, **kwargs):
+    def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
+                 name=None, parent=None, **kwargs):
 
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)
 
 
@@ -73,9 +71,8 @@ class EpicsMCARecord(Device):
 
     rois = DDC(add_rois(range(0, 32)))
 
-    def __init__(self, prefix, *, read_attrs=None,
-                 configuration_attrs=None, monitor_attrs=None, name=None,
-                 parent=None, **kwargs):
+    def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
+                 name=None, parent=None, **kwargs):
 
         default_read_attrs = ['spectrum', 'preset_real_time',
                               'elapsed_real_time']
@@ -89,7 +86,6 @@ class EpicsMCARecord(Device):
 
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)
 
         # could arguably be made a configuration_attr instead...
@@ -142,11 +138,9 @@ class EpicsDXP(Device):
     input_count_rate = C(EpicsSignalRO, 'InputCountRate', lazy=True)
     output_count_rate = C(EpicsSignalRO, 'OutputCountRate', lazy=True)
 
-    def __init__(self, prefix, *, read_attrs=None,
-                 configuration_attrs=None, monitor_attrs=None, name=None,
-                 parent=None, **kwargs):
+    def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
+                 name=None, parent=None, **kwargs):
 
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -311,8 +311,7 @@ class PseudoPositioner(Device, SoftPositioner):
         The default timeout to use for motion requests, in seconds.
     '''
     def __init__(self, prefix, *, concurrent=True, read_attrs=None,
-                 configuration_attrs=None, monitor_attrs=None, name=None,
-                 egu='', **kwargs):
+                 configuration_attrs=None, name=None, egu='', **kwargs):
 
         self._finished_lock = threading.RLock()
         self._concurrent = bool(concurrent)
@@ -326,7 +325,6 @@ class PseudoPositioner(Device, SoftPositioner):
 
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, egu=egu, **kwargs)
 
         self._real = [getattr(self, attr)

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -80,11 +80,9 @@ class PVPositioner(Device, PositionerBase):
     put_complete = False
 
     def __init__(self, prefix='', *, limits=None, name=None, read_attrs=None,
-                 configuration_attrs=None, monitor_attrs=None, parent=None,
-                 egu='', **kwargs):
+                 configuration_attrs=None, parent=None, egu='', **kwargs):
         super().__init__(prefix=prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)
 
         if self.__class__ is PVPositioner:

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -33,7 +33,7 @@ class EpicsScaler(Device):
     gates = DDC(_scaler_fields('gate', '.G', range(1, 33)))
 
     def __init__(self, prefix, *, read_attrs=None, configuration_attrs=None,
-                 monitor_attrs=None, name=None, parent=None, **kwargs):
+                 name=None, parent=None, **kwargs):
         if read_attrs is None:
             read_attrs = ['channels', 'time']
 
@@ -42,7 +42,6 @@ class EpicsScaler(Device):
 
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
-                         monitor_attrs=monitor_attrs,
                          name=name, parent=parent, **kwargs)
 
         self.stage_sigs.update([(self.count_mode, 0)])

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -50,13 +50,11 @@ class DeviceTests(unittest.TestCase):
 
         d = MyDevice('prefix', read_attrs=['cpt1'],
                      configuration_attrs=['cpt2'],
-                     monitor_attrs=['cpt3']
                      )
 
         d.read()
         self.assertEqual(d.read_attrs, ['cpt1'])
         self.assertEqual(d.configuration_attrs, ['cpt2'])
-        self.assertEqual(d.monitor_attrs, ['cpt3'])
 
         self.assertEqual(list(d.read().keys()), [d.cpt1.name])
         self.assertEqual(set(d.read_configuration().keys()),
@@ -157,8 +155,8 @@ class DeviceTests(unittest.TestCase):
 
     def test_name_shadowing(self):
         RESERVED_ATTRS = ['name', 'parent', 'signal_names', '_signals',
-                          'read_attrs', 'configuration_attrs', 'monitor_attrs',
-                          '_sig_attrs', '_sub_devices']
+                          'read_attrs', 'configuration_attrs', '_sig_attrs',
+                          '_sub_devices']
 
         type('a', (Device,), {'a': None})  # legal class definition
         # Illegal class definitions:

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -86,7 +86,6 @@ class SignalTests(unittest.TestCase):
         self.assertEquals(copy(sca).read_attrs, sca.read_attrs)
         self.assertEquals(copy(sca).configuration_attrs,
                           sca.configuration_attrs)
-        self.assertEquals(copy(sca).monitor_attrs, sca.monitor_attrs)
         repr(sca)
         str(sca)
 


### PR DESCRIPTION
As discussed. Is it safe to say that no beamline configs are using it?