### PR TITLE
API: make the name keyword to device a required keyword only arg

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -676,13 +676,13 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
     ----------
     prefix : str
         The PV prefix for all components of the device
+    name : str, keyword only
+        The name of the device
     read_attrs : sequence of attribute names
         the components to include in a normal reading (i.e., in ``read()``)
     configuration_attrs : sequence of attribute names
         the components to be read less often (i.e., in
         ``read_configuration()``) and to adjust via ``configure()``
-    name : str, optional
-        The name of the device
     parent : instance or None
         The instance of the parent device, if applicable
     """
@@ -697,8 +697,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
     # If `None`, defaults to `[]`
     _default_configuration_attrs = None
 
-    def __init__(self, prefix='', *, read_attrs=None, configuration_attrs=None,
-                 name=None, parent=None, **kwargs):
+    def __init__(self, prefix='', *, name,
+                 read_attrs=None, configuration_attrs=None,
+                 parent=None, **kwargs):
         # Store EpicsSignal objects (only created once they are accessed)
         self._signals = {}
 
@@ -706,9 +707,6 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         if self.component_names and prefix is None:
             raise ValueError('Must specify prefix if device signals are being '
                              'used')
-
-        if name is None:
-            name = prefix
 
         super().__init__(name=name, parent=parent, **kwargs)
 

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -73,7 +73,7 @@ def test_basic():
     class MyDetector(SingleTrigger, SimDetector):
         tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
 
-    det = MyDetector(prefix)
+    det = MyDetector(prefix, name='test')
     det.wait_for_connection()
     det.stage()
     det.trigger()
@@ -90,7 +90,7 @@ def test_stubbing():
 
 
 def test_detector():
-    det = SimDetector(prefix)
+    det = SimDetector(prefix, name='test')
 
     det.find_signal('a', f=StringIO())
     det.find_signal('a', use_re=True, f=StringIO())
@@ -127,7 +127,7 @@ def test_tiff_plugin():
     class TestDet(SimDetector):
         p = Cpt(TIFFPlugin, 'TIFF1:')
 
-    det = TestDet(prefix)
+    det = TestDet(prefix, name='test')
     plugin = det.p
 
     plugin.file_template.put('%s%s_%3.3d.tif')
@@ -155,7 +155,7 @@ def test_subclass():
     class MyDetector(SimDetector):
         tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
 
-    det = MyDetector(prefix)
+    det = MyDetector(prefix, name='test')
     det.wait_for_connection()
 
     print(det.describe())
@@ -166,7 +166,7 @@ def test_getattr():
     class MyDetector(SimDetector):
         tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
 
-    det = MyDetector(prefix)
+    det = MyDetector(prefix, name='test')
     assert getattr(det, 'tiff1.name') == det.tiff1.name
     assert getattr(det, 'tiff1') is det.tiff1
     # raise
@@ -178,7 +178,7 @@ def test_invalid_plugins():
         tiff1 = Cpt(TIFFPlugin, 'TIFF1:')
         stats1 = Cpt(StatsPlugin, 'Stats1:')
 
-    det = MyDetector(prefix)
+    det = MyDetector(prefix, name='test')
     det.wait_for_connection()
     det.tiff1.nd_array_port.put(det.cam.port_name.get())
     det.stats1.nd_array_port.put('AARDVARK')
@@ -197,7 +197,7 @@ def test_validete_plugins_no_portname():
         roi1 = Cpt(ROIPlugin, 'ROI1:')
         over1 = Cpt(OverlayPlugin, 'Over1:')
 
-    det = MyDetector(prefix)
+    det = MyDetector(prefix, name='test')
 
     det.roi1.nd_array_port.put(det.cam.port_name.get())
     det.over1.nd_array_port.put(det.roi1.port_name.get())
@@ -211,7 +211,7 @@ def test_get_plugin_by_asyn_port():
         stats1 = Cpt(StatsPlugin, 'Stats1:')
         roi1 = Cpt(ROIPlugin, 'ROI1:')
 
-    det = MyDetector(prefix)
+    det = MyDetector(prefix, name='test')
 
     det.tiff1.nd_array_port.put(det.cam.port_name.get())
     det.roi1.nd_array_port.put(det.cam.port_name.get())

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -35,7 +35,7 @@ def tearDownModule():
 
 
 def test_device_state():
-    d = Device('test')
+    d = Device('test', name='test')
 
     d.stage()
     old, new = d.configure({})
@@ -52,6 +52,7 @@ class DeviceTests(unittest.TestCase):
 
         d = MyDevice('prefix', read_attrs=['cpt1'],
                      configuration_attrs=['cpt2'],
+                     name='test'
                      )
 
         d.read()
@@ -201,7 +202,7 @@ class DeviceTests(unittest.TestCase):
 
         ch_value = '_test_'
 
-        device = MyDevice('prefix:', ch=ch_value)
+        device = MyDevice('prefix:', ch=ch_value, name='test')
         self.assertIs(device.cpt.parent, device)
         self.assertIs(device.ch.parent, device)
         self.assertIs(device._ch, ch_value)
@@ -209,12 +210,11 @@ class DeviceTests(unittest.TestCase):
         self.assertEquals(device.cpt.read_pv,
                           device.prefix + MyDevice.cpt.suffix)
 
-
     def test_root(self):
         class MyDevice(Device):
             cpt = Component(FakeSignal, 'suffix')
 
-        d = MyDevice('')
+        d = MyDevice('', name='test')
         assert d.cpt.root == d
         assert d.root == d
 
@@ -303,7 +303,7 @@ def test_signal_names():
     class MyDevice(Device):
         cpt = Component(FakeSignal, 'suffix')
 
-    d = MyDevice('')
+    d = MyDevice('', name='test')
     with pytest.warns(UserWarning):
         signal_names = d.signal_names
 

--- a/ophyd/tests/test_flyers.py
+++ b/ophyd/tests/test_flyers.py
@@ -100,7 +100,7 @@ def wf_sim_detector(prefix):
         wfcol = Cpt(WaveformCollector, suffix)
 
     try:
-        det = Detector(prefix)
+        det = Detector(prefix, name='det')
         det.wait_for_connection(timeout=1.0)
     except TimeoutError:
         pytest.skip('IOC unavailable')

--- a/ophyd/tests/test_mca.py
+++ b/ophyd/tests/test_mca.py
@@ -21,7 +21,7 @@ devs = ['XF:23ID2-ES{Vortex}mca1', 'XF:23ID2-ES{Vortex}dxp1:']
 
 @using_fake_epics_pv
 def test_mca_spectrum():
-    mca = EpicsMCA(devs[0])
+    mca = EpicsMCA(devs[0], name='test')
     with pytest.raises(ReadOnlyError):
         mca.spectrum.put(3.14)
     with pytest.raises(ReadOnlyError):
@@ -31,16 +31,16 @@ def test_mca_spectrum():
 @using_fake_epics_pv
 def test_mca_read_attrs():
     r_attrs = ['spectrum', 'rois.roi1.count', 'rois.roi2.count']
-    mca = EpicsMCA(devs[0], read_attrs=r_attrs)
+    mca = EpicsMCA(devs[0], read_attrs=r_attrs, name='test')
     assert r_attrs == mca.read_attrs
 
 
 @using_fake_epics_pv
 def test_mca_describe():
-    mca = EpicsMCA(devs[0])
+    mca = EpicsMCA(devs[0], name='test')
 
     desc = mca.describe()
-    d = desc[mca.prefix + '_spectrum']
+    d = desc[mca.name + '_spectrum']
 
     assert d['dtype'] == 'number'
     assert d['shape'] == []
@@ -72,7 +72,7 @@ def test_rois():
     with pytest.raises(ValueError):
         add_rois([32, ])
     # read-only?
-    mca = EpicsMCA(devs[0])
+    mca = EpicsMCA(devs[0], name='test')
     with pytest.raises(ReadOnlyError):
         mca.rois.roi1.count.put(3.14)
     with pytest.raises(ReadOnlyError):

--- a/ophyd/tests/test_scaler.py
+++ b/ophyd/tests/test_scaler.py
@@ -22,7 +22,7 @@ scalers = ['XF:23ID2-ES{Sclr:1}']
 @using_fake_epics_pv
 def test_temp_scaler():
     # TODO fix
-    scaler.EpicsScaler(scalers[0])
+    scaler.EpicsScaler(scalers[0], name='test')
 
 
 @using_fake_epics_pv

--- a/ophyd/tests/test_status.py
+++ b/ophyd/tests/test_status.py
@@ -69,7 +69,7 @@ def test_status_pre():
 
 def test_subscription_status():
     # Arbitrary device
-    d = Device("Tst:Prefix")
+    d = Device("Tst:Prefix", name='test')
     # Mock callback
     m = Mock()
 

--- a/ophyd/tests/test_timestamps.py
+++ b/ophyd/tests/test_timestamps.py
@@ -18,11 +18,11 @@ def tearDownModule():
 
 class EpicsSignalTests(unittest.TestCase):
     def test_read_pv_timestamp_no_monitor(self):
-        mtr = EpicsMotor(config.motor_recs[0])
+        mtr = EpicsMotor(config.motor_recs[0], name='test')
         mtr.wait_for_connection()
 
-        sp = EpicsSignal(mtr.user_setpoint.pvname)
-        rbv = EpicsSignalRO(mtr.user_readback.pvname)
+        sp = EpicsSignal(mtr.user_setpoint.pvname, name='test')
+        rbv = EpicsSignalRO(mtr.user_readback.pvname, name='test')
 
         rbv_value0 = rbv.get()
         ts0 = rbv.timestamp
@@ -37,10 +37,10 @@ class EpicsSignalTests(unittest.TestCase):
         sp.put(sp.value - 0.1, wait=True)
 
     def test_write_pv_timestamp_no_monitor(self):
-        mtr = EpicsMotor(config.motor_recs[0])
+        mtr = EpicsMotor(config.motor_recs[0], name='test')
         mtr.wait_for_connection()
 
-        sp = EpicsSignal(mtr.user_setpoint.pvname)
+        sp = EpicsSignal(mtr.user_setpoint.pvname, name='test')
 
         sp_value0 = sp.get()
         ts0 = sp.timestamp
@@ -55,11 +55,11 @@ class EpicsSignalTests(unittest.TestCase):
         sp.put(sp.value - 0.1, wait=True)
 
     def test_read_pv_timestamp_monitor(self):
-        mtr = EpicsMotor(config.motor_recs[0])
+        mtr = EpicsMotor(config.motor_recs[0], name='test')
         mtr.wait_for_connection()
 
-        sp = EpicsSignal(mtr.user_setpoint.pvname, auto_monitor=True)
-        rbv = EpicsSignalRO(mtr.user_readback.pvname, auto_monitor=True)
+        sp = EpicsSignal(mtr.user_setpoint.pvname, auto_monitor=True, name='test')
+        rbv = EpicsSignalRO(mtr.user_readback.pvname, auto_monitor=True, name='test')
 
         rbv_value0 = rbv.get()
         ts0 = rbv.timestamp
@@ -74,10 +74,10 @@ class EpicsSignalTests(unittest.TestCase):
         sp.put(sp.value - 0.1, wait=True)
 
     def test_write_pv_timestamp_monitor(self):
-        mtr = EpicsMotor(config.motor_recs[0])
+        mtr = EpicsMotor(config.motor_recs[0], name='test')
         mtr.wait_for_connection()
 
-        sp = EpicsSignal(mtr.user_setpoint.pvname, auto_monitor=True)
+        sp = EpicsSignal(mtr.user_setpoint.pvname, auto_monitor=True, name='test')
 
         sp_value0 = sp.get()
         ts0 = sp.timestamp


### PR DESCRIPTION
This ensures that the names that appear in the read dictionary are
always human-readable.

In practice if this is left out it is accidental and results in saved
data with keys that are a concatenation of the PV prefix with the
names of the children in the python class.  This is neither human
understandable nor a valid / existing PV.  Neither humans nor machines
can read this.

Keeping keyword only to preserve the ability to have sub-classes with
more than one required positional arguments.

Do not want to make it the first positional argument to avoid massive
API breakage and the convention of 'last positional argument' is
brittle.

A keyword-only argument also clearly disambiguates the name (for
humans) from the prefix (for hardware).