### PR TITLE
MAINT: Hidden signals

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1040,7 +1040,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
     def get(self, **kwargs):
         '''Get the value of all components in the device
 
-        Keyword arguments are passed onto each signal.get()
+        Keyword arguments are passed onto each signal.get(). Components
+        beginning with an underscore will not be included.
         '''
         values = {}
         for attr in self.component_names:

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -414,10 +414,10 @@ class ComponentMeta(type):
         clsobj.component_names = list(clsobj._sig_attrs.keys())
 
         # The namedtuple associated with the device
-        clsobj._device_tuple = namedtuple(name + 'Tuple',
-                                          clsobj.component_names,
-                                          rename=True)
-
+        clsobj._device_tuple = namedtuple(
+                                    name + 'Tuple',
+                                    [comp for comp in clsobj.component_names
+                                     if not comp.startswith('_')])
         # Finally, create all the component docstrings
         for cpt in clsobj._sig_attrs.values():
             cpt.__doc__ = cpt.make_docstring(clsobj)
@@ -1044,8 +1044,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         '''
         values = {}
         for attr in self.component_names:
-            signal = getattr(self, attr)
-            values[attr] = signal.get(**kwargs)
+            if not attr.startswith('_'):
+                signal = getattr(self, attr)
+                values[attr] = signal.get(**kwargs)
 
         return self._device_tuple(**values)
 

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -218,6 +218,13 @@ class DeviceTests(unittest.TestCase):
         assert d.cpt.root == d
         assert d.root == d
 
+    def test_hidden_component(self):
+        class MyDevice(Device):
+            _hidden_sig = Component(FakeSignal, 'suffix')
+        d = MyDevice('', name='test')
+        assert '_hidden_sig' in d.component_names
+        assert not hasattr(d.get(), '_hidden_sig')
+
 
 def test_attribute_signal():
     init_value = 33


### PR DESCRIPTION
## Description
Currently, if you have a signal that begins with an underscore it is renamed in the `_device_tuple` object to be something completely unhelpful like `_1` . This will go unnoticed until you call `.get()` on your device and we try and stuff `component_names` into the tuple. This raises an Exception that looks as follows:
```
__new__() got an unexpected keyword argument '_your_signal'
```
This may lead a dull programmer to blame his compatriot for mangling a class's MRO
https://github.com/pcdshub/pcdsdevices/issues/157. 

Anyways I looked through some documentation, but I found nothing saying that you can't start a component name with an underscore. This PR makes it so that the `.get` method works by **not** putting underscored properties in the `_device_tuple` constructor., then when we call `.get` we skip over these "hidden components"  when filling the tuple.

This is only one option to fix this issue. I figured this was a 3 line fix so might as well put in a PR but the other options are:

1.  Do not allow components with leading underscores and document this.
2. Remove underscores when creating the device tuples and filling it with `get`

## Motivation
Stumbled head first into this issue, `.get()` was failing with a cryptic error message. 