### PR TITLE
ENH: add methods to walk AD plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ cache:
 
 matrix:
   include:
-    #  - python: 2.7  # ophyd is python 3+ only at the moment
-  - python: 3.4
-  # - python: 3.5
+    - python: 3.4
+    - python: 3.5
 
 before_install:
   - export DOCKER0_IP=$(/sbin/ifconfig docker0 |grep 'inet addr' | sed -e 's/.*addr:\([^ ]*\).*/\1/')
@@ -42,12 +41,13 @@ before_install:
   - conda config --set always_yes true
   - conda update conda --yes
   - conda install conda-build anaconda-client jinja2
+  - conda config --add channels lightsource2-dev
   - conda config --add channels lightsource2
   - conda config --add channels soft-matter
-
+  - conda config --add channels defaults
 
   # MAKE THE CONDA RECIPE
-  - conda create -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION
+  - conda create -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION -c defaults
   - source activate $CONDA_ENV
 
   # need to reactivate after installing epics-base so that the EPICS_BASE env
@@ -56,7 +56,8 @@ before_install:
 
 install:
   # INSTALL OPHYD
-  - conda install numpy pyepics prettytable filestore ipython pyolog
+  - conda install numpy pyepics prettytable filestore ipython pyolog networkx
+  - conda install readline -c lightsource2
   - pip install coveralls pytest pytest-cov codecov
   - python setup.py develop
 

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -8,6 +8,7 @@ import networkx as nx
 from ..signal import EpicsSignal
 from . import docs
 from ..device import (Device, Component)
+from ..signal import (ArrayAttributeSignal)
 
 
 class EpicsSignalWithRBV(EpicsSignal):
@@ -254,3 +255,10 @@ class ADBase(Device):
                 ret.append(node)
 
         return ret
+    configuration_names = Component(ArrayAttributeSignal,
+                                    attr='_configuration_names')
+
+    @property
+    def _configuration_names(self):
+        return [getattr(self, c).name
+                for c in self.configuration_attrs]

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -83,7 +83,8 @@ class PluginBase(ADBase):
 
     _default_configuration_attrs = ('port_name', 'nd_array_port', 'enable',
                                     'blocking_callbacks', 'plugin_type',
-                                    'asyn_pipeline_config', 'configuration_names')
+                                    'asyn_pipeline_config',
+                                    'configuration_names')
 
     _html_docs = ['pluginDoc.html']
     _plugin_type = None
@@ -210,7 +211,6 @@ class ImagePlugin(PluginBase):
     _plugin_type = 'NDPluginStdArrays'
 
     array_data = C(EpicsSignal, 'ArrayData')
-    _default_configuration_attrs = PluginBase._default_configuration_attrs
 
     @property
     def image(self):
@@ -354,6 +354,8 @@ class ColorConvPlugin(PluginBase):
     _suffix_re = 'CC\d:'
     _html_docs = ['NDPluginColorConvert.html']
     _plugin_type = 'NDPluginColorConvert'
+    _default_configuration_attrs = (PluginBase._default_configuration_attrs +
+                                    ('color_mode_out', 'false_color'))
 
     color_mode_out = C(SignalWithRBV, 'ColorModeOut')
     false_color = C(SignalWithRBV, 'FalseColor')
@@ -502,7 +504,10 @@ class OverlayPlugin(PluginBase):
     _suffix_re = 'Over\d:'
     _html_docs = ['NDPluginOverlay.html']
     _plugin_type = 'NDPluginOverlay'
