### PR TITLE
ENH: add signal/positioner mixin

### DIFF
--- a/ophyd/mixins.py
+++ b/ophyd/mixins.py
@@ -1,0 +1,125 @@
+import types
+from .signal import EpicsSignal
+from .positioner import PositionerBase
+
+
+class SignalPositionerMixin(PositionerBase):
+    '''Mixin to make a Signal a Positioner
+
+    Should be mixed in first, with the Signal second, such that:
+        set, move will be from PositionerBase
+
+    Parameters
+    ----------
+    set_func : callable
+        The set() functionality for the class. Must be specified as the mixin
+        takes over set() functionality.
+    egu : str, optional
+        Engineering units of positioner
+    hold_on_stop : bool, optional
+        When stop is called on the positioner
+    '''
+    def __init__(self, *args, set_func=None, egu='', hold_on_stop=False,
+                 **kwargs):
+        if set_func is None:
+            raise RuntimeError('set() functionality not stashed: '
+                               'see SignalPositionerMixin docs')
+        super().__init__(*args, **kwargs)
+        self._egu = egu
+        self._hold_on_stop = hold_on_stop
+        self._status = None
+
+        # bind method to this class instance:
+        self._mixed_set = set_func.__get__(self, self.__class__)
+
+        self.subscribe(self._position_updated)
+
+    def _position_updated(self, value=None, **kwargs):
+        # for readback subscriptions
+        self._set_position(value)
+
+    @property
+    def position(self):
+        '''The current position of the motor in its engineering units
+
+        Returns
+        -------
+        position : any
+        '''
+        return self.get()
+
+    @property
+    def egu(self):
+        '''The engineering units (EGU) for positions'''
+        return self._egu
+
+    def move(self, position, moved_cb=None, timeout=None):
+        '''Move to a specified position, optionally waiting for motion to
+        complete.
+
+        Parameters
+        ----------
+        position
+            Position to move to
+        moved_cb : callable
+            Call this callback when movement has finished. This callback
+            must accept one keyword argument: 'obj' which will be set to
+            this positioner instance.
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+
+        Returns
+        -------
+        status : Status
+
+        Raises
+        ------
+        TimeoutError
+            When motion takes longer than `timeout`
+        ValueError
+            On invalid positions
+        RuntimeError
+            If motion fails other than timing out
+        '''
+        if timeout is None:
+            timeout = self._timeout
+
+        self.check_value(position)
+
+        self._run_subs(sub_type=self._SUB_REQ_DONE, success=False)
+        self._reset_sub(self._SUB_REQ_DONE)
+
+        self._moving = True
+        self._run_subs(sub_type=self.SUB_START)
+
+        def finished():
+            self._done_moving(success=self._status.success)
+
+            if moved_cb is not None:
+                moved_cb(obj=self)
+
+            self._status = None
+
+        # set() functionality depends on the signal
+        self._status = self._mixed_set(self, position, timeout=timeout,
+                                       settle_time=self.settle_time)
+        self._status.finished_cb = finished
+        return self._status
+
+    def stop(self):
+        '''Stops motion'''
+        if self._hold_on_stop:
+            self.move(self.get(), wait=False)
+        # TODO status object?
+        return super().stop()
+
+    def _repr_info(self):
+        yield from super()._repr_info()
+        yield ('egu', self.egu)
+        yield ('hold_on_stop', self._hold_on_stop)
+
+
+class EpicsSignalPositioner(SignalPositionerMixin, EpicsSignal):
+    def __init__(self, read_pv, **kwargs):
+        super().__init__(read_pv=read_pv, set_func=EpicsSignal.set, **kwargs)

--- a/tests/test_positioner.py
+++ b/tests/test_positioner.py
@@ -1,17 +1,11 @@
-
-
-import time
 import logging
 import unittest
-import pytest
 from copy import copy
 from unittest import mock
 from unittest.mock import Mock
 
-import epics
 import ophyd
-from ophyd import (SoftPositioner, PVPositioner)
-from ophyd import (Component as C)
+from ophyd import (SoftPositioner, )
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_signalpositioner.py
+++ b/tests/test_signalpositioner.py
@@ -1,0 +1,80 @@
+import logging
+from copy import copy
+from unittest import mock
+from unittest.mock import Mock
+
+import ophyd
+from ophyd.mixins import EpicsSignalPositioner
+from ophyd.utils import record_field
+from ophyd.status import wait
+
+from .config import motor_recs
+
+
+logger = logging.getLogger(__name__)
+
+
+def setUpModule():
+    ophyd.commands.setup_ophyd()
+    logging.getLogger('ophyd.mixins').setLevel(logging.DEBUG)
+
+
+def tearDownModule():
+    logger.debug('Cleaning up')
+
+
+def test_epics_signal_positioner():
+    readback = record_field(motor_recs[0], 'RBV')
+    setpoint = record_field(motor_recs[0], 'VAL')
+    p = EpicsSignalPositioner(readback, write_pv=setpoint, name='p', egu='egu',
+                              tolerance=0.005)
+    p.wait_for_connection()
+    assert p.connected
+
+    position_callback = Mock()
+    started_motion_callback = Mock()
+    finished_motion_callback = Mock()
+    assert p.egu == 'egu'
+
+    p.subscribe(position_callback, event_type=p.SUB_READBACK)
+    p.subscribe(started_motion_callback, event_type=p.SUB_START)
+    p.subscribe(finished_motion_callback, event_type=p.SUB_DONE)
+
+    start_pos = p.position
+    target_pos = start_pos - 1.5
+    p.move(target_pos, wait=True)
+    logger.debug(str(p))
+    assert not p.moving
+    assert abs(p.position - target_pos) <= p.tolerance
+
+    position_callback.assert_called_with(
+        obj=p, value=target_pos, sub_type=p.SUB_READBACK, timestamp=mock.ANY)
+    started_motion_callback.assert_called_once_with(
+        obj=p, sub_type=p.SUB_START, timestamp=mock.ANY)
+    finished_motion_callback.assert_called_once_with(
+        obj=p, sub_type=p.SUB_DONE, value=None, timestamp=mock.ANY)
+
+    st = p.set(start_pos)
+
+    wait(st)
+
+    assert st.done
+    assert st.error == 0
+    assert st.elapsed > 0
+    assert abs(p.position - start_pos) <= p.tolerance
+
+    repr(p)
+    str(p)
+
+    p.stop()
+
+    p.position
+
+    pc = copy(p)
+    assert pc.egu == p.egu
+    assert pc.limits == p.limits
+
+
+from . import main
+is_main = (__name__ == '__main__')
+main(is_main)

--- a/tests/test_signalpositioner.py
+++ b/tests/test_signalpositioner.py
@@ -34,6 +34,7 @@ def test_epics_signal_positioner():
     position_callback = Mock()
     started_motion_callback = Mock()
     finished_motion_callback = Mock()
+    moved_cb = Mock()
     assert p.egu == 'egu'
 
     p.subscribe(position_callback, event_type=p.SUB_READBACK)
@@ -42,11 +43,12 @@ def test_epics_signal_positioner():
 
     start_pos = p.position
     target_pos = start_pos - 1.5
-    p.move(target_pos, wait=True)
+    p.move(target_pos, wait=True, moved_cb=moved_cb)
     logger.debug(str(p))
     assert not p.moving
     assert abs(p.position - target_pos) <= p.tolerance
 
+    moved_cb.assert_called_with(obj=p)
     position_callback.assert_called_with(
         obj=p, value=target_pos, sub_type=p.SUB_READBACK, timestamp=mock.ANY)
     started_motion_callback.assert_called_once_with(


### PR DESCRIPTION
Alternative to PVPositioner modification idea (#331); ~~only for discussion~~

Could be used as follows:
```python
   sig = EpicsSignalPositioner('Prefix:Motor.RBV', write_pv='Prefix:Motor.VAL', tolerance=0.005)
   sig.move(5.0)
```
This would use `set` -> `set_and_wait` for moves on a signal, which boils down to `abs(readback - setpoint) <= tolerance` (ignoring the unset relative tolerance), so once at 4.995 <= position <= 5.005 would run the done move callbacks, etc.