### PR TITLE
ENH: Individual Device logging

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1025,7 +1025,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             except ExceptionBundle as ex:
                 exc_list.extend([('{}.{}'.format(attr, sub_attr), ex)
                                  for sub_attr, ex in ex.exceptions.items()])
-            except Exception:
+            except Exception as ex:
                 exc_list.append((attr, ex))
                 self.log.exception('Device %s (%s) stop failed', attr, dev)
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -563,7 +563,7 @@ class BlueskyInterface:
                                    "Maybe the most recent unstaging "
                                    "encountered an error before finishing. "
                                    "Try unstaging again.".format(self))
-        logger.debug("Staging %s", self.name)
+        self.log.debug("Staging %s", self.name)
         self._staged = Staged.partially
 
         # Resolve any stage_sigs keys given as strings: 'a.b' -> self.a.b
@@ -586,7 +586,7 @@ class BlueskyInterface:
         devices_staged = []
         try:
             for sig, val in stage_sigs.items():
-                logger.debug("Setting %s to %r (original value: %r)",
+                self.log.debug("Setting %s to %r (original value: %r)",
                              self.name,
                              val, original_vals[sig])
                 set_and_wait(sig, val)
@@ -601,7 +601,7 @@ class BlueskyInterface:
                     device.stage()
                     devices_staged.append(device)
         except Exception:
-            logger.debug("An exception was raised while staging %s or "
+            self.log.debug("An exception was raised while staging %s or "
                          "one of its children. Attempting to restore "
                          "original settings before re-raising the "
                          "exception.", self.name)
@@ -629,7 +629,7 @@ class BlueskyInterface:
             list including self and all child devices unstaged
 
         """
-        logger.debug("Unstaging %s", self.name)
+        self.log.debug("Unstaging %s", self.name)
         self._staged = Staged.partially
         devices_unstaged = []
 
@@ -642,7 +642,7 @@ class BlueskyInterface:
 
         # Restore original values.
         for sig, val in reversed(list(self._original_vals.items())):
-            logger.debug("Setting %s back to its original value: %r)",
+            self.log.debug("Setting %s back to its original value: %r)",
                          self.name,
                          val)
             set_and_wait(sig, val)
@@ -1016,7 +1016,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             dev = getattr(self, attr)
 
             if not dev.connected:
-                logger.debug('stop: device %s (%s) is not connected; '
+                self.log.debug('stop: device %s (%s) is not connected; '
                              'skipping', attr, dev)
                 continue
 
@@ -1027,7 +1027,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
                                  for sub_attr, ex in ex.exceptions.items()])
             except Exception as ex:
                 exc_list.append((attr, ex))
-                logger.error('Device %s (%s) stop failed', attr, dev,
+                self.log.error('Device %s (%s) stop failed', attr, dev,
                              exc_info=ex)
 
         if exc_list:

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1025,10 +1025,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             except ExceptionBundle as ex:
                 exc_list.extend([('{}.{}'.format(attr, sub_attr), ex)
                                  for sub_attr, ex in ex.exceptions.items()])
-            except Exception as ex:
+            except Exception:
                 exc_list.append((attr, ex))
-                self.log.error('Device %s (%s) stop failed', attr, dev,
-                             exc_info=ex)
+                self.log.exception('Device %s (%s) stop failed', attr, dev)
 
         if exc_list:
             exc_info = '\n'.join('{} raised {!r}'.format(attr, ex)

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -232,7 +232,7 @@ class EpicsMotor(Device, PositionerBase):
         if not self._started_moving:
             started = self._started_moving = (not was_moving and self._moving)
 
-        logger.debug('[ts=%s] %s moving: %s (value=%s)', fmt_time(timestamp),
+        self.log.debug('[ts=%s] %s moving: %s (value=%s)', fmt_time(timestamp),
                      self, self._moving, value)
 
         if started:
@@ -254,8 +254,8 @@ class EpicsMotor(Device, PositionerBase):
 
             if severity != AlarmSeverity.NO_ALARM:
                 status = self.user_readback.alarm_status
-                logger.error('Motion failed: %s is in an alarm state '
-                             'status=%s severity=%s',
+                self.log.error('Motion failed: %s is in an alarm state '
+                               'status=%s severity=%s',
                              self.name, status, severity)
                 success = False
 

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -256,7 +256,7 @@ class EpicsMotor(Device, PositionerBase):
                 status = self.user_readback.alarm_status
                 self.log.error('Motion failed: %s is in an alarm state '
                                'status=%s severity=%s',
-                             self.name, status, severity)
+                               self.name, status, severity)
                 success = False
 
             self._done_moving(success=success, timestamp=timestamp,

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -220,10 +220,11 @@ class OphydObject:
             def inner(*args, **kwargs):
                 try:
                     cb(*args, **kwargs)
-                except Exception as ex:
+                except Exception:
                     sub_type = kwargs['sub_type']
-                    self.log.error('Subscription %s callback exception (%s)',
-                                 sub_type, self, exc_info=ex)
+                    self.log.exception('Subscription %s callback '\
+                                       'exception (%s)',
+                                       sub_type, self)
             return inner
         # get next cid
         cid = next(self._cb_count)

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -60,6 +60,13 @@ class OphydObject:
         self._args_cache = {k: None for k in self.subscriptions}
         # count of subscriptions we have handed out, used to give unique ids
         self._cb_count = count()
+        # Create logger name from parent or from module class
+        if self.parent:
+            base_log = self.parent.log.name
+        else:
+            base_log = self.__class__.__module__
+        # Instantiate logger
+        self.log = logging.getLogger(base_log + '.' + self.name)
 
     @property
     def name(self):

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -61,10 +61,12 @@ class OphydObject:
         # Create logger name from parent or from module class
         if self.parent:
             base_log = self.parent.log.name
+            name = self.name.lstrip(self.parent.name + '_')
         else:
             base_log = self.__class__.__module__
+            name = self.name
         # Instantiate logger
-        self.log = logging.getLogger(base_log + '.' + self.name)
+        self.log = logging.getLogger(base_log + '.' + name)
 
     @property
     def name(self):

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -6,8 +6,6 @@ import logging
 
 from .status import (StatusBase, MoveStatus, DeviceStatus)
 
-logger = logging.getLogger(__name__)
-
 
 class UnknownSubscription(KeyError):
     "Subclass of KeyError.  Raised for unknown event type"
@@ -224,7 +222,7 @@ class OphydObject:
                     cb(*args, **kwargs)
                 except Exception as ex:
                     sub_type = kwargs['sub_type']
-                    logger.error('Subscription %s callback exception (%s)',
+                    self.log.error('Subscription %s callback exception (%s)',
                                  sub_type, self, exc_info=ex)
             return inner
         # get next cid

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -418,8 +418,8 @@ class PseudoPositioner(Device, SoftPositioner):
         self.RealPosition = self._real_position_tuple()
         self.PseudoPosition = self._pseudo_position_tuple()
 
-        logger.debug('Real positioners: %s', self._real)
-        logger.debug('Pseudo positioners: %s', self._pseudo)
+        self.log.debug('Real positioners: %s', self._real)
+        self.log.debug('Pseudo positioners: %s', self._pseudo)
 
         for idx, pseudo in enumerate(self._pseudo):
             pseudo._idx = idx
@@ -562,8 +562,8 @@ class PseudoPositioner(Device, SoftPositioner):
                                  for sub_attr, ex in ex.exceptions.items()])
             except Exception as ex:
                 exc_list.append((attr, ex))
-                logger.error('Device %s (%s) stop failed', attr, dev,
-                             exc_info=ex)
+                self.log.error('Device %s (%s) stop failed', attr, dev,
+                               exc_info=ex)
 
         if exc_list:
             exc_info = '\n'.join('{} raised {!r}'.format(attr, ex)
@@ -720,7 +720,7 @@ class PseudoPositioner(Device, SoftPositioner):
         '''
         with self._finished_lock:
             real = obj
-            logger.debug('Real motor %s finished moving', real.name)
+            self.log.debug('Real motor %s finished moving', real.name)
 
             if real in self._real_waiting:
                 self._real_waiting.remove(real)
@@ -762,12 +762,12 @@ class PseudoPositioner(Device, SoftPositioner):
 
         def move_next(obj=None):
             # last motion complete message came from 'obj'
-            logger.debug('[%s:sequential] move_next called', self.name)
+            self.log.debug('[%s:sequential] move_next called', self.name)
             with self._finished_lock:
                 if pending_status:
                     last_status = pending_status[-1]
                     if not last_status.success:
-                        logger.error('Failing due to last motion')
+                        self.log.error('Failing due to last motion')
                         self._done_moving(success=False)
                         return
 
@@ -777,7 +777,7 @@ class PseudoPositioner(Device, SoftPositioner):
                     self._done_moving(success=True)
                     return
 
-                logger.debug('[%s:sequential] Moving next motor: %s',
+                self.log.debug('[%s:sequential] Moving next motor: %s',
                              self.name, real.name)
 
                 elapsed = time.time() - t0
@@ -786,11 +786,11 @@ class PseudoPositioner(Device, SoftPositioner):
                 else:
                     sub_timeout = timeout - elapsed
 
-                logger.debug('[%s:sequential] Moving %s to %s (timeout=%s)',
+                self.log.debug('[%s:sequential] Moving %s to %s (timeout=%s)',
                              self.name, real.name, position, sub_timeout)
 
                 if sub_timeout is not None and sub_timeout < 0:
-                    logger.error('Motion timeout')
+                    self.log.error('Motion timeout')
                     self._done_moving(success=False)
                 else:
                     status = real.move(position, wait=False,
@@ -798,10 +798,10 @@ class PseudoPositioner(Device, SoftPositioner):
                                        moved_cb=move_next,
                                        **kwargs)
                     pending_status.append(status)
-                    logger.debug('[%s:sequential] waiting on %s',
+                    self.log.debug('[%s:sequential] waiting on %s',
                                  self.name, real.name)
 
-        logger.debug('[%s:sequential] started', self.name)
+        self.log.debug('[%s:sequential] started', self.name)
         move_next()
 
     def _concurrent_move(self, real_pos, **kwargs):
@@ -809,7 +809,7 @@ class PseudoPositioner(Device, SoftPositioner):
         self._real_waiting.extend(self._real)
 
         for real, value in zip(self._real, real_pos):
-            logger.debug('[concurrent] Moving %s to %s', real.name, value)
+            self.log.debug('[concurrent] Moving %s to %s', real.name, value)
             real.move(value, wait=False, moved_cb=self._real_finished,
                       **kwargs)
 

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -560,10 +560,9 @@ class PseudoPositioner(Device, SoftPositioner):
             except ExceptionBundle as ex:
                 exc_list.extend([('{}.{}'.format(attr, sub_attr), ex)
                                  for sub_attr, ex in ex.exceptions.items()])
-            except Exception as ex:
+            except Exception:
                 exc_list.append((attr, ex))
-                self.log.error('Device %s (%s) stop failed', attr, dev,
-                               exc_info=ex)
+                self.log.exception('Device %s (%s) stop failed', attr, dev)
 
         if exc_list:
             exc_info = '\n'.join('{} raised {!r}'.format(attr, ex)

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -560,7 +560,7 @@ class PseudoPositioner(Device, SoftPositioner):
             except ExceptionBundle as ex:
                 exc_list.extend([('{}.{}'.format(attr, sub_attr), ex)
                                  for sub_attr, ex in ex.exceptions.items()])
-            except Exception:
+            except Exception as ex:
                 exc_list.append((attr, ex))
                 self.log.exception('Device %s (%s) stop failed', attr, dev)
 

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -143,10 +143,10 @@ class PVPositioner(Device, PositionerBase):
 
     def _setup_move(self, position):
         '''Move and do not wait until motion is complete (asynchronous)'''
-        logger.debug('%s.setpoint = %s', self.name, position)
+        self.log.debug('%s.setpoint = %s', self.name, position)
         self.setpoint.put(position, wait=True)
         if self.actuate is not None:
-            logger.debug('%s.actuate = %s', self.name, self.actuate_value)
+            self.log.debug('%s.actuate = %s', self.name, self.actuate_value)
             self.actuate.put(self.actuate_value, wait=False)
 
     def move(self, position, wait=True, timeout=None, moved_cb=None):
@@ -207,10 +207,10 @@ class PVPositioner(Device, PositionerBase):
         started = False
         if not self._started_moving:
             started = self._started_moving = (not was_moving and self._moving)
-            logger.debug('[ts=%s] %s started moving: %s', fmt_time(timestamp),
+            self.log.debug('[ts=%s] %s started moving: %s', fmt_time(timestamp),
                          self.name, started)
 
-        logger.debug('[ts=%s] %s moving: %s (value=%s)', fmt_time(timestamp),
+        self.log.debug('[ts=%s] %s moving: %s (value=%s)', fmt_time(timestamp),
                      self.name, self._moving, value)
 
         if started:
@@ -280,7 +280,7 @@ class PVPositionerPC(PVPositioner):
     def _setup_move(self, position):
         '''Move and do not wait until motion is complete (asynchronous)'''
         def done_moving(**kwargs):
-            logger.debug('%s async motion done', self.name)
+            self.log.debug('%s async motion done', self.name)
             self._done_moving(success=True)
 
         if self.done is None:
@@ -288,12 +288,12 @@ class PVPositionerPC(PVPositioner):
             moving_val = 1 - self.done_value
             self._move_changed(value=moving_val)
 
-        logger.debug('%s.setpoint = %s', self.name, position)
+        self.log.debug('%s.setpoint = %s', self.name, position)
 
         if self.actuate is not None:
             self.setpoint.put(position, wait=True)
 
-            logger.debug('%s.actuate = %s', self.name, self.actuate_value)
+            self.log.debug('%s.actuate = %s', self.name, self.actuate_value)
             self.actuate.put(self.actuate_value, wait=False,
                              callback=done_moving)
         else:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -156,15 +156,15 @@ class Signal(OphydObject):
                 set_and_wait(self, value, timeout=timeout, atol=self.tolerance,
                              rtol=self.rtolerance)
             except TimeoutError:
-                logger.debug('set_and_wait(%r, %s) timed out', self.name,
+                self.log.debug('set_and_wait(%r, %s) timed out', self.name,
                              value)
                 success = False
             except Exception as ex:
-                logger.debug('set_and_wait(%r, %s) failed', self.name, value,
+                self.log.debug('set_and_wait(%r, %s) failed', self.name, value,
                              exc_info=ex)
                 success = False
             else:
-                logger.debug('set_and_wait(%r, %s) succeeded => %s', self.name,
+                self.log.debug('set_and_wait(%r, %s) succeeded => %s', self.name,
                              value, self.value)
                 success = True
                 if settle_time is not None:


### PR DESCRIPTION
## Description
Reroute logging messages through loggers attached to instantiations of devices. This allows more detailed logging of individual device behaviors through complex scanning routines. Component devices use their `parent` log so that logic can be tracked through often complex nested component architecture. The highest level logger in the device will still start with `ophyd.` so `logging.getLogger('ophyd')` still gets all the log messages you received previously. 

I avoided changing any class that doesn't explicitly inherit from `OphydObject` so any log messages in the interface classes still go to module level logger. It would be nice to get these as well but I didn't want to break anything by assuming all implementations of the interface are on `OphydObj`. 

## Motivation
Closes #525 