-
+    _default_configuration_attrs = (PluginBase._default_configuration_attrs + (
+        'overlay_1', 'overlay_2', 'overlay_3', 'overlay_4', 'overlay_5',
+        'overlay_6', 'overlay_7', 'overlay_8')
+    )
     max_size = DDC(ad_group(EpicsSignalRO,
                             (('x', 'MaxSizeX_RBV'),
                              ('y', 'MaxSizeY_RBV'))),
@@ -651,7 +656,18 @@ class FilePlugin(PluginBase, GenerateDatumInterface):
     _default_suffix = ''
     _html_docs = ['NDPluginFile.html']
     _plugin_type = 'NDPluginFile'
-
+    _default_configuration_attrs = (PluginBase._default_configuration_attrs + (
+        'auto_increment',
+        'auto_save',
+        'file_format',
+        'file_name',
+        'file_path',
+        'file_path_exists',
+        'file_template',
+        'file_write_mode',
+        'full_file_name',
+        'num_capture'
+        ))
     FileWriteMode = enum(SINGLE=0, CAPTURE=1, STREAM=2)
 
     auto_increment = C(SignalWithRBV, 'AutoIncrement')
@@ -695,6 +711,8 @@ class JPEGPlugin(FilePlugin):
     _suffix_re = 'JPEG\d:'
     _html_docs = ['NDFileJPEG.html']
     _plugin_type = 'NDFileJPEG'
+    _default_configuration_attrs = (FilePlugin._default_configuration_attrs + (
+        'jpeg_quality',))
 
     jpeg_quality = C(SignalWithRBV, 'JPEGQuality')
 
@@ -705,6 +723,8 @@ class NexusPlugin(FilePlugin):
     _html_docs = ['NDFileNexus.html']
     # _plugin_type = 'NDPluginFile'  # TODO was this ever fixed?
     _plugin_type = 'NDPluginNexus'
+    _default_configuration_attrs = (FilePlugin._default_configuration_attrs + (
+        'template_file_name', 'template_file_path'))
 
     file_template_valid = C(EpicsSignal, 'FileTemplateValid')
     template_file_name = C(SignalWithRBV, 'TemplateFileName', string=True)
@@ -716,6 +736,27 @@ class HDF5Plugin(FilePlugin):
     _suffix_re = 'HDF\d:'
     _html_docs = ['NDFileHDF5.html']
     _plugin_type = 'NDFileHDF5'
+
+    _default_configuration_attrs = (FilePlugin._default_configuration_attrs + (
+        'boundary_align',
+        'boundary_threshold',
+        'compression',
+        'data_bits_offset',
+        'extra_dim_name',
+        'extra_dim_size',
+        'io_speed',
+        'num_col_chunks',
+        'num_data_bits',
+        'num_extra_dims',
+        'num_frames_chunks',
+        'num_frames_flush',
+        'num_row_chunks',
+        'run_time',
+        'store_attr',
+        'store_perform',
+        'szip_num_pixels',
+        'zlevel')
+    )
 
     boundary_align = C(SignalWithRBV, 'BoundaryAlign')
     boundary_threshold = C(SignalWithRBV, 'BoundaryThreshold')
@@ -780,6 +821,8 @@ class MagickPlugin(FilePlugin):
     _suffix_re = 'Magick\d:'
     _html_docs = ['NDFileMagick']  # sic., no html extension
     _plugin_type = 'NDFileMagick'
+    _default_configuration_attrs = (FilePlugin._default_configuration_attrs + (
+        'bit_depth', 'compress_type', 'quality',))
 
     bit_depth = C(SignalWithRBV, 'BitDepth')
     compress_type = C(SignalWithRBV, 'CompressType')

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -66,6 +66,16 @@ class PluginBase(ADBase):
         # Without this, no array data is sent to the plugins.
         super().__init__(*args, configuration_attrs=configuration_attrs,
                          **kwargs)
+        # make sure it is the right type of plugin
+        if (self._plugin_type is not None and
+                not self.plugin_type.get().startswith(self._plugin_type)):
+            raise TypeError('Trying to use {!r} class which is for {!r} '
+                            'plugin type for a plugin that reports being '
+                            'of type {!r} with base prefix '
+                            '{!r}'.format(self.__class__.__name__,
+                                          self._plugin_type,
+                                          self.plugin_type.get(), self.prefix))
+
         self.stage_sigs[self.blocking_callbacks] = 'Yes'
         if self.parent is not None and hasattr(self.parent, 'cam'):
             self.stage_sigs.update([(self.parent.cam.array_callbacks, 1),

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -126,17 +126,22 @@ class PluginBase(ADBase):
     def read_configuration(self):
         ret = super().read_configuration()
 
-        source_port = self.nd_array_port.get()
-        source_plugin = self.root.get_plugin_by_asyn_port(source_port)
-        ret.update(source_plugin.read_configuration())
+        ret.update(self.source_plugin.read_configuration())
 
         return ret
+
+    @property
+    def source_plugin(self):
+        '''The PluginBase object that is the asyn source for this plugin.
+        '''
+        source_port = self.nd_array_port.get()
+        source_plugin = self.root.get_plugin_by_asyn_port(source_port)
+        return source_plugin
 
     def describe_configuration(self):
         ret = super().describe_configuration()
 
-        source_port = self.nd_array_port.get()
-        source_plugin = self.root.get_plugin_by_asyn_port(source_port)
+        source_plugin = self.source_plugin
         ret.update(source_plugin.describe_configuration())
 
         return ret

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -140,9 +140,10 @@ class PluginBase(ADBase):
                      doc='The array size')
 
     bayer_pattern = C(EpicsSignalRO, 'BayerPattern_RBV')
-    blocking_callbacks = C(SignalWithRBV, 'BlockingCallbacks')
+    blocking_callbacks = C(SignalWithRBV, 'BlockingCallbacks',
+                           string=True)
     color_mode = C(EpicsSignalRO, 'ColorMode_RBV')
-    data_type = C(EpicsSignalRO, 'DataType_RBV')
+    data_type = C(EpicsSignalRO, 'DataType_RBV', string=True)
 
     dim0_sa = C(EpicsSignal, 'Dim0SA')
     dim1_sa = C(EpicsSignal, 'Dim1SA')
@@ -155,7 +156,7 @@ class PluginBase(ADBase):
 
     dimensions = C(EpicsSignalRO, 'Dimensions_RBV')
     dropped_arrays = C(SignalWithRBV, 'DroppedArrays')
-    enable = C(SignalWithRBV, 'EnableCallbacks')
+    enable = C(SignalWithRBV, 'EnableCallbacks', string=True)
     min_callback_time = C(SignalWithRBV, 'MinCallbackTime')
     nd_array_address = C(SignalWithRBV, 'NDArrayAddress')
     nd_array_port = C(SignalWithRBV, 'NDArrayPort')
@@ -216,10 +217,10 @@ class StatsPlugin(PluginBase):
                              ('y', 'CentroidY_RBV'))),
                    doc='The centroid XY')
 
-    compute_centroid = C(SignalWithRBV, 'ComputeCentroid')
-    compute_histogram = C(SignalWithRBV, 'ComputeHistogram')
-    compute_profiles = C(SignalWithRBV, 'ComputeProfiles')
-    compute_statistics = C(SignalWithRBV, 'ComputeStatistics')
+    compute_centroid = C(SignalWithRBV, 'ComputeCentroid', string=True)
+    compute_histogram = C(SignalWithRBV, 'ComputeHistogram', string=True)
+    compute_profiles = C(SignalWithRBV, 'ComputeProfiles', string=True)
+    compute_statistics = C(SignalWithRBV, 'ComputeStatistics', string=True)
 
     cursor = DDC(ad_group(SignalWithRBV,
                           (('x', 'CursorX'),
@@ -290,7 +291,7 @@ class StatsPlugin(PluginBase):
                                 ('y', 'TSCentroidY'))),
                       doc='Time series centroid in XY')
 
-    ts_control = C(EpicsSignal, 'TSControl')
+    ts_control = C(EpicsSignal, 'TSControl', string=True)
     ts_current_point = C(EpicsSignal, 'TSCurrentPoint')
     ts_max_value = C(EpicsSignal, 'TSMaxValue')
 
@@ -368,11 +369,11 @@ class ProcessPlugin(PluginBase):
         'valid_background',
         'valid_flat_field')
     )
-    auto_offset_scale = C(EpicsSignal, 'AutoOffsetScale')
-    auto_reset_filter = C(SignalWithRBV, 'AutoResetFilter')
+    auto_offset_scale = C(EpicsSignal, 'AutoOffsetScale', string=True)
+    auto_reset_filter = C(SignalWithRBV, 'AutoResetFilter', string=True)
     average_seq = C(EpicsSignal, 'AverageSeq')
     copy_to_filter_seq = C(EpicsSignal, 'CopyToFilterSeq')
-    data_type_out = C(SignalWithRBV, 'DataTypeOut')
+    data_type_out = C(SignalWithRBV, 'DataTypeOut', string=True)
     difference_seq = C(EpicsSignal, 'DifferenceSeq')
     enable_background = C(SignalWithRBV, 'EnableBackground', string=True)
     enable_filter = C(SignalWithRBV, 'EnableFilter', string=True)
@@ -390,8 +391,8 @@ class ProcessPlugin(PluginBase):
 
     foffset = C(SignalWithRBV, 'FOffset')
     fscale = C(SignalWithRBV, 'FScale')
-    filter_callbacks = C(SignalWithRBV, 'FilterCallbacks')
-    filter_type = C(EpicsSignal, 'FilterType')
+    filter_callbacks = C(SignalWithRBV, 'FilterCallbacks', string=True)
+    filter_type = C(EpicsSignal, 'FilterType', string=True)
     filter_type_seq = C(EpicsSignal, 'FilterTypeSeq')
     high_clip = C(SignalWithRBV, 'HighClip')
     low_clip = C(SignalWithRBV, 'LowClip')
@@ -424,8 +425,8 @@ class ProcessPlugin(PluginBase):
     scale = C(SignalWithRBV, 'Scale')
     scale_flat_field = C(SignalWithRBV, 'ScaleFlatField')
     sum_seq = C(EpicsSignal, 'SumSeq')
-    valid_background = C(EpicsSignalRO, 'ValidBackground_RBV')
-    valid_flat_field = C(EpicsSignalRO, 'ValidFlatField_RBV')
+    valid_background = C(EpicsSignalRO, 'ValidBackground_RBV', string=True)
+    valid_flat_field = C(EpicsSignalRO, 'ValidFlatField_RBV', string=True)
 
 
 class Overlay(ADBase):
@@ -493,7 +494,7 @@ class ROIPlugin(PluginBase):
     _html_docs = ['NDPluginROI.html']
     _plugin_type = 'NDPluginROI'
     _default_configuration_attrs = (PluginBase._default_configuration_attrs + (
-        'roi_enable', 'name_', 'bin_', 'data_type_out', )
+        'roi_enable', 'name_', 'bin_', 'data_type_out', 'enable_scale')
     )
     array_size = DDC(ad_group(EpicsSignalRO,
                               (('x', 'ArraySizeX_RBV'),
@@ -514,8 +515,8 @@ class ROIPlugin(PluginBase):
                          ('z', 'BinZ'))),
                doc='Binning in XYZ')
 
-    data_type_out = C(SignalWithRBV, 'DataTypeOut')
-    enable_scale = C(SignalWithRBV, 'EnableScale')
+    data_type_out = C(SignalWithRBV, 'DataTypeOut', string=True)
+    enable_scale = C(SignalWithRBV, 'EnableScale', string=True)
 
     roi_enable = DDC(ad_group(SignalWithRBV,
                               (('x', 'EnableX'),

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -63,7 +63,7 @@ class PluginBase(ADBase):
         # Turn array callbacks on during staging.
         # Without this, no array data is sent to the plugins.
         super().__init__(*args, **kwargs)
-
+        self.stage_sigs[self.blocking_callbacks] = 'Yes'
         if self.parent is not None and hasattr(self.parent, 'cam'):
             self.stage_sigs.update([(self.parent.cam.array_callbacks, 1),
                                    ])

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -18,6 +18,10 @@ def _current_fields(attr_base, field_base, range_, **kwargs):
 
 
 class QuadEM(SingleTrigger, DetectorBase):
+    # This is needed because ophyd verifies that it can see all
+    # of the nodes in the asyn pipeline, however these IOCs do not
+    # expose their port name via a PV, but nevertheless server as the
+    # root node for the plugins.
     port_name = Cpt(Signal, value='NSLS2_EM')
     model = Cpt(EpicsSignalRO, 'Model')
     firmware = Cpt(EpicsSignalRO, 'Firmware')

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -1,10 +1,10 @@
 from collections import OrderedDict
 
 from . import (EpicsSignalRO, EpicsSignal, Component as Cpt,
-               DynamicDeviceComponent as DDCpt)
+               DynamicDeviceComponent as DDCpt, Signal)
 from .areadetector import (ADComponent as ADCpt, EpicsSignalWithRBV,
-                            ImagePlugin, StatsPlugin, DetectorBase,
-                            SingleTrigger)
+                           ImagePlugin, StatsPlugin, DetectorBase,
+                           SingleTrigger)
 
 
 def _current_fields(attr_base, field_base, range_, **kwargs):
@@ -16,7 +16,9 @@ def _current_fields(attr_base, field_base, range_, **kwargs):
 
     return defn
 
+
 class QuadEM(SingleTrigger, DetectorBase):
+    port_name = Cpt(Signal, value='NSLS2_EM')
     model = Cpt(EpicsSignalRO, 'Model')
     firmware = Cpt(EpicsSignalRO, 'Firmware')
 
@@ -40,7 +42,7 @@ class QuadEM(SingleTrigger, DetectorBase):
     hvi_readback = Cpt(EpicsSignalRO, 'HVIReadback')
 
     values_per_read = Cpt(EpicsSignalWithRBV, 'ValuesPerRead')
-    sample_time = Cpt(EpicsSignalRO, 'SampleTime_RBV') # yay for consistency
+    sample_time = Cpt(EpicsSignalRO, 'SampleTime_RBV')  # yay for consistency
     averaging_time = Cpt(EpicsSignalWithRBV, 'AveragingTime')
     num_average = Cpt(EpicsSignalRO, 'NumAverage_RBV')
     num_averaged = Cpt(EpicsSignalRO, 'NumAveraged_RBV')
@@ -51,12 +53,13 @@ class QuadEM(SingleTrigger, DetectorBase):
     trigger_mode = Cpt(EpicsSignal, 'TriggerMode')
     reset = Cpt(EpicsSignal, 'Reset')
 
-    current_names = DDCpt(_current_fields('ch', 'CurrentName', range(1,5),
+    current_names = DDCpt(_current_fields('ch', 'CurrentName', range(1, 5),
                                           string=True))
-    current_offsets = DDCpt(_current_fields('ch', 'CurrentOffset', range(1,5)))
+    current_offsets = DDCpt(_current_fields('ch', 'CurrentOffset',
+                                            range(1, 5)))
     current_offset_calcs = DDCpt(_current_fields('ch', 'ComputeCurrentOffset',
-                                                 range(1,5)))
-    current_scales = DDCpt(_current_fields('ch', 'CurrentScale', range(1,5)))
+                                                 range(1, 5)))
+    current_scales = DDCpt(_current_fields('ch', 'CurrentScale', range(1, 5)))
 
     position_offset_x = Cpt(EpicsSignal, 'PositionOffsetX')
     position_offset_y = Cpt(EpicsSignal, 'PositionOffsetY')
@@ -73,15 +76,14 @@ class QuadEM(SingleTrigger, DetectorBase):
     current3 = ADCpt(StatsPlugin, 'Current3:')
     current4 = ADCpt(StatsPlugin, 'Current4:')
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stage_sigs.update([(self.acquire, 0), # if acquiring, stop
-                                (self.acquire_mode, 2) # single mode
-                               ])
+        self.stage_sigs.update([(self.acquire, 0),  # if acquiring, stop
+                                (self.acquire_mode, 2)  # single mode
+                                ])
         self._acquisition_signal = self.acquire
 
         self.configuration_attrs = ['integration_time', 'averaging_time']
-        self.read_attrs = ['current1.mean_value','current2.mean_value',
-                            'current3.mean_value','current4.mean_value']
+        self.read_attrs = ['current1.mean_value', 'current2.mean_value',
+                           'current3.mean_value', 'current4.mean_value']

--- a/tests/test_areadetector.py
+++ b/tests/test_areadetector.py
@@ -213,6 +213,7 @@ def test_default_configuration_smoke():
 
     d = MyDetector(prefix, name='d')
     {n: getattr(d, n).read_configuration() for n in d.signal_names}
+    {n: getattr(d, n).describe_configuration() for n in d.signal_names}
 
 
 @pytest.mark.parametrize('plugin',

--- a/tests/test_areadetector.py
+++ b/tests/test_areadetector.py
@@ -4,7 +4,7 @@ import pytest
 from io import StringIO
 
 from ophyd import (SimDetector, TIFFPlugin, HDF5Plugin, SingleTrigger,
-                   StatsPlugin, ROIPlugin)
+                   StatsPlugin, ROIPlugin, ProcessPlugin)
 from ophyd.areadetector.util import stub_templates
 from ophyd.device import (Component as Cpt, )
 
@@ -134,7 +134,7 @@ def test_invalid_plugins():
     assert ['AARDVARK'] == det.missing_plugins()
 
 
-def test_get_plugin_by_port():
+def test_get_plugin_by_asyn_port():
     class MyDetector(SingleTrigger, SimDetector):
         tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
         stats1 = Cpt(StatsPlugin, 'Stats1:')
@@ -148,9 +148,32 @@ def test_get_plugin_by_port():
 
     assert det.validate_asyn_ports()
 
-    assert det.tiff1 is det.get_plugin_by_port(det.tiff1.port_name.get())
-    assert det.cam is det.get_plugin_by_port(det.cam.port_name.get())
-    assert det.roi1 is det.get_plugin_by_port(det.roi1.port_name.get())
+    assert det.tiff1 is det.get_plugin_by_asyn_port(det.tiff1.port_name.get())
+    assert det.cam is det.get_plugin_by_asyn_port(det.cam.port_name.get())
+    assert det.roi1 is det.get_plugin_by_asyn_port(det.roi1.port_name.get())
+
+
+def test_read_configuration_smoke():
+    class MyDetector(SingleTrigger, SimDetector):
+        stats1 = Cpt(StatsPlugin, 'Stats1:')
+        porc1 = Cpt(ProcessPlugin, 'ROI1:')
+        roi1 = Cpt(ROIPlugin, 'ROI1:')
+
+    det = MyDetector(prefix, name='test')
+    det.proc1.nd_array_port.put(det.cam.port_name.get())
+    det.roi1.nd_array_port.put(det.proc1.port_name.get())
+    det.stats1.nd_array_port.put(det.roi1.port_name.get())
+    # smoke test
+    det.stage()
+    conf = det.stats1.read_configuration()
+    desc = det.stats1.describe_configuration()
+    det.unstage()
+    for k in conf:
+        assert k in desc
+
+    assert len(conf) > 0
+    assert len(conf) == len(desc)
+
 
 from . import main
 is_main = (__name__ == '__main__')

--- a/tests/test_areadetector.py
+++ b/tests/test_areadetector.py
@@ -3,9 +3,17 @@ import logging
 import pytest
 from io import StringIO
 
-from ophyd import (SimDetector, TIFFPlugin, HDF5Plugin, SingleTrigger,
-                   StatsPlugin, ROIPlugin, ProcessPlugin, Component,
+from ophyd import (SimDetector, SingleTrigger, Component,
                    DynamicDeviceComponent)
+from ophyd.areadetector.plugins import (ImagePlugin, StatsPlugin,
+                                        ColorConvPlugin,
+                                        ProcessPlugin, OverlayPlugin,
+                                        ROIPlugin, TransformPlugin,
+                                        NetCDFPlugin, TIFFPlugin, JPEGPlugin,
+                                        HDF5Plugin,
+                                        MagickPlugin)
+# we do not have nexus installed on our test IOC
+# from ophyd.areadetector.plugins import NexusPlugin
 from ophyd.areadetector.plugins import PluginBase
 from ophyd.areadetector.util import stub_templates
 from ophyd.device import (Component as Cpt, )
@@ -97,11 +105,14 @@ def test_hdf5_plugin():
     class MyDet(SimDetector):
         p = Cpt(HDF5Plugin, suffix='HDF1:')
 
-    d = MyDet(prefix)
+    d = MyDet(prefix, name='d')
     d.p.file_path.put('/tmp')
     d.p.file_name.put('--')
     d.p.warmup()
     d.stage()
+    print(d.p.read_configuration())
+    d.p.describe_configuration()
+    d.unstage()
 
 
 def test_subclass():
@@ -182,6 +193,26 @@ def test_read_configuration_smoke():
 
     assert len(conf) > 0
     assert len(conf) == len(desc)
+
+
+def test_default_configuration_smoke():
+    class MyDetector(SimDetector):
+        imageplugin = Cpt(ImagePlugin, ImagePlugin._default_suffix)
+        statsplugin = Cpt(StatsPlugin, StatsPlugin._default_suffix)
+        colorconvplugin = Cpt(ColorConvPlugin, ColorConvPlugin._default_suffix)
+        processplugin = Cpt(ProcessPlugin, ProcessPlugin._default_suffix)
+        overlayplugin = Cpt(OverlayPlugin, OverlayPlugin._default_suffix)
+        roiplugin = Cpt(ROIPlugin, ROIPlugin._default_suffix)
+        transformplugin = Cpt(TransformPlugin, TransformPlugin._default_suffix)
+        netcdfplugin = Cpt(NetCDFPlugin, NetCDFPlugin._default_suffix)
+        tiffplugin = Cpt(TIFFPlugin, TIFFPlugin._default_suffix)
+        jpegplugin = Cpt(JPEGPlugin, JPEGPlugin._default_suffix)
+        # nexusplugin = Cpt(NexusPlugin, NexusPlugin._default_suffix)
+        hdf5plugin = Cpt(HDF5Plugin, HDF5Plugin._default_suffix)
+        magickplugin = Cpt(MagickPlugin, MagickPlugin._default_suffix)
+
+    d = MyDetector(prefix, name='d')
+    {n: getattr(d, n).read_configuration() for n in d.signal_names}
 
 
 @pytest.mark.parametrize('plugin',

--- a/tests/test_areadetector.py
+++ b/tests/test_areadetector.py
@@ -10,8 +10,6 @@ from ophyd.device import (Component as Cpt, )
 
 logger = logging.getLogger(__name__)
 
-
-
 prefix = 'XF:31IDA-BI{Cam:Tbl}'
 ad_path = '/epics/support/areaDetector/1-9-1/ADApp/Db/'
 
@@ -156,7 +154,7 @@ def test_get_plugin_by_asyn_port():
 def test_read_configuration_smoke():
     class MyDetector(SingleTrigger, SimDetector):
         stats1 = Cpt(StatsPlugin, 'Stats1:')
-        porc1 = Cpt(ProcessPlugin, 'ROI1:')
+        proc1 = Cpt(ProcessPlugin, 'Proc1:')
         roi1 = Cpt(ROIPlugin, 'ROI1:')
 
     det = MyDetector(prefix, name='test')


### PR DESCRIPTION
 - find all plugins that ophyd knows about
 - find a plugin by port name
 - validate that the full processing path is know to ophyd
 - turn blocking_callbacks on by default in all Plugin stage methods