### PR TITLE
FIX: ADBase stage should only validate_asyn_ports after staging the signals

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -152,8 +152,13 @@ class ADBase(Device):
                 match_fcn(attr=attr, signal=getattr(self, attr), doc=doc)
 
     def stage(self, *args, **kwargs):
-        self.validate_asyn_ports()
-        return super().stage(*args, **kwargs)
+        ret = super().stage(*args, **kwargs)
+        try:
+            self.validate_asyn_ports()
+        except RuntimeError as err:
+            self.unstage(*args, **kwargs)
+            raise err
+        return ret
 
     def get_plugin_by_asyn_port(self, port_name):
         '''Get the plugin which has the given asyn port name


### PR DESCRIPTION
This allows one to change for instance the nd_array_port in a plugin and have a correct validation on the asyn ports.

Here is the use case for that...

At the normal operation the camera is pointing to a stream of data that is limited in terms of data rate and sometimes with binning
when we want to collect data we want to switch the plugin nd_array_port to the CAM stream which is the raw data coming as fast as the camera can acquire.

Attn @danielballan @tacaswell 