### PR TITLE
REF: Make use of #351 to make more devices lazy.

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -141,10 +141,10 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
 class FileStorePluginBase(FileStoreBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stage_sigs.update([(self.auto_increment, 'Yes'),
-                                (self.array_counter, 0),
-                                (self.auto_save, 'Yes'),
-                                (self.num_capture, 0),
+        self.stage_sigs.update([('auto_increment', 'Yes'),
+                                ('array_counter', 0),
+                                ('auto_save', 'Yes'),
+                                ('num_capture', 0),
                                 ])
         self._fn = None
 
@@ -199,9 +199,9 @@ class FileStoreHDF5(FileStorePluginBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filestore_spec = 'AD_HDF5'  # spec name stored in resource doc
-        self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.h5'),
-                                (self.file_write_mode, 'Stream'),
-                                (self.capture, 1)
+        self.stage_sigs.update([('file_template', '%s%s_%6.6d.h5'),
+                                ('file_write_mode', 'Stream'),
+                                ('capture', 1)
                                 ])
 
     def get_frames_per_point(self):
@@ -219,8 +219,8 @@ class FileStoreTIFF(FileStorePluginBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filestore_spec = 'AD_TIFF'  # spec name stored in resource doc
-        self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.tiff'),
-                                (self.file_write_mode, 'Single'),
+        self.stage_sigs.update([('file_template', '%s%s_%6.6d.tiff'),
+                                ('file_write_mode', 'Single'),
                                 ])
         # 'Single' file_write_mode means one image : one file.
         # It does NOT mean that 'num_images' is ignored.
@@ -249,15 +249,15 @@ class FileStoreTIFFSquashing(FileStorePluginBase):
         self._proc_name = proc_name
         cam = getattr(self.parent, self._cam_name)
         proc = getattr(self.parent, self._proc_name)
-        self.stage_sigs.update([(self.file_template, '%s%s_%6.6d.tiff'),
-                                (self.file_write_mode, 'Single'),
+        self.stage_sigs.update([('file_template', '%s%s_%6.6d.tiff'),
+                                ('file_write_mode', 'Single'),
                                 (proc.nd_array_port, cam.port_name.get()),
                                 (proc.reset_filter, 1),
                                 (proc.enable_filter, 1),
                                 (proc.filter_type, 'Average'),
                                 (proc.auto_reset_filter, 1),
                                 (proc.filter_callbacks, 1),
-                                (self.nd_array_port, proc.port_name.get())
+                                ('nd_array_port', proc.port_name.get())
                                 ])
         # 'Single' file_write_mode means one image : one file.
         # It does NOT mean that 'num_images' is ignored.

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -76,9 +76,9 @@ class PluginBase(ADBase):
                                           self._plugin_type,
                                           self.plugin_type.get(), self.prefix))
 
-        self.stage_sigs[self.blocking_callbacks] = 'Yes'
+        self.stage_sigs['blocking_callbacks'] = 'Yes'
         if self.parent is not None and hasattr(self.parent, 'cam'):
-            self.stage_sigs.update([(self.parent.cam.array_callbacks, 1),
+            self.stage_sigs.update([('parent.cam.array_callbacks', 1),
                                     ])
 
     _default_configuration_attrs = ('port_name', 'nd_array_port', 'enable',

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -33,8 +33,8 @@ class TriggerBase(BlueskyInterface):
         # careful here: quadEM devices have areadetector components but,
         # they have no 'cam' plugin. See QuadEM initializer.
         if hasattr(self, 'cam'):
-            self.stage_sigs.update([(self.cam.acquire, 0),  # If acquiring, stop
-                                    (self.cam.image_mode, 1),  # 'Multiple' mode
+            self.stage_sigs.update([('cam.acquire', 0),  # If acquiring, stop
+                                    ('cam.image_mode', 1),  # 'Multiple' mode
                                     ])
             self._acquisition_signal = self.cam.acquire
 

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -86,7 +86,7 @@ class EpicsMCARecord(Device):
                          name=name, parent=parent, **kwargs)
 
         # could arguably be made a configuration_attr instead...
-        self.stage_sigs[self.mode] = 'PHA'
+        self.stage_sigs['mode'] = 'PHA'
 
     def stop(self, *, success=False):
         self.stop_signal.put(1)

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -84,8 +84,8 @@ class QuadEM(SingleTrigger, DetectorBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.stage_sigs.update([(self.acquire, 0),  # if acquiring, stop
-                                (self.acquire_mode, 2)  # single mode
+        self.stage_sigs.update([('acquire', 0),  # if acquiring, stop
+                                ('acquire_mode', 2)  # single mode
                                 ])
         self._acquisition_signal = self.acquire
 

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -44,4 +44,4 @@ class EpicsScaler(Device):
                          configuration_attrs=configuration_attrs,
                          name=name, parent=parent, **kwargs)
 
-        self.stage_sigs.update([(self.count_mode, 0)])
+        self.stage_sigs.update([('count_mode', 0)])

--- a/tests/test_quadem.py
+++ b/tests/test_quadem.py
@@ -45,25 +45,31 @@ def quadem():
             EpicsSignalWithRBVs... :-(
     '''
     for sig in em.stage_sigs:
+        sig = getattr(em, sig)
         sig._read_pv = sig._write_pv
 
     for sig in em.image.stage_sigs:
+        sig = getattr(em.image, sig)
         sig._read_pv = sig._write_pv
     em.image.enable._read_pv = em.image.enable._write_pv
 
     for sig in em.current1.stage_sigs:
+        sig = getattr(em.current1, sig)
         sig._read_pv = sig._write_pv
     em.current1.enable._read_pv = em.current1.enable._write_pv
 
     for sig in em.current2.stage_sigs:
+        sig = getattr(em.current2, sig)
         sig._read_pv = sig._write_pv
     em.current2.enable._read_pv = em.current2.enable._write_pv
 
     for sig in em.current3.stage_sigs:
+        sig = getattr(em.current3, sig)
         sig._read_pv = sig._write_pv
     em.current3.enable._read_pv = em.current3.enable._write_pv
 
     for sig in em.current4.stage_sigs:
+        sig = getattr(em.current4, sig)
         sig._read_pv = sig._write_pv
     em.current4.enable._read_pv = em.current4.enable._write_pv
     ''' End: Ugly Hack '''


### PR DESCRIPTION
In #351, we added the option to specify stage_sigs as attribute *names* as opposed to attributes. This restores the intended lazy-connecting feature of ophyd objects, where they don't need to connect to all their signals at __init__ time.

This PR takes advantage of that in more places in the codebase. It should improve the startup time of IPython at SIX and others. 