### PR TITLE
API/TST: flyers have methods: complete, describe_collect, pause, resume

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -492,6 +492,12 @@ class BlueskyInterface:
         self._staged = Staged.no
         return devices_unstaged
 
+    def pause(self):
+        pass
+
+    def resume(self):
+        pass
+
 
 class GenerateDatumInterface:
     """Classes that inherit from this can safely customize the

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -89,10 +89,12 @@ class AreaDetectorTimeseriesCollector(Device):
     def pause(self):
         # Stop without clearing buffers
         self.control.put('Stop', wait=True)
+        super().pause()
 
     def resume(self):
         # Resume without erasing
         self.control.put('Start', wait=True)
+        super().resume()
 
     def complete(self):
         if self.control.get(as_string=True) == 'Stop':

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -163,6 +163,8 @@ class WaveformCollector(Device):
                       'timestamps': {self.name: v},
                       'time': v}
                 yield ev
+        else:
+            yield from []
 
     def _repr_info(self):
         yield from super()._repr_info()

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -6,56 +6,10 @@ from collections import OrderedDict
 from .signal import (Signal, EpicsSignal, EpicsSignalRO)
 from .status import DeviceStatus
 from .device import (Device, Component as C, BlueskyInterface)
+from .utils import OrderedDefaultDict
 
 
 logger = logging.getLogger(__name__)
-
-
-class OrderedDefaultDict(OrderedDict):
-    """
-    a combination of defaultdict and OrderedDict
-
-    source: http://stackoverflow.com/a/6190500/1221924
-    """
-    def __init__(self, default_factory=None, *a, **kw):
-        if (default_factory is not None and not callable(default_factory)):
-            raise TypeError('first argument must be callable')
-        OrderedDict.__init__(self, *a, **kw)
-        self.default_factory = default_factory
-
-    def __getitem__(self, key):
-        try:
-            return OrderedDict.__getitem__(self, key)
-        except KeyError:
-            return self.__missing__(key)
-
-    def __missing__(self, key):
-        if self.default_factory is None:
-            raise KeyError(key)
-        self[key] = value = self.default_factory()
-        return value
-
-    def __reduce__(self):
-        if self.default_factory is None:
-            args = tuple()
-        else:
-            args = self.default_factory,
-        return type(self), args, None, None, self.items()
-
-    def copy(self):
-        return self.__copy__()
-
-    def __copy__(self):
-        return type(self)(self.default_factory, self)
-
-    def __deepcopy__(self, memo):
-        import copy
-        return type(self)(self.default_factory,
-                          copy.deepcopy(self.items()))
-
-    def __repr__(self):
-        return 'OrderedDefaultDict(%s, %s)' % (self.default_factory,
-                                               OrderedDict.__repr__(self))
 
 
 class AreaDetectorTimeseriesCollector(Device):

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from .signal import (Signal, EpicsSignal, EpicsSignalRO)
 from .status import DeviceStatus
-from .device import (Device, Component as C)
+from .device import (Device, Component as C, BlueskyInterface)
 
 
 logger = logging.getLogger(__name__)
@@ -225,7 +225,7 @@ class WaveformCollector(Device):
         return {self.stream_name: desc}
 
 
-class MonitorFlyerMixin:
+class MonitorFlyerMixin(BlueskyInterface):
     '''A bluesky-compatible flyer mixin, using monitor_attrs
 
     At kickoff(), all monitor_attrs will be subscribed to and monitored for the

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -33,12 +33,23 @@ class AreaDetectorTimeseriesCollector(Device):
 
     def kickoff(self):
         # Erase buffer and start collection
-        self.control.put(0, wait=True)
+        self.control.put('Erase/Start', wait=True)
         # make status object
         status = DeviceStatus(self)
         # it always done, the scan should never even try to wait for this
         status._finished()
         return status
+
+    def pause(self):
+        self.stop()
+
+    def resume(self):
+        # Resume without erasing
+        self.control.put('Start', wait=True)
+
+    def stop(self):
+        # Stop without clearing buffers
+        self.control.put('Stop', wait=True)
 
     def collect(self):
         self.stop()
@@ -47,9 +58,6 @@ class AreaDetectorTimeseriesCollector(Device):
             yield {'data': {self.name: v},
                    'timestamps': {self.name: t},
                    'time': t}
-
-    def stop(self):
-        self.control.put(2, wait=True)  # Stop Collection
 
     def describe_collect(self):
         '''Describe details for the flyer collect() method'''
@@ -85,6 +93,17 @@ class WaveformCollector(Device):
         else:
             return []
 
+    def pause(self):
+        self.stop()
+
+    def resume(self):
+        # Resume without erasing
+        self.select.put(1, wait=True)
+
+    def stop(self):
+        # Stop without clearing buffers
+        self.select.put(0, wait=True)
+
     def kickoff(self):
         # Put us in reset mode
         self.select.put(2, wait=True)
@@ -109,9 +128,6 @@ class WaveformCollector(Device):
                       'timestamps': {self.name: v},
                       'time': v}
                 yield ev
-
-    def stop(self):
-        self.select.put(0, wait=True)  # Stop Collection
 
     def _repr_info(self):
         yield from super()._repr_info()

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -190,9 +190,11 @@ class MonitorFlyerMixin:
     monitor_attrs : list, optional
         List of signal attribute names to monitor
     '''
-    def __init__(self, *args, **kwargs):
-        self.monitor_attrs = kwargs.pop('monitor_attrs', [])
-        self.stream_name = kwargs.pop('stream_name', None)
+    def __init__(self, *args, monitor_attrs=None, stream_name=None, **kwargs):
+        if monitor_attrs is None:
+            monitor_attrs = []
+        self.monitor_attrs = monitor_attrs
+        self.stream_name = stream_name
         self._acquiring = False
         self._paused = False
 

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -51,6 +51,10 @@ class AreaDetectorTimeseriesCollector(Device):
     def stop(self):
         self.control.put(2, wait=True)  # Stop Collection
 
+    def describe_collect(self):
+        '''Describe details for the flyer collect() method'''
+        return [self._describe_attr_list(['waveform', 'waveform_ts'])]
+
 
 class WaveformCollector(Device):
     select = C(EpicsSignal, "Sw-Sel")
@@ -112,3 +116,7 @@ class WaveformCollector(Device):
     def _repr_info(self):
         yield from super()._repr_info()
         yield ('data_is_time', self.data_is_time.get())
+
+    def describe_collect(self):
+        '''Describe details for the flyer collect() method'''
+        return [self._describe_attr_list(['waveform'])]

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -1,6 +1,14 @@
+import time as ttime
+import functools
+import logging
+from collections import OrderedDict
+
 from .signal import (Signal, EpicsSignal, EpicsSignalRO)
 from .status import DeviceStatus
 from .device import (Device, Component as C)
+
+
+logger = logging.getLogger(__name__)
 
 
 class AreaDetectorTimeseriesCollector(Device):
@@ -136,3 +144,92 @@ class WaveformCollector(Device):
     def describe_collect(self):
         '''Describe details for the flyer collect() method'''
         return [self._describe_attr_list(['waveform'])]
+
+
+class MonitorFlyerMixin(Device):
+    '''A bluesky flyer device, using monitor_attrs
+    '''
+    def __init__(self, prefix, monitor_attrs=None, **kwargs):
+        if monitor_attrs is None:
+            monitor_attrs = []
+
+        self.monitor_attrs = monitor_attrs
+
+        super().__init__(prefix, **kwargs)
+        self._acquiring = False
+
+    def kickoff(self):
+        self._status = DeviceStatus(self)
+        self._collected_data = OrderedDict()
+        self._start_time = ttime.time()
+        self._acquiring = True
+
+        for attr in self.monitor_attrs:
+            obj = getattr(self, attr)
+            if isinstance(obj, Device):
+                raise ValueError('Cannot monitor sub-devices')
+            self._collected_data[attr] = {'values': [],
+                                          'timestamps': []
+                                          }
+            obj.subscribe(functools.partial(self._monitor_callback,
+                                            attribute=attr))
+
+        return self._status
+
+    def _monitor_callback(self, attribute=None, obj=None, value=None,
+                          timestamp=None, **kwargs):
+        if not self._acquiring:
+            return
+
+        if value is None or timestamp is None:
+            data = obj.read()[obj.name]
+            value = data['value']
+            timestamp = data['timestamp']
+
+        collected = self._collected_data[attribute]
+        collected['values'].append(value)
+        collected['timestamps'].append(timestamp)
+
+    def describe_collect(self):
+        return [self._describe_attr_list([attr])
+                for attr in self.monitor_attrs]
+
+    def _clear_monitors(self):
+        for attr in self._collected_data.keys():
+            obj = getattr(self, attr)
+            try:
+                obj.clear_sub(self._monitor_callback)
+            except Exception as ex:
+                logger.debug('Failed to clear subscription',
+                             exc_info=ex)
+
+    def pause(self):
+        self._acquiring = False
+
+    def resume(self):
+        self._acquiring = True
+
+    def stop(self):
+        self._clear_monitors()
+        try:
+            super().stop()
+        finally:
+            if not self._status.done:
+                self._status._finished(success=True)
+
+    def collect(self):
+        self.stop()
+
+        names = [getattr(self, attr).name
+                 for attr in self._collected_data]
+
+        collected = [dict(time=self._start_time,
+                          timestamps={name: data['timestamps']},
+                          data={name: data['values']},
+                          )
+                     for name, data in zip(names,
+                                           self._collected_data.values())
+                     ]
+
+        self._collected_data = None
+        return collected

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -279,7 +279,7 @@ class MonitorFlyerMixin(BlueskyInterface):
             return
         self._paused = False
         self._add_monitors()
-        super.resume()
+        super().resume()
 
     def complete(self):
         '''Acquisition completed'''

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -12,40 +12,51 @@ logger = logging.getLogger(__name__)
 
 
 class OrderedDefaultDict(OrderedDict):
-    "a pure Python implementation of defaultdict, inheriting from OrderedDict"
+    """
+    a combination of defaultdict and OrderedDict
+
+    source: http://stackoverflow.com/a/6190500/1221924
+    """
     def __init__(self, default_factory=None, *a, **kw):
-        if (default_factory is not None and
-            not hasattr(default_factory, '__call__')):
+        if (default_factory is not None and not callable(default_factory)):
             raise TypeError('first argument must be callable')
-        dict.__init__(self, *a, **kw)
+        OrderedDict.__init__(self, *a, **kw)
         self.default_factory = default_factory
+
     def __getitem__(self, key):
         try:
-            return dict.__getitem__(self, key)
+            return OrderedDict.__getitem__(self, key)
         except KeyError:
             return self.__missing__(key)
+
     def __missing__(self, key):
         if self.default_factory is None:
             raise KeyError(key)
         self[key] = value = self.default_factory()
         return value
+
     def __reduce__(self):
         if self.default_factory is None:
             args = tuple()
         else:
             args = self.default_factory,
         return type(self), args, None, None, self.items()
+
     def copy(self):
         return self.__copy__()
+
     def __copy__(self):
         return type(self)(self.default_factory, self)
+
     def __deepcopy__(self, memo):
         import copy
         return type(self)(self.default_factory,
-                            copy.deepcopy(self.items()))
+                          copy.deepcopy(self.items()))
+
     def __repr__(self):
-        return 'defaultdict(%s, %s)' % (self.default_factory,
-                                        dict.__repr__(self))
+        return 'OrderedDefaultDict(%s, %s)' % (self.default_factory,
+                                               OrderedDict.__repr__(self))
+
 
 class AreaDetectorTimeseriesCollector(Device):
     control = C(EpicsSignal, "TSControl")

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -11,6 +11,42 @@ from .device import (Device, Component as C)
 logger = logging.getLogger(__name__)
 
 
+class OrderedDefaultDict(OrderedDict):
+    "a pure Python implementation of defaultdict, inheriting from OrderedDict"
+    def __init__(self, default_factory=None, *a, **kw):
+        if (default_factory is not None and
+            not hasattr(default_factory, '__call__')):
+            raise TypeError('first argument must be callable')
+        dict.__init__(self, *a, **kw)
+        self.default_factory = default_factory
+    def __getitem__(self, key):
+        try:
+            return dict.__getitem__(self, key)
+        except KeyError:
+            return self.__missing__(key)
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = tuple()
+        else:
+            args = self.default_factory,
+        return type(self), args, None, None, self.items()
+    def copy(self):
+        return self.__copy__()
+    def __copy__(self):
+        return type(self)(self.default_factory, self)
+    def __deepcopy__(self, memo):
+        import copy
+        return type(self)(self.default_factory,
+                            copy.deepcopy(self.items()))
+    def __repr__(self):
+        return 'defaultdict(%s, %s)' % (self.default_factory,
+                                        dict.__repr__(self))
+
 class AreaDetectorTimeseriesCollector(Device):
     control = C(EpicsSignal, "TSControl")
     num_points = C(EpicsSignal, "TSNumPoints")
@@ -208,7 +244,8 @@ class MonitorFlyerMixin:
         DeviceStatus
             This will be set to done when acquisition has begun
         '''
-        self._collected_data = OrderedDict()
+        self._collected_data = OrderedDefaultDict(lambda: {'values': [],
+                                                           'timestamps': []})
         self._start_time = ttime.time()
         self._acquiring = True
         self._paused = False

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -300,4 +300,4 @@ class MonitorFlyerMixin:
                      ]
 
         self._collected_data = None
-        return collected
+        yield from collected

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -8,6 +8,7 @@
 '''
 
 import logging
+from collections import OrderedDict
 
 from .errors import *
 from .epics_pvs import *
@@ -19,3 +20,50 @@ logger.addHandler(logging.NullHandler())
 def enum(**enums):
     '''Create an enum from the keyword arguments'''
     return type('Enum', (object,), enums)
+
+
+class OrderedDefaultDict(OrderedDict):
+    """
+    a combination of defaultdict and OrderedDict
+
+    source: http://stackoverflow.com/a/6190500/1221924
+    """
+    def __init__(self, default_factory=None, *a, **kw):
+        if (default_factory is not None and not callable(default_factory)):
+            raise TypeError('first argument must be callable')
+        OrderedDict.__init__(self, *a, **kw)
+        self.default_factory = default_factory
+
+    def __getitem__(self, key):
+        try:
+            return OrderedDict.__getitem__(self, key)
+        except KeyError:
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = tuple()
+        else:
+            args = self.default_factory,
+        return type(self), args, None, None, self.items()
+
+    def copy(self):
+        return self.__copy__()
+
+    def __copy__(self):
+        return type(self)(self.default_factory, self)
+
+    def __deepcopy__(self, memo):
+        import copy
+        return type(self)(self.default_factory,
+                          copy.deepcopy(self.items()))
+
+    def __repr__(self):
+        return 'OrderedDefaultDict(%s, %s)' % (self.default_factory,
+                                               OrderedDict.__repr__(self))

--- a/ophyd/utils/__init__.py
+++ b/ophyd/utils/__init__.py
@@ -31,12 +31,12 @@ class OrderedDefaultDict(OrderedDict):
     def __init__(self, default_factory=None, *a, **kw):
         if (default_factory is not None and not callable(default_factory)):
             raise TypeError('first argument must be callable')
-        OrderedDict.__init__(self, *a, **kw)
+        super().__init__(*a, **kw)
         self.default_factory = default_factory
 
     def __getitem__(self, key):
         try:
-            return OrderedDict.__getitem__(self, key)
+            return super().__getitem__(key)
         except KeyError:
             return self.__missing__(key)
 
@@ -65,5 +65,5 @@ class OrderedDefaultDict(OrderedDict):
                           copy.deepcopy(self.items()))
 
     def __repr__(self):
-        return 'OrderedDefaultDict(%s, %s)' % (self.default_factory,
-                                               OrderedDict.__repr__(self))
+        return '%s(%s, %s)' % (self.__class__.__name__, self.default_factory,
+                               super().__repr__())

--- a/tests/test_flyers.py
+++ b/tests/test_flyers.py
@@ -67,7 +67,9 @@ def test_ad_time_series(ts_sim_detector, tscollector):
     print('cam stage sigs', cam.stage_sigs)
     print('stats stage sigs', sim_detector.stats.stage_sigs)
 
-    tscollector.stop()
+    st = tscollector.complete()
+    wait(st)
+
     tscollector.stage_sigs[tscollector.num_points] = num_points
 
     sim_detector.stage()
@@ -123,10 +125,13 @@ def test_monitor_flyer():
         pass
 
     fdev = FlyerDevice('', name='fdev')
+    fdev.wait_for_connection()
+
     fdev.monitor_attrs = ['mtr1.user_readback', 'mtr2.user_readback']
     fdev.describe()
 
     st = fdev.kickoff()
+    wait(st)
 
     mtr1, mtr2 = fdev.mtr1, fdev.mtr2
     rbv1, rbv2 = mtr1.position, mtr2.position
@@ -139,7 +144,8 @@ def test_monitor_flyer():
     fdev.mtr2.move(rbv2 - 0.2, wait=True)
 
     fdev.resume()
-    fdev.stop()
+    st = fdev.complete()
+    wait(st)
 
     assert fdev.describe_collect() == [fdev.mtr1.user_readback.describe(),
                                        fdev.mtr2.user_readback.describe()]

--- a/tests/test_flyers.py
+++ b/tests/test_flyers.py
@@ -77,6 +77,9 @@ def test_ad_time_series(ts_sim_detector, tscollector):
         print(st)
         time.sleep(0.1)
 
+    tscollector.pause()
+    tscollector.resume()
+
     collected = list(tscollector.collect())
     print('collected', collected)
     sim_detector.unstage()

--- a/tests/test_flyers.py
+++ b/tests/test_flyers.py
@@ -58,6 +58,7 @@ def test_ad_time_series(ts_sim_detector, tscollector):
     cam.stage_sigs[cam.trigger_mode] = 'Internal'
 
     print('tscollector desc', tscollector.describe())
+    print('tscollector flyer desc', tscollector.describe_collect())
     print('tscollector repr', repr(tscollector))
     print('simdet stage sigs', sim_detector.stage_sigs)
     print('tscoll stage sigs', tscollector.stage_sigs)
@@ -90,8 +91,8 @@ def wf_sim_detector(prefix):
     class Detector(SimDetector):
         wfcol = Cpt(WaveformCollector, suffix)
 
-    det = Detector(prefix)
     try:
+        det = Detector(prefix)
         det.wait_for_connection(timeout=1.0)
     except TimeoutError:
         pytest.skip('IOC unavailable')
@@ -105,3 +106,4 @@ def wfcol(wf_sim_detector):
 
 def test_waveform(wf_sim_detector, wfcol):
     print('waveform collector', wfcol)
+    print('wfcol flyer desc', wfcol.describe_collect())

--- a/tests/test_flyers.py
+++ b/tests/test_flyers.py
@@ -2,8 +2,8 @@ import time
 import pytest
 
 from ophyd import (Component as Cpt,
-                   SimDetector, SimDetectorCam, StatsPlugin, EpicsSignal,
-                   EpicsSignalRO, EpicsMotor, Device)
+                   SimDetector, SimDetectorCam, StatsPlugin, EpicsMotor,
+                   Device)
 from ophyd.areadetector.base import EpicsSignalWithRBV
 from ophyd.flyers import (AreaDetectorTimeseriesCollector,
                           WaveformCollector,
@@ -125,7 +125,7 @@ def test_monitor_flyer():
     class FlyerDevice(MonitorFlyerMixin, BasicDevice):
         pass
 
-    fdev = FlyerDevice('', name='fdev', stream_name='oranges')
+    fdev = FlyerDevice('', name='fdev', stream_names={'mtr1.user_readback': 'oranges'})
     fdev.wait_for_connection()
 
     fdev.monitor_attrs = ['mtr1.user_readback', 'mtr2.user_readback']
@@ -148,11 +148,12 @@ def test_monitor_flyer():
     st = fdev.complete()
     wait(st)
 
-    desc = OrderedDefaultDict()
-    desc.update(fdev.mtr1.user_readback.describe())
-    desc.update(fdev.mtr2.user_readback.describe())
-
-    assert fdev.describe_collect() == {'oranges': desc}
+    print(fdev.describe_collect())
+    assert (fdev.describe_collect() ==
+            {'oranges': fdev.mtr1.user_readback.describe(),
+             'fdev_mtr2': fdev.mtr2.user_readback.describe(),
+             }
+            )
     data = list(fdev.collect())
     # data from both motors
     assert len(data) == 2


### PR DESCRIPTION
* `describe_collect()` is separate from the normal `Device.describe()` in that it has a description of what `collect()` will return. The return value is also a list of descriptions, whereas `describe` and `describe_configuration` return only a single dictionary each.
* `complete()` returns a status object indicating when data is ready for collection (all implemented flyers return completed status objects currently)
* `pause` pauses flyer data acquisition
* `resume` resumes after a pause