### PR TITLE
BLD: Update requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-git+https://github.com/NSLS-II/databroker#egg=databroker
 networkx
 numpy
 pyepics

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,5 @@
 codecov
 coveralls
+databroker
 pytest
 pytest-cov
-git+https://github.com/NSLS-II/pyOlog#egg=pyOlog
-h5py
-tifffile
-pims


### PR DESCRIPTION
- databroker is optional and available on PyPI
- pyOlog is no longer used in tests
- tifffile, pims, h5py will come in through test dependency on databroker