### PR TITLE
FIX: Reorder set_and_wait to avoid race condition

### DIFF
--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -225,14 +225,15 @@ def set_and_wait(signal, val, poll_time=0.01, timeout=10, rtol=None,
     ------
     TimeoutError if timeout is exceeded
     """
+    signal.put(val)
+    expiration_time = ttime.time() + timeout if timeout is not None else None
+    current_value = signal.get()
+
     if atol is None and hasattr(signal, 'tolerance'):
         atol = signal.tolerance
     if rtol is None and hasattr(signal, 'rtolerance'):
         rtol = signal.rtolerance
 
-    signal.put(val)
-    expiration_time = ttime.time() + timeout if timeout is not None else None
-    current_value = signal.get()
     try:
         es = signal.enum_strs
     except AttributeError:


### PR DESCRIPTION
`set_and_wait` currently accesses `signal.tolerance` on the first line. This is a problem because the `tolerance` property is wrapped with a `raise_if_disconnected` decorator, which prevents the whole method from being run if the `EpicsSignal` object has not finished connecting.

This happened to me with the `AreaDetectorComponent` objects. Since these are the only `Component` objects that are set as `lazy=True`, there was no guarantee that the connection finished in time for my `set_and_wait` call.

I expect that these `epics_pvs` utils should work even if the connection hasn't finished yet, so here I've reordered the method so that the `put` and `get` calls happen first, which call `wait_for_connection` on the `_write_pv` and `_read_pv` attributes respectively. This guarantees that the connection has happened in time for the tolerance check.