### PR TITLE
CI: Turn off parallel building for now because it is broken.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W -j 4
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build


### PR DESCRIPTION
There seems to be an issue with sphinx's parallelization feature
that is not specific to our projects. This PR removes the `-j` option
to get things working again until it is resolved.