### PR TITLE
FIX: cache clearing unnecessary with new pyepics

### DIFF
--- a/ophyd/utils/startup.py
+++ b/ophyd/utils/startup.py
@@ -49,9 +49,5 @@ def _cleanup():
 
     _dispatcher = None
 
-    logger.debug('Clearing the pyepics cache')
-    epics.ca.clear_cache()
-    time.sleep(0.1)
-
     logger.debug('Finalizing libca')
     epics.ca.finalize_libca()


### PR DESCRIPTION
No crashing at exit with Python 3 and pyepics/pyepics@e4cd21cfaf63bc2150d5679ad4f6cf75deb2ff0f

We should make sure that this new version of pyepics (and of course ophyd) gets deployed for the next cycle.