### PR TITLE
ENH/API: Make status objects support __and__

### DIFF
--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -186,7 +186,7 @@ class PositionerBase(OphydObject):
                             settle_time=self._settle_time)
 
         if moved_cb is not None:
-            status.finished_cb = functools.partial(moved_cb, obj=self)
+            status.add_callback(functools.partial(moved_cb, obj=self))
             # the status object will run this callback when finished
 
         self.subscribe(status._finished, event_type=self._SUB_REQ_DONE,

--- a/ophyd/status.py
+++ b/ophyd/status.py
@@ -1,6 +1,8 @@
+from collections import deque
 import time
 from threading import RLock
 from functools import wraps
+from warnings import warn
 
 import logging
 import threading
@@ -9,13 +11,17 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+class UseNewProperty(RuntimeError):
+    ...
+
+
 # This is used below by StatusBase.
 def _locked(func):
     "an decorator for running a method with the instance's lock"
     @wraps(func)
     def f(self, *args, **kwargs):
         with self._lock:
-            func(self, *args, **kwargs)
+            return func(self, *args, **kwargs)
 
     return f
 
@@ -38,7 +44,7 @@ class StatusBase:
                  success=False):
         super().__init__()
         self._lock = RLock()
-        self._cb = None
+        self._callbacks = deque()
         self.done = done
         self.success = success
         self.timeout = None
@@ -98,9 +104,9 @@ class StatusBase:
             self.done = True
             self._settled()
 
-            if self._cb is not None:
-                self._cb()
-                self._cb = None
+            for cb in self._callbacks:
+                cb()
+            self._callbacks.clear()
 
     def _finished(self, success=True, **kwargs):
         '''Inform the status object that it is done and if it succeeded
@@ -133,26 +139,98 @@ class StatusBase:
             self._settle_then_run_callbacks(success=success)
 
     @property
-    def finished_cb(self):
+    def callbacks(self):
         """
-        Callback to be run when the status is marked as finished
+        Callbacks to be run when the status is marked as finished
 
         The callback has no arguments ::
 
             def cb() -> None:
 
         """
-        return self._cb
+        return self._callbacks
+
+    @property
+    @_locked
+    def finished_cb(self):
+        if len(self.callbacks) == 1:
+            warn("The property `finished_cb` is deprecated, and must raise "
+                 "an error if a status object has multiple callbacks. Use "
+                 "the `callbacks` property instead.")
+            cb, = self.callbacks
+            assert cb is not None
+            return cb
+        else:
+            raise UseNewProperty("The deprecated `finished_cb` property "
+                                 "cannot be used for status objects that have "
+                                 "multiple callbacks. Use the `callbacks` "
+                                 "property instead.")
+
+    @_locked
+    def add_callback(self, cb):
+        if self.done:
+            cb()
+        else:
+            self._callbacks.append(cb)
 
     @finished_cb.setter
     @_locked
     def finished_cb(self, cb):
-        if self._cb is not None:
-            raise RuntimeError("Can not change the call back")
-        if self.done:
-            cb()
+        if not self.callbacks:
+            warn("The setter `finished_cb` is deprecated, and must raise "
+                 "an error if a status object already has one callback. Use "
+                 "the `add_callback` method instead.")
+            self.add_callback(cb)
         else:
-            self._cb = cb
+            raise UseNewProperty("The deprecated `finished_cb` setter cannot "
+                                 "be used for status objects that already "
+                                 "have one callback. Use the `add_callbacks` "
+                                 "method instead.")
+
+    def __and__(self, other):
+        """
+        Returns a new 'composite' status object, AndStatus,
+        with the same base API.
+
+        It will finish when both `self` or `other` finish.
+        """
+        return AndStatus(self, other)
+
+
+class AndStatus(StatusBase):
+    "a Status that has composes two other Status objects using logical and"
+    def __init__(self, left, right, **kwargs):
+        super().__init__(**kwargs)
+        self.left = left
+        self.right = right
+
+        def inner():
+            with self._lock:
+                with self.left._lock:
+                    with self.right._lock:
+                        l_success = self.left.success
+                        r_success = self.right.success
+                        l_done = self.left.done
+                        r_done = self.right.done
+
+                        # At least one is done.
+                        # If it failed, do not wait for the second one.
+                        if (not l_success) and l_done:
+                            self._finished(success=False)
+                        elif (not r_success) and r_done:
+                            self._finished(success=False)
+
+                        elif l_success and r_success and l_done and r_done:
+                            # Both are done, successfully.
+                            self._finished(success=True)
+                        # Else one is done, successfully, and we wait for #2,
+                        # when this function will be called again.
+
+        self.left.add_callback(inner)
+        self.right.add_callback(inner)
+
+    def __repr__(self):
+        return "({self.left!r} & {self.right!r})".format(self=self)
 
     def __str__(self):
         return ('{0}(done={1.done}, '

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -1,36 +1,68 @@
 from unittest.mock import Mock
 from ophyd import Device
-from ophyd.status import StatusBase, SubscriptionStatus
+from ophyd.status import StatusBase, SubscriptionStatus, UseNewProperty
+import pytest
 
 
-def _setup_st():
-    st = StatusBase()
+def _setup_state_and_cb():
     state = {}
 
     def cb():
         state['done'] = True
-    repr(st)
-    return st, state, cb
+    return state, cb
 
 
 def test_status_post():
-    st, state, cb = _setup_st()
+    st = StatusBase()
+    state, cb = _setup_state_and_cb()
 
     assert 'done' not in state
-    st.finished_cb = cb
+    st.add_callback(cb)
     assert 'done' not in state
     st._finished()
     assert 'done' in state
     assert state['done']
 
 
+def test_status_legacy_finished_cb():
+    st = StatusBase()
+    state1, cb1 = _setup_state_and_cb()
+    state2, cb2 = _setup_state_and_cb()
+
+    # The old setter works for adding one callback.
+    with pytest.warns(UserWarning):
+        st.finished_cb = cb1
+    # The new getter works.
+    st.callbacks == set([cb1])
+    # And the old getter works so long as there is just one callback set.
+    with pytest.warns(UserWarning):
+        assert st.finished_cb is cb1
+    # As before, the old setter cannot be updated once set.
+    with pytest.raises(UseNewProperty):
+        st.finished_cb = cb2
+    # But, using the new method, we can add another callback.
+    st.add_callback(cb2)
+    # Once we have two callbacks, the getter does not work.
+    with pytest.raises(UseNewProperty):
+        st.finished_cb
+    # But the new getter does.
+    st.callbacks == set([cb1, cb2])
+
+    assert 'done' not in state1
+    assert 'done' not in state2
+    st._finished()
+    assert 'done' in state1
+    assert 'done' in state2
+
+
 def test_status_pre():
-    st, state, cb = _setup_st()
+    st = StatusBase()
+    state, cb = _setup_state_and_cb()
 
     st._finished()
 
     assert 'done' not in state
-    st.finished_cb = cb
+    st.add_callback(cb)
     assert 'done' in state
     assert state['done']
 
@@ -58,3 +90,38 @@ def test_subscription_status():
     # Run callbacks and mark as complete
     d._run_subs(sub_type=d.SUB_ACQ_DONE, done=True)
     assert status.done and status.success
+
+
+def test_and():
+    st1 = StatusBase()
+    st2 = StatusBase()
+    st3 = st1 & st2
+    # make sure deep recursion works
+    st4 = st1 & st3
+    st5 = st3 & st4
+    state1, cb1 = _setup_state_and_cb()
+    state2, cb2 = _setup_state_and_cb()
+    state3, cb3 = _setup_state_and_cb()
+    state4, cb4 = _setup_state_and_cb()
+    state5, cb5 = _setup_state_and_cb()
+    st1.add_callback(cb1)
+    st2.add_callback(cb2)
+    st3.add_callback(cb3)
+    st4.add_callback(cb4)
+    st5.add_callback(cb5)
+    st1._finished()
+    assert 'done' in state1
+    assert 'done' not in state2
+    assert 'done' not in state3
+    assert 'done' not in state4
+    assert 'done' not in state5
+    st2._finished()
+    assert 'done' in state3
+    assert 'done' in state4
+    assert 'done' in state5
+    assert st3.left is st1
+    assert st3.right is st2
+    assert st4.left is st1
+    assert st4.right is st3
+    assert st5.left is st3
+    assert st5.right is st4


### PR DESCRIPTION
I'm reviving this very old branch because I keep seeing places
where it seems useful to me, including most recently a use case
that @swilkins found.

Unlike my first attempt, this one is fully backward-compatible.