### PR TITLE
FIX: For QuadEM the port_name must be different

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -21,7 +21,7 @@ from .device import (Device, Component, FormattedComponent,
                      DynamicDeviceComponent)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
-from .quadem import QuadEM
+from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM
 
 # Areadetector-related
 from .areadetector import *

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -22,7 +22,8 @@ class QuadEM(SingleTrigger, DetectorBase):
     # of the nodes in the asyn pipeline, however these IOCs do not
     # expose their port name via a PV, but nevertheless server as the
     # root node for the plugins.
-    port_name = Cpt(Signal, value='NSLS2_EM')
+    # Leaving this port_name here for compatibility
+    port_name = Cpt(Signal, value='NSLS_EM')
     model = Cpt(EpicsSignalRO, 'Model')
     firmware = Cpt(EpicsSignalRO, 'Firmware')
 
@@ -91,3 +92,16 @@ class QuadEM(SingleTrigger, DetectorBase):
         self.configuration_attrs = ['integration_time', 'averaging_time']
         self.read_attrs = ['current1.mean_value', 'current2.mean_value',
                            'current3.mean_value', 'current4.mean_value']
+
+
+class NSLS_EM(QuadEM):
+    port_name = Cpt(Signal, value='NSLS_EM')
+
+
+class TetrAMM(QuadEM):
+    port_name = Cpt(Signal, value='TetrAMM')
+
+
+class APS_EM(QuadEM):
+    port_name = Cpt(Signal, value='APS_EM')
+

--- a/tests/test_quadem.py
+++ b/tests/test_quadem.py
@@ -14,11 +14,11 @@ logger = logging.getLogger(__name__)
 def quadem():
     class FakeStats(StatsPlugin):
         plugin_type = Cpt(Signal, value=StatsPlugin._plugin_type)
-        nd_array_port = Cpt(Signal, value='NSLS2_EM')
+        nd_array_port = Cpt(Signal, value='NSLS_EM')
 
     class FakeImage(ImagePlugin):
         plugin_type = Cpt(Signal, value=ImagePlugin._plugin_type)
-        nd_array_port = Cpt(Signal, value='NSLS2_EM')
+        nd_array_port = Cpt(Signal, value='NSLS_EM')
 
     class FakeQuadEM(QuadEM):
         image = Cpt(FakeImage, 'image1:')


### PR DESCRIPTION
 for each type of device (NSLS_EM, TetrAMM, APS_EM, etc).