### PR TITLE
ENH: Allow stage_sigs keys to be attr names, not attrs.

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -424,8 +424,19 @@ class BlueskyInterface:
         logger.debug("Staging %s", self.name)
         self._staged = Staged.partially
 
+        # Resolve any stage_sigs keys given as strings: 'a.b' -> self.a.b
+        stage_sigs = OrderedDict()
+        for k, v in self.stage_sigs.items():
+            if isinstance(k, str):
+                attr = self
+                for attrname in k.split('.'):
+                    attr = getattr(attr, attrname)
+                stage_sigs[attr] = v
+            else:
+                stage_sigs[k] = v
+
         # Read current values, to be restored by unstage()
-        original_vals = {sig: sig.get() for sig, _ in self.stage_sigs.items()}
+        original_vals = {sig: sig.get() for sig, _ in stage_sigs.items()}
 
         # We will add signals and values from original_vals to
         # self._original_vals one at a time so that
@@ -434,7 +445,7 @@ class BlueskyInterface:
         # Apply settings.
         devices_staged = []
         try:
-            for sig, val in self.stage_sigs.items():
+            for sig, val in stage_sigs.items():
                 logger.debug("Setting %s to %r (original value: %r)", self.name,
                              val, original_vals[sig])
                 set_and_wait(sig, val)

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -428,10 +428,8 @@ class BlueskyInterface:
         stage_sigs = OrderedDict()
         for k, v in self.stage_sigs.items():
             if isinstance(k, str):
-                attr = self
-                for attrname in k.split('.'):
-                    attr = getattr(attr, attrname)
-                stage_sigs[attr] = v
+                # Device.__getattr__ handles nested attr lookup
+                stage_sigs[getattr(self, k)] = v
             else:
                 stage_sigs[k] = v
 


### PR DESCRIPTION
Speaking of lazy instantiation, devices with `stage_sigs` typically break lazy instantiation by including references to signals in the `__init__`, such as:

```python
class AD(AreaDetector):

    def __init__(self, ...):
        super().__init__(...)
        self.stage_sigs[self.cam.whatever] = 5
```

This PR allows the keys in stage sigs to be strings, like so:

```python
class AD(AreaDetector):

    def __init__(self, ...):
        super().__init__(...)
        self.stage_sigs['cam.whatever'] = 5
```

Here, the attribute lookup / signal connection happens during `stage()` instead of during `__init__`. This should significantly speedup reload times for IPython profile scripts that include many area detectors.

The old usage is still allowed. In cases where the key refers to something that is not an attribute of `self`, it will still be the only option.