### PR TITLE
ENH: Switch the wait log message in set_and_wait from info level to debug level

### DIFF
--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -408,8 +408,8 @@ def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
         within_str = ''
 
     while not _compare_maybe_enum(val, current_value, es, atol, rtol):
-        logger.info("Waiting for %s to be set from %r to %r%s...",
-                    signal.name, current_value, val, within_str)
+        logger.debug("Waiting for %s to be set from %r to %r%s...",
+                     signal.name, current_value, val, within_str)
         ttime.sleep(poll_time)
         if poll_time < 0.1:
             poll_time *= 2  # logarithmic back-off


### PR DESCRIPTION
Small change. This is actually the only location in ophyd outside of tests and examples with a call to logger.info. The info level is often used for on-screen prints, and this one was spamming me today during `stage()` and `unstage()`, so I'd like to request that it be moved to debug. I don't think a user wants a print out every time we check that the put wait has finished, as this may produce log messages every 0.1s.