### PR TITLE
FIX: Fix a issue when a ADBase device has no port name and validate_a…

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -235,7 +235,7 @@ class ADBase(Device):
     def validate_asyn_ports(self):
         g, port_map = self.get_asyn_digraph()
         g = nx.Graph(g)
-        if nx.number_connected_components(g) != 1:
+        if port_map and nx.number_connected_components(g) != 1:
             missing_plugins = self.missing_plugins()
             raise RuntimeError('The asyn ports {!r} are used by plugins '
                                'that ophyd is aware of but the source plugin '

--- a/tests/test_areadetector.py
+++ b/tests/test_areadetector.py
@@ -155,6 +155,17 @@ def test_invalid_plugins():
 
     assert ['AARDVARK'] == det.missing_plugins()
 
+def test_validete_plugins_no_portname():
+    class MyDetector(SingleTrigger, SimDetector):
+        roi1 = Cpt(ROIPlugin, 'ROI1:')
+        over1 = Cpt(OverlayPlugin, 'Over1:')
+
+    det = MyDetector(prefix)
+
+    det.roi1.nd_array_port.put(det.cam.port_name.get())
+    det.over1.nd_array_port.put(det.roi1.port_name.get())
+
+    det.validate_asyn_ports()
 
 def test_get_plugin_by_asyn_port():
     class MyDetector(SingleTrigger, SimDetector):


### PR DESCRIPTION
…syn_port is called with it. E.g., OverlayPlugin and Overlay object, the first one has the port but its child no.

Still need to add tests for this case.

Attn. @danielballan 
