### PR TITLE
ENH: fully fleshed out Signal.set and EpicsSignal.set

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -526,6 +526,9 @@ class EpicsSignalRO(EpicsSignalBase):
     def put(self, *args, **kwargs):
         raise ReadOnlyError('Read-only signals cannot be put to')
 
+    def set(self, *args, **kwargs):
+        raise ReadOnlyError('Read-only signals cannot be set')
+
 
 class EpicsSignal(EpicsSignalBase):
     '''An EPICS signal, comprised of either one or two EPICS PVs

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -21,8 +21,8 @@ def _locked(func):
 
 class StatusBase:
     """
-    This is a base class that provides a single-slot
-    call back for finished.
+    This is a base class that provides a single-slot callback for when the
+    specific operation has finished.
 
     Parameters
     ----------
@@ -125,6 +125,30 @@ class StatusBase:
 
     def __str__(self):
         return ('{0}(done={1.done}, '
+                'success={1.success})'
+                ''.format(self.__class__.__name__, self)
+                )
+
+    __repr__ = __str__
+
+
+class Status(StatusBase):
+    '''A basic status object
+
+    Has an optional associated object instance
+
+    Attributes
+    ----------
+    obj : any or None
+        The object
+    '''
+    def __init__(self, obj=None, **kwargs):
+        self.obj = obj
+        super().__init__(**kwargs)
+
+    def __str__(self):
+        return ('{0}(obj={1.obj}, '
+                'done={1.done}, '
                 'success={1.success})'
                 ''.format(self.__class__.__name__, self)
                 )

--- a/tests/test_flyers.py
+++ b/tests/test_flyers.py
@@ -33,8 +33,8 @@ def ts_sim_detector(prefix, stats_suffix):
         ts_col = Cpt(AreaDetectorTimeseriesCollector, stats_suffix)
         stats = Cpt(StatsPlugin, stats_suffix)
 
-    det = Detector(prefix, name='sim')
     try:
+        det = Detector(prefix, name='sim')
         det.wait_for_connection(timeout=1.0)
     except TimeoutError:
         pytest.skip('IOC unavailable')

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,4 +1,3 @@
-
 import sys
 import logging
 import unittest
@@ -6,12 +5,14 @@ import threading
 import random
 import time
 import copy
+import pytest
 
 import numpy as np
 import epics
 
 from ophyd.signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)
 from ophyd.utils import ReadOnlyError
+from ophyd.status import wait
 
 logger = logging.getLogger(__name__)
 
@@ -515,7 +516,10 @@ class EpicsSignalTests(unittest.TestCase):
     def test_set_method(self):
         sig = Signal()
 
-        sig.set(28)
+        st = sig.set(28)
+        wait(st)
+        assert st.done
+        assert st.success
         self.assertEquals(sig.get(), 28)
 
 
@@ -556,6 +560,33 @@ class DerivedSignalTests(unittest.TestCase):
         # race condition with the FakeEpicsPV update loop, can't really test
         # self.assertEqual(derived.timestamp, signal.timestamp)
         # self.assertEqual(derived.get(), signal.value)
+
+
+@pytest.mark.parametrize('put_complete', [True, False])
+def test_epicssignal_set(put_complete):
+    epics.PV = epics._PV
+    sim_pv = EpicsSignal(write_pv='XF:31IDA-OP{Tbl-Ax:X1}Mtr.VAL',
+                         read_pv='XF:31IDA-OP{Tbl-Ax:X1}Mtr.RBV',
+                         put_complete=put_complete)
+
+    # move to +0.2 and check the status object
+    target = sim_pv.get() + 0.2
+    st = sim_pv.set(target, timeout=1, settle_time=0.001)
+    wait(st)
+    assert st.done
+    assert st.success
+    assert abs(target - sim_pv.get()) < 0.05
+
+    # move back to -0.2, forcing a timeout with a low value
+    target = sim_pv.get() - 0.2
+    st = sim_pv.set(target, timeout=1e-6)
+    time.sleep(0.1)
+    assert st.done
+    assert not st.success
+
+    # keep the axis in position
+    st = sim_pv.set(target)
+    wait(st)
 
 
 from . import main

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -351,6 +351,9 @@ class EpicsSignalTests(unittest.TestCase):
         with self.assertRaises(ReadOnlyError):
             signal.put(10)
 
+        with self.assertRaises(ReadOnlyError):
+            signal.set(10)
+
         # vestigial, to be removed
         with self.assertRaises(AttributeError):
             signal.setpoint_ts


### PR DESCRIPTION
This will give us the option to use `set` similar to `Positioner`s for all signals, with asynchronous status completion objects.

* `Signal.set` uses `set_and_wait` (runs in a separate CAThread) - and so all signals derived from this will do the same
* `EpicsSignal.set` uses put completion if specified by the user (requires no background thread), and falls back to `set_and_wait`
* Switched Signal from using `StatusBase` -> `Status`