### PR TITLE
ENH: Avoid the use of wrong PVs prefix when defining a motor

### DIFF
--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -40,6 +40,7 @@ class EpicsMotor(Device, PositionerBase):
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
     '''
+    record_type = Cpt(EpicsSignalRO, '.RTYP', string=True)
     user_offset = Cpt(EpicsSignal, '.OFF')
     user_readback = Cpt(EpicsSignalRO, '.RBV')
     user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
@@ -68,6 +69,9 @@ class EpicsMotor(Device, PositionerBase):
         super().__init__(prefix, read_attrs=read_attrs,
                          configuration_attrs=configuration_attrs,
                          name=name, parent=parent, **kwargs)
+
+        if self.record_type.get() != "motor":
+            raise ValueError("Prefix: {} is not a valid Epics Motor Record.")
 
         # Make the default alias for the user_readback the name of the
         # motor itself.

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -71,7 +71,7 @@ class EpicsMotor(Device, PositionerBase):
                          name=name, parent=parent, **kwargs)
 
         if self.record_type.get() != "motor":
-            raise ValueError("Prefix: {} is not a valid Epics Motor Record.")
+            raise ValueError("Prefix: {} is not a valid Epics Motor Record.".format(prefix))
 
         # Make the default alias for the user_readback the name of the
         # motor itself.

--- a/tests/test_epicsmotor.py
+++ b/tests/test_epicsmotor.py
@@ -41,6 +41,19 @@ def test_timeout(motor):
     assert motor.timeout == 20.0
 
 
+def test_record_type():
+    sim_pv = 'XF:31IDA-OP{Tbl-Ax:X1}Mtr'
+
+    m = TestEpicsMotor(sim_pv, name='epicsmotor', settle_time=0.1,
+                       timeout=10.0)
+
+    sim_pv = 'XF:31IDA-OP{Tbl-Ax:X1}Mtr.VAL'
+
+    with pytest.raises(ValueError):
+        TestEpicsMotor(sim_pv, name='epicsmotor', settle_time=0.1,
+                       timeout=10.0)
+
+
 def test_connected(motor):
     assert motor.connected
 


### PR DESCRIPTION
The following situation happened at LIX beamline:
```
sh=EpicsMotor('XF:16IDC-ES:Sol{Enc-Ax:XL}Mtr.VAL', name='hand_low_encl')
```

This resulted on every kind of weird issues and also one accident with a motor.
This simple fix will block this sort of situation.