### PR TITLE
API: Make Component lazy by default.

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -71,7 +71,7 @@ class Component:
         string to attach to component DvcClass.component.__doc__
     '''
 
-    def __init__(self, cls, suffix=None, *, lazy=False, trigger_value=None,
+    def __init__(self, cls, suffix=None, *, lazy=True, trigger_value=None,
                  add_prefix=None, doc=None, **kwargs):
         self.attr = None  # attr is set later by the device when known
         self.cls = cls


### PR DESCRIPTION
Closes #443. It looks like our friends at SLAC are
[already doing this locally](https://github.com/slaclab/pcds-devices/blob/780117057595b906f813e171f2efd676d48eb1e8/pcdsdevices/component.py#L10).

I originally reported (in #443) that I thought this might cause
trouble but I was seeing an unrelated issue. I think this is pretty
safe to change, and it should improve IPython load times in a big way.