### PR TITLE
API: Signal.set = Signal.put for bluesky compatibility

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -97,6 +97,9 @@ class Signal(OphydObject):
         self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value,
                        value=value, timestamp=self._timestamp)
 
+    # For bluesky compatibility, 'set' is an alias for put
+    set = put
+
     @property
     def value(self):
         '''The signal's value'''


### PR DESCRIPTION
Hopefully saving @danielballan a bit of typing

Allows `Signal`s to be used in plans (specifically `count_time` in the bs refactor)