### PR TITLE
MNT: Import setup_ophyd at top level.

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -29,6 +29,8 @@ from ._version import get_versions
 from .commands import (mov, movr, set_pos, wh_pos, set_lm, log_pos,
                        log_pos_diff, log_pos_mov)
 
+from .utils.startup import setup as setup_ophyd
+
 
 __version__ = get_versions()['version']
 del get_versions


### PR DESCRIPTION
I assume I will be voted down here, but what about *calling* `setup_ophyd()` in the `__init__.py` as well? We have previously seen cases where executing code on import is a tempted but bad idea (bluesky's qt_kicker) but I'm not convinced this is in the same category. Is there ever a case where it *shouldn't* be called? Should ophyd be in charge of setting itself up?

Note: as stated in the title, this PR does not do what I am suggesting above; it merely imports it in a more obvious place. I assume that is non-controversial.