### PR TITLE
BLD/CI: List requirements descriptively; test pip-based build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,11 @@ cache:
 
 matrix:
   include:
-    - python: 3.4
-      env: BUILD_DOCS=false
     - python: 3.5
+      env: BUILD_DOCS=false CONDA_ENV=1
+    - python: 3.6
+      env: BUILD_DOCS=false CONDA_ENV=1
+    - python: 3.6
       env: BUILD_DOCS=true
 
 before_install:
@@ -33,7 +35,6 @@ before_install:
   - export EPICS_CA_AUTO_ADDR_LIST="no"
   - export EPICS_CA_MAX_ARRAY_BYTES=10000000
   - export DOCKERIMAGE="klauer/epics-docker"
-  - export CONDA_ENV="testenv"
 
   - perl --version
   - git fetch --unshallow
@@ -43,34 +44,28 @@ before_install:
   - docker run -d -p $DOCKER0_IP:5064:5064/tcp -p $DOCKER0_IP:5065:5065/udp --name epics_iocs ${DOCKERIMAGE}
   - docker ps -a
 
-  # INSTALL CONDA
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - "./miniconda.sh -b -p /home/travis/mc"
-  - env
-
-  - export PATH=/home/travis/mc/bin:$PATH
-  - conda config --set always_yes true
-  - conda update conda --yes
-  - conda install conda-build anaconda-client jinja2
-  - conda config --add channels lightsource2-dev
-  - conda config --add channels lightsource2
-  - conda config --add channels soft-matter
-  - conda config --add channels defaults
-
-  # MAKE THE CONDA RECIPE
-  - conda create -n $CONDA_ENV python=$TRAVIS_PYTHON_VERSION -c defaults
-  - source activate $CONDA_ENV
-
-  # need to reactivate after installing epics-base so that the EPICS_BASE env
-  # var is set
-  - source activate $CONDA_ENV
+  - |
+    if [ $CONDA_ENV ]; then
+       wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+       chmod +x miniconda.sh
+       ./miniconda.sh -b -p /home/travis/mc
+       export PATH=/home/travis/mc/bin:$PATH
+       conda config --set show_channel_urls True
+       conda config --set always_yes True
+    fi
 
 install:
-  # INSTALL OPHYD
-  - conda install numpy pyepics prettytable filestore ipython pyolog networkx
-  - conda install readline -c lightsource2
-  - pip install coveralls pytest pytest-cov codecov
+  - |
+    if [ $CONDA_ENV ]; then
+       conda create -n testenv python=$TRAVIS_PYTHON_VERSION numpy pyepics prettytable filestore ipython pyolog networkx -c lightsource2-tag -c conda-forge -c soft-matter -c defaults --override-channels
+       source activate testenv
+       conda install readline -c lightsource2
+       source activate testenv
+    else
+       sudo bash install_epics_on_travis.sh
+       pip install -r requirements.txt
+    fi
+  - pip install -r test-requirements.txt
   - python setup.py develop
 
   # setup some path environment variables for epics

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - python: 3.6
       env: BUILD_DOCS=false CONDA_ENV=1
     - python: 3.6
-      env: BUILD_DOCS=true
+      env: BUILD_DOCS=true EPICS_DEB_DIST="jessie/staging"
 
 before_install:
   - git clone https://github.com/NSLS-II/nsls2-ci --branch master --single-branch ~/ci_scripts
@@ -62,7 +62,7 @@ install:
        conda install readline -c lightsource2
        source activate testenv
     else
-       sudo bash install_epics_on_travis.sh
+       sudo -E bash install_epics_on_travis.sh
        pip install -r requirements.txt
     fi
   - pip install -r test-requirements.txt

--- a/install_epics_on_travis.sh
+++ b/install_epics_on_travis.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+sudo apt-get update
+sudo apt-get install -yq wget
+wget --quiet http://epics.nsls2.bnl.gov/debian/repo-key.pub -O - | apt-key add -
+echo "deb http://epics.nsls2.bnl.gov/debian/ jessie/staging main contrib" | tee /etc/apt/sources.list.d/nsls2.list
+sudo apt-get update
+sudo apt-get install -yq epics-dev

--- a/install_epics_on_travis.sh
+++ b/install_epics_on_travis.sh
@@ -3,6 +3,6 @@ set -e
 sudo apt-get update
 sudo apt-get install -yq wget
 wget --quiet http://epics.nsls2.bnl.gov/debian/repo-key.pub -O - | apt-key add -
-echo "deb http://epics.nsls2.bnl.gov/debian/ jessie/staging main contrib" | tee /etc/apt/sources.list.d/nsls2.list
+echo "deb http://epics.nsls2.bnl.gov/debian/ $EPICS_DEB_DIST main contrib" | tee /etc/apt/sources.list.d/nsls2.list
 sudo apt-get update
 sudo apt-get install -yq epics-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+ipython
+networkx
+numpy
+prettytable
+pyepics
+git+https://github.com/NSLS-II/filestore#egg=filestore

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,18 @@
 from setuptools import (setup, find_packages)
 import versioneer
 
+with open('requirements.txt') as f:
+    requirements = f.read().split()
+
+# Temporary hack until filestore is on PyPI, needed because
+# `pip install -r requirements.txt` works with git URLs, but `install_requires`
+# does not.
+requirements = [r for r in requirements if not r.startswith('git+')]
+print("User must install https://github.com/NSLS-II/filestore manually")
 
 setup(name='ophyd',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       license='BSD',
+      install_requires=requirements,
       packages=find_packages())

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,5 @@
+codecov
+coveralls
+pytest
+pytest-cov
+git+https://github.com/NSLS-II/pyOlog#egg=pyOlog


### PR DESCRIPTION
* Add tests on 3.6; drop tests on 3.4 (superceding #386)
* Add a test using pip install and EPICS from Debian (no conda).
* Use requirements.txt and test-requirements.txt.

This applies the same Travis cleanup @tacaswell and I applied to bluesky in https://github.com/NSLS-II/bluesky/pull/660 and https://github.com/NSLS-II/bluesky/pull/668