### PR TITLE
MNT: validate there is at most 1 '.' in pvname

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -9,7 +9,7 @@ import epics
 from .utils import (ReadOnlyError, LimitError)
 from .utils.epics_pvs import (pv_form, waveform_to_string,
                               raise_if_disconnected, data_type, data_shape,
-                              AlarmStatus, AlarmSeverity)
+                              AlarmStatus, AlarmSeverity, validate_pv_name)
 from .ophydobj import OphydObject
 from .status import Status
 from .utils import set_and_wait
@@ -344,6 +344,7 @@ class EpicsSignalBase(Signal):
 
         super().__init__(name=name, **kwargs)
 
+        validate_pv_name(read_pv)
         self._read_pv = epics.PV(read_pv, form=pv_form,
                                  auto_monitor=auto_monitor,
                                  **pv_kw)
@@ -655,6 +656,7 @@ class EpicsSignal(EpicsSignalBase):
                          auto_monitor=auto_monitor, name=name, **kwargs)
 
         if write_pv is not None:
+            validate_pv_name(write_pv)
             self._write_pv = epics.PV(write_pv, form=pv_form,
                                       auto_monitor=self._auto_monitor,
                                       **self._pv_kw)

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -6,7 +6,6 @@
 .. module:: ophyd.utils.epics_pvs
    :synopsis:
 '''
-
 from enum import IntEnum
 import time as ttime
 import ctypes
@@ -19,7 +18,7 @@ import numpy as np
 
 import epics
 
-from .errors import DisconnectedError
+from .errors import DisconnectedError, OpException
 
 __all__ = ['split_record_field',
            'strip_field',
@@ -32,6 +31,10 @@ __all__ = ['split_record_field',
            ]
 
 logger = logging.getLogger(__name__)
+
+
+class BadPVName(ValueError, OpException):
+    ...
 
 
 class AlarmSeverity(IntEnum):
@@ -64,6 +67,22 @@ class AlarmStatus(IntEnum):
     SIMM = 19
     READ_ACCESS = 20
     WRITE_ACCESS = 21
+
+
+def validate_pv_name(pv):
+    '''Validates that there is not more than 1 '.' in pv
+
+    Parameters
+    ----------
+    pv : str
+        The pv to check
+
+    Raises
+    ------
+    BadPVName
+    '''
+    if pv.count('.') > 1:
+        raise BadPVName(pv)
 
 
 def split_record_field(pv):
@@ -429,6 +448,7 @@ _type_map = {'number': (float, ),
              'integer': (int, ),
              }
 
+
 def data_type(val):
     '''Determine data-type of val.
 
@@ -442,6 +462,7 @@ def data_type(val):
             return json_type
     # no legit type found...
     raise ValueError('{} not a valid type (int, float, ndarray, str)'.format(val))
+
 
 def data_shape(val):
     '''Determine data-shape (dimensions)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import os
 import logging
 import unittest
@@ -116,6 +117,11 @@ def test_make_dir_tree():
 
         assert os.path.join(tempdir, '2016', '03', '04') in paths
         assert os.path.join(tempdir, '2016', '02', '29') in paths
+
+
+def test_valid_pvname():
+    with pytest.raises(epics_utils.BadPVName):
+        epics_utils.validate_pv_name('this.will.fail')
 
 
 from . import main


### PR DESCRIPTION
Avoid typos where a PV.FIELD is passed into a Device which represents
an record (and hence is going to use that pvname as a base to find other
fields).

attn @hhslepicka 