### PR TITLE
REF: Use a generator in collect_asset_docs.

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -373,9 +373,10 @@ class FileStoreBase(BlueskyInterface, GenerateDatumInterface):
         return res
 
     def collect_asset_docs(self):
-        ret = tuple(self._asset_docs_cache)
+        items = list(self._asset_docs_cache)
         self._asset_docs_cache.clear()
-        return ret
+        for item in items:
+            yield item
 
     def unstage(self):
         self._locked_key_list = False

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -732,9 +732,10 @@ class SynSignalWithRegistry(SynSignal):
         return res
 
     def collect_asset_docs(self):
-        ret = tuple(self._asset_docs_cache)
+        items = list(self._asset_docs_cache)
         self._asset_docs_cache.clear()
-        return ret
+        for item in items:
+            yield item
 
     def unstage(self):
         self._resource_uid = None


### PR DESCRIPTION
This requires no changes to bluesky, which just expects any Iterable and will be just as happy with a generator as with a tuple. The rationale for changing the implementation is to protect against accidentally introducing the assumption that this is non-lazy (i.e. something with a length) in the future. There are cases where a generator is useful, such as when datums are dynamically generated during collection. But returning a tuple or a list will continue to be accepted too.