### PR TITLE
FIX: unbreak the homing tests

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -211,7 +211,7 @@ class DeviceStatus(StatusBase):
 
     def _handle_failure(self):
         super()._handle_failure()
-        logger.debug('Trying to stop %s', str(self.device))
+        logger.debug('Trying to stop %s', repr(self.device))
         self.device.stop()
 
     def __str__(self):


### PR DESCRIPTION
What seems to be happening is that computing the fancy string
representation was taking too long and the motor was finishing it's
move.  Or something.