### PR TITLE
FIX: PluginBase assumes root is ADBase

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -277,3 +277,11 @@ class ADBase(Device):
     def _configuration_names(self):
         return [getattr(self, c).name
                 for c in self.configuration_attrs]
+
+    @property
+    def ad_root(self):
+        root = self
+        while True:
+            if not isinstance(root.parent, ADBase):
+                return root
+            root = root.parent

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -161,7 +161,7 @@ class PluginBase(ADBase):
         '''The PluginBase object that is the asyn source for this plugin.
         '''
         source_port = self.nd_array_port.get()
-        source_plugin = self.root.get_plugin_by_asyn_port(source_port)
+        source_plugin = self.ad_root.get_plugin_by_asyn_port(source_port)
         return source_plugin
 
     def describe_configuration(self):
@@ -174,7 +174,7 @@ class PluginBase(ADBase):
 
     @property
     def _asyn_pipeline(self):
-        parent = self.root.get_plugin_by_asyn_port(self.nd_array_port.get())
+        parent = self.ad_root.get_plugin_by_asyn_port(self.nd_array_port.get())
         if hasattr(parent, '_asyn_pipeline'):
             return parent._asyn_pipeline + (self, )
         return (parent, self)


### PR DESCRIPTION
`PluginBase` has some methods that refer to `self.root`, but these assume that `self.root` is an `ADBase` subclass by accessing the `get_plugin_by_asyn_port` method. This fails if `self.root` is not an `ADBase` object, which happens when you try to include an areadetector class as a component in a larger assembly.

This fix adds an `ad_root` property, which is the highest ancestor that is an `ADBase` subclass, and then swaps `PluginBase` to use the new property. This is guaranteed to have the requisite methods, and will be identical to `root` when instantiating `DetectorBase` subclasses alone.