### PR TITLE
FIX: Size-link does not exist on the ROI plugin

### DIFF
--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -597,11 +597,6 @@ class ROIPlugin(PluginBase):
                          ('z', 'SizeZ'))),
                doc='Size of the ROI in XYZ')
 
-    size_link = DDC(ad_group(EpicsSignal,
-                             (('x', 'SizeXLink'),
-                              ('y', 'SizeYLink'))),
-                    doc='Size link in XY')
-
 
 class TransformPlugin(PluginBase):
     _default_suffix = 'Trans1:'


### PR DESCRIPTION
Looks like a copy/paste error from ages ago