### PR TITLE
API: Deprecate signal_names; rename it to component_names.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ script:
 
 
   # running tests
-  - py.test -v --cov=ophyd --cov-report term-missing
+  - python run_tests.py --cov=ophyd --cov-report term-missing
 
   - |
     if [ $BUILD_DOCS == true ]; then

--- a/doc/source/device-overview.rst
+++ b/doc/source/device-overview.rst
@@ -117,7 +117,7 @@ and static information about the object
  ===========================  ========================================================
  :attr:`prefix`               'base' of PV name, used when building components
  ---------------------------  --------------------------------------------------------
- :attr:`signal_names`         List of the names components on this device.
+ :attr:`component_names`      List of the names components on this device.
 	                      Direct children only
  ---------------------------  --------------------------------------------------------
  :attr:`trigger_signals`      Signals for use in `Implicit Triggering`_

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -1,6 +1,17 @@
 Release Notes
 -------------
 
+0.8.0
+=====
+
+Deprecations
+************
+
+* The ``signal_names`` attribute of devices has been renamed
+  ``component_names`` for clarity because it may include a mixture of Signals
+  and Devices -- any Components. The old name now issues a warning when
+  accessed, and it may be removed in a future release of ophyd.
+
 0.7.0
 =====
 

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -127,7 +127,7 @@ class ScalerCH(Device):
         self.channels.configuration_attrs = ['chan01']
 
     def match_names(self):
-        for s in self.channels.signal_names:
+        for s in self.channels.component_names:
             getattr(self.channels, s).match_name()
 
     def select_channels(self, chan_names):
@@ -142,7 +142,7 @@ class ScalerCH(Device):
         '''
         self.match_names()
         name_map = {getattr(self.channels, s).name.get(): s
-                    for s in self.channels.signal_names}
+                    for s in self.channels.component_names}
 
         read_attrs = ['chan01']  # always include time
         for ch in chan_names:

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -96,7 +96,7 @@ def test_detector():
     det.find_signal('a', use_re=True, f=StringIO())
     det.find_signal('a', case_sensitive=True, f=StringIO())
     det.find_signal('a', use_re=True, case_sensitive=True, f=StringIO())
-    det.signal_names
+    det.component_names
     det.report
 
     cam = det.cam
@@ -279,8 +279,8 @@ def test_default_configuration_smoke():
 
     d = MyDetector(prefix, name='d')
     d.stage()
-    {n: getattr(d, n).read_configuration() for n in d.signal_names}
-    {n: getattr(d, n).describe_configuration() for n in d.signal_names}
+    {n: getattr(d, n).read_configuration() for n in d.component_names}
+    {n: getattr(d, n).describe_configuration() for n in d.component_names}
     d.unstage()
 
 

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -92,9 +92,9 @@ class DeviceTests(unittest.TestCase):
         self.assertIs(device.subsub2.parent, device)
         self.assertIs(device.cpt3.parent, device)
 
-        self.assertEquals(device.sub1.signal_names,
+        self.assertEquals(device.sub1.component_names,
                           ['cpt1', 'cpt2', 'cpt3'])
-        self.assertEquals(device.subsub2.signal_names,
+        self.assertEquals(device.subsub2.component_names,
                           ['cpt1', 'cpt2', 'cpt3', 'cpt4'])
 
         conf_keys = {'dev_sub1_cpt1_conf',    # from sub1.*
@@ -179,7 +179,7 @@ class DeviceTests(unittest.TestCase):
         self.assertTrue(dev.sub3.subsub.success)
 
     def test_name_shadowing(self):
-        RESERVED_ATTRS = ['name', 'parent', 'signal_names', '_signals',
+        RESERVED_ATTRS = ['name', 'parent', 'component_names', '_signals',
                           'read_attrs', 'configuration_attrs', '_sig_attrs',
                           '_sub_devices']
 
@@ -296,3 +296,15 @@ def test_array_attribute_signal():
     np.testing.assert_array_equal(dev.attrsig.get(), init_value)
     assert isinstance(dev.attrsig.get(), np.ndarray)
     assert isinstance(dev.attrsig.get(), np.ndarray)
+
+
+def test_signal_names():
+
+    class MyDevice(Device):
+        cpt = Component(FakeSignal, 'suffix')
+
+    d = MyDevice('')
+    with pytest.warns(UserWarning):
+        signal_names = d.signal_names
+
+    assert signal_names is d.component_names

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import sys
+import pytest
+
+if __name__ == '__main__':
+    sys.exit(pytest.main(sys.argv[1:]))


### PR DESCRIPTION
Closes #448