### PR TITLE
ENH: SubscriptionStatus

### DIFF
--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -257,44 +257,42 @@ class SubscriptionStatus(DeviceStatus):
     """
     def __init__(self, device, callback, event_type=None,
                  timeout=None, settle_time=None):
-        #Store device and attribute information
-        self.device    = device
-        self.callback  = callback
+        # Store device and attribute information
+        self.device = device
+        self.callback = callback
 
-        #Start timeout thread in the background
+        # Start timeout thread in the background
         super().__init__(device, timeout=timeout, settle_time=settle_time)
 
-        #Subscribe callback and run initial check
+        # Subscribe callback and run initial check
         self.device.subscribe(self.check_value,
                               event_type=event_type,
                               run=True)
-
 
     def check_value(self, *args, **kwargs):
         """
         Update the status object
         """
-        #Get attribute from device
+        # Get attribute from device
         try:
             success = self.callback(*args, **kwargs)
 
-        #Do not fail silently
+        # Do not fail silently
         except Exception as e:
             logger.error(e)
             raise
 
-        #If successfull indicate completion
+        # If successfull indicate completion
         if success:
             self._finished(success=True)
-
 
     def _finished(self, *args, **kwargs):
         """
         Reimplemented finished command to cleanup callback subscription
         """
-        #Clear callback
+        # Clear callback
         self.device.clear_sub(self.check_value)
-        #Run completion
+        # Run completion
         super()._finished(**kwargs)
 
 

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 from ophyd import Device
-from ophyd.status  import StatusBase, SubscriptionStatus
+from ophyd.status import StatusBase, SubscriptionStatus
 
 
 def _setup_st():
@@ -11,7 +11,6 @@ def _setup_st():
         state['done'] = True
     repr(st)
     return st, state, cb
-
 
 
 def test_status_post():
@@ -37,26 +36,25 @@ def test_status_pre():
 
 
 def test_subscription_status():
-    #Arbitrary device
+    # Arbitrary device
     d = Device("Tst:Prefix")
-    #Mock callback
+    # Mock callback
     m = Mock()
 
-    #Full fake callback signature
+    # Full fake callback signature
     def cb(*args, done=False, **kwargs):
-        #Run mock callback
+        # Run mock callback
         m()
-        #Return finished or not
+        # Return finished or not
         return done
 
     status = SubscriptionStatus(d, cb, event_type=d.SUB_ACQ_DONE)
 
-    #Run callbacks but do not mark as complete
+    # Run callbacks but do not mark as complete
     d._run_subs(sub_type=d.SUB_ACQ_DONE, done=False)
     assert m.called
     assert not status.done and not status.success
 
-    #Run callbacks and mark as complete
+    # Run callbacks and mark as complete
     d._run_subs(sub_type=d.SUB_ACQ_DONE, done=True)
     assert status.done and status.success
-

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -1,4 +1,6 @@
-from ophyd.status import StatusBase
+from unittest.mock import Mock
+from ophyd import Device
+from ophyd.status  import StatusBase, SubscriptionStatus
 
 
 def _setup_st():
@@ -32,3 +34,29 @@ def test_status_pre():
     st.finished_cb = cb
     assert 'done' in state
     assert state['done']
+
+
+def test_subscription_status():
+    #Arbitrary device
+    d = Device("Tst:Prefix")
+    #Mock callback
+    m = Mock()
+
+    #Full fake callback signature
+    def cb(*args, done=False, **kwargs):
+        #Run mock callback
+        m()
+        #Return finished or not
+        return done
+
+    status = SubscriptionStatus(d, cb, event_type=d.SUB_ACQ_DONE)
+
+    #Run callbacks but do not mark as complete
+    d._run_subs(sub_type=d.SUB_ACQ_DONE, done=False)
+    assert m.called
+    assert not status.done and not status.success
+
+    #Run callbacks and mark as complete
+    d._run_subs(sub_type=d.SUB_ACQ_DONE, done=True)
+    assert status.done and status.success
+


### PR DESCRIPTION
Created a `SubscriptionStatus` object that uses the built-in Ophyd event system to update itself
## Description
The `SubscriptionStatus` is a subclass of the `DeviceStatus` object that accepts a device, event_type and callback. The callback is registered at initialization and automatically cleared from the device after the status finishes via completion or timeout.
 
## Motivation and Context
While `PositionerBase` handles any device that has a `DMOV` type flag to subscribe to, I found myself rewriting a lot of code for simpler devices that did not have this flag. For instance if you wanted to set signal A, and wait for signal B and C to reach specific values you were stuck implementing this on a class by class basis. Now you can just write a simple function to check the state of these PVs and summarize it in a boolean, then plug it straight into the `SubscriptionStatus`. I also like that this solution avoids unnecessary polling and spawning additional threads.

## How Has This Been Tested?
I wrote a basic test inside `ophyd/tests/test_status.py` but saw afterwards that `ophyd/tests/test_ophydobj.py` has most of the actual `Status` tests. Let me know if you want it moved. I also didn't put a test in where this status fails, tried to avoid long waits and/or race conditions.

## General Thoughts
There are only two ways the status will mark itself finished, either via timeout or a success. I could see this causing some strange behavior, but I don't think there is a clean way around it if the device does not have a DMOV flag you can use. For example, if you create your status with a timeout of `None`, then check it later, you have no idea if it is your request that finished it or a subsequent call or motion of the device triggered the completion. I considered putting in a default `timeout` but decided against it. 