### PR TITLE
ENH/TST: Implement Signal.set()

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -97,6 +97,8 @@ class Signal(OphydObject):
         self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value,
                        value=value, timestamp=self._timestamp)
 
+    set = put
+
     @property
     def value(self):
         '''The signal's value'''

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -512,6 +512,12 @@ class EpicsSignalTests(unittest.TestCase):
         self.assertEquals(desc['dtype'], 'array')
         self.assertEquals(desc['shape'], [1,])
 
+    def test_set_method(self):
+        sig = Signal()
+
+        sig.set(28)
+        self.assertEquals(sig.get(), 28)
+
 
 class DerivedSignalTests(unittest.TestCase):
     def test_soft_derived(self):


### PR DESCRIPTION
per conversation with @klauer, `Signal.set` is a synonym for `Signal.put`, so that things like `det.count_time.set(2)` work as expected.