### PR TITLE
API: Stop acquiring when device is stopped (via pause for example).

### DIFF
--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -143,6 +143,10 @@ class SingleTrigger(TriggerBase):
             # Negative-going edge means an acquisition just finished.
             self._status._finished()
 
+    def stop(self):
+        self._acquisition_signal.put(0)
+
+
 
 class MultiTrigger(TriggerBase):
     """This trigger mixin class can take multiple acquisitions per trigger.


### PR DESCRIPTION
The addition of progress bars has made it more obvious that detectors
continue acquiring after the RunEngine is paused. I 'fixed' that
locally at CSX but I *think* it's a sensible default and should move
into ophyd here.

Open for debate!