### PR TITLE
FIX: protect against mutating subs list while iterating

### DIFF
--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -139,7 +139,7 @@ class OphydObject:
         # callback at a later time (e.g., when a new subscription is made)
         self._sub_cache[sub_type] = (tuple(args), dict(kwargs))
 
-        for cb in self._subs[sub_type]:
+        for cb in tuple(self._subs[sub_type]):
             self._run_sub(cb, *args, **kwargs)
 
     def subscribe(self, cb, event_type=None, run=True):

--- a/tests/test_ophydobj.py
+++ b/tests/test_ophydobj.py
@@ -74,24 +74,30 @@ def test_self_removing_cb():
 
     test_obj = TestObj(name='name', parent=None)
 
-    hit_A = False
-    hit_B = False
+    hit_A = 0
+    hit_B = 0
 
     def remover(obj, **kwargs):
         nonlocal hit_A
-        hit_A = True
+        hit_A += 1
         obj.clear_sub(remover)
 
     def sitter(**kwargs):
         nonlocal hit_B
-        hit_B = True
+        hit_B += 1
 
     test_obj.subscribe(remover, 'value')
     test_obj.subscribe(sitter, 'value')
     test_obj._run_subs(sub_type='value')
 
-    assert hit_A
-    assert hit_B
+    assert hit_A == 1
+    assert hit_B == 1
+
+    test_obj._run_subs(sub_type='value')
+
+    assert hit_A == 1
+    assert hit_B == 2
+
 
 is_main = (__name__ == '__main__')
 main(is_main)

--- a/tests/test_ophydobj.py
+++ b/tests/test_ophydobj.py
@@ -68,5 +68,30 @@ def test_ophydobj():
     assert parent.connected
 
 
+def test_self_removing_cb():
+    class TestObj(OphydObject):
+        SUB_TEST = 'value'
+
+    test_obj = TestObj(name='name', parent=None)
+
+    hit_A = False
+    hit_B = False
+
+    def remover(obj, **kwargs):
+        nonlocal hit_A
+        hit_A = True
+        obj.clear_sub(remover)
+
+    def sitter(**kwargs):
+        nonlocal hit_B
+        hit_B = True
+
+    test_obj.subscribe(remover, 'value')
+    test_obj.subscribe(sitter, 'value')
+    test_obj._run_subs(sub_type='value')
+
+    assert hit_A
+    assert hit_B
+
 is_main = (__name__ == '__main__')
 main(is_main)


### PR DESCRIPTION
If a subscription is added or removed while iterating over the list of
callbacks to run, odd things (like skipping running callbacks) may
happen.  To prevent this keep a local (shallow) copy of the callbacks to
iterate over.

attn @gjwillms 