### PR TITLE
MNT: Move verbose summary from __str__ into new method, 'summary'.

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -166,6 +166,8 @@ class Component:
         return ('{self.__class__.__name__}({self.cls.__name__}{arg_str})'
                 ''.format(self=self, arg_str=arg_str))
 
+    __str__ = __repr__
+
     def __get__(self, instance, owner):
         if instance is None:
             return self
@@ -739,7 +741,11 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
                       "removed in a future release of ophyd.")
         return self.component_names
 
-    def __str__(self):
+    def summary(self):
+        print(self._summary())
+
+    def _summary(self):
+        "Return a string summarizing the structure of the Device."
         desc = self.describe()
         config_desc = self.describe_configuration()
         read_attrs = self.read_attrs

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -308,3 +308,14 @@ def test_signal_names():
         signal_names = d.signal_names
 
     assert signal_names is d.component_names
+
+
+def test_summary():
+    class MyDevice(Device):
+        cpt = Component(FakeSignal, 'suffix')
+
+    d = MyDevice('', name='test')
+    # smoke tests
+    d.summary()
+    d.__str__()
+    d.__repr__()


### PR DESCRIPTION
The new verbose summary, currently available as ``print(device)``, is great to
have but overwhelmingly verbose when it shows up inside a log or a Traceback.
This PR moves that verbose summary into a new method and restores the old behavior
of ``__str__`` so that ``print(device)`` does the same thing as ``repr(device)``.

Notice that ``summary()`` prints but returns ``None`` so that the line breaks
are correctly displayed. The string itself is available programmatically from
``_summary()``.

Example:

```python
In [1]: from ophyd.sim import motor

In [2]: motor
Out[2]: SynAxis(prefix='', name='motor', read_attrs=['readback', 'setpoint'], configuration_attrs=[])

In [3]: print(motor)
SynAxis(prefix='', name='motor', read_attrs=['readback', 'setpoint'], configuration_attrs=[])

In [4]: motor.summary()
data keys (* hints)
-------------------
*motor
 motor_setpoint

 read attrs
 ----------
 readback             ReadbackSignal      ('motor')
 setpoint             SetpointSignal      ('motor_setpoint')

 config keys
 -----------

 configuration attrs
 ----------

 Unused attrs
 ------------

 In [5]: motor._summary()
 Out[5]: "data keys (* hints)\n-------------------\n*motor\n motor_setpoint\n\nread attrs\n----------\nreadback             ReadbackSignal      ('motor')\nsetpoint             SetpointSignal      ('motor_setpoint')\n\nconfig keys\n-----------\n\nconfiguration attrs\n----------\n\nUnused attrs\n------------"