### PR TITLE
FIX: Initialize SynSignal with a None value if no func provided.

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -75,6 +75,8 @@ class SynSignal(Signal):
         if func is None:
             # When triggered, just put the current value.
             func = self.get
+            # Initialize readback with a None value
+            self._readback = None
         if loop is None:
             loop = asyncio.get_event_loop()
         self._func = func


### PR DESCRIPTION
Small change. I noticed that `SynSignal` gave tracebacks like the following if `func` wasn't provided. The docs claim this should be optional, so the simple fix is to initialize a value for the `._readback` attribute.
```
In [1]: from ophyd.sim import SynSignal
In [2]: sig = SynSignal(name='test')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-8e56780657fc> in <module>()
----> 1 sig = SynSignal(name='test')

~/conda/envs/nikea/lib/python3.6/site-packages/ophyd/sim.py in __init__(self, func, name, exposure_time, precision, parent, loop)
     82         self.precision = 3
     83         self.loop = loop
---> 84         super().__init__(value=self._func(), timestamp=ttime.time(), name=name,
     85                          parent=parent)
     86 

~/conda/envs/nikea/lib/python3.6/site-packages/ophyd/sim.py in get(self)
    119         # Get a new value, which allows us to synthesize noisy data, for
    120         # example.
--> 121         return super().get()
    122 
    123 

~/conda/envs/nikea/lib/python3.6/site-packages/ophyd/signal.py in get(self, **kwargs)
    107     def get(self, **kwargs):
    108         '''The readback value'''
--> 109         return self._readback
    110 
    111     def put(self, value, *, timestamp=None, force=False, **kwargs):

AttributeError: 'SynSignal' object has no attribute '_readback'
```