### PR TITLE
ENH: pseudo lock

### DIFF
--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -303,6 +303,11 @@ class PseudoPositioner(Device, SoftPositioner):
         ``read_configuration()``) and to adjust via ``configure()``
     name : str, optional
         The name of the device
+    egu : str, optional
+        The user-defined engineering units for the whole PseudoPositioner
+    auto_target : bool, optional
+        Automatically set the target position of PseudoSingle devices when
+        moving to a single PseudoPosition
     parent : instance or None
         The instance of the parent device, if applicable
     settle_time : float, optional
@@ -311,13 +316,15 @@ class PseudoPositioner(Device, SoftPositioner):
         The default timeout to use for motion requests, in seconds.
     '''
     def __init__(self, prefix, *, concurrent=True, read_attrs=None,
-                 configuration_attrs=None, name=None, egu='', **kwargs):
+                 configuration_attrs=None, name=None, egu='', auto_target=True,
+                 **kwargs):
 
         self._finished_lock = threading.RLock()
         self._concurrent = bool(concurrent)
         self._finish_thread = None
         self._real_waiting = []
         self._move_queue = []
+        self.auto_target = auto_target
 
         if self.__class__ is PseudoPositioner:
             raise TypeError('PseudoPositioner must be subclassed with the '
@@ -730,6 +737,11 @@ class PseudoPositioner(Device, SoftPositioner):
         RuntimeError
             If motion fails other than timing out
         '''
+        if self.auto_target:
+            # in auto-target mode, we update the setpoints of the PseudoSingles
+            # on every motion of the PseudoPositioner
+            for positioner, single_pos in zip(self._pseudo, position):
+                positioner._target = single_pos
         return super().move(position, wait=wait, timeout=timeout,
                             moved_cb=moved_cb)
 


### PR DESCRIPTION
Two additional features: 

Per-PseudoSingle, use initial inverse-calculated position as target (setpoint)
Per-PseudoPositioner, auto-target: automatically set the target (setpoint) of all PseudoSingles when a full PseudoPosition is specified (e.g., setting an hkl position would set the targets of the three pseudo axes)

cc @cmazzoli @ambarb 