### PR TITLE
Component Kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ htmlcov/
 .tox/
 .coverage
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -69,7 +69,7 @@ from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
                      DynamicDeviceComponent, OmittedComponent,
                      NormalComponent, ConfigComponent, HintedComponent,
-                     RESPECT_KIND)
+                     RESPECT_KIND, kind_context)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -67,8 +67,7 @@ from .pseudopos import (PseudoPositioner, PseudoSingle)
 # Devices
 from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
-                     DynamicDeviceComponent, OmittedComponent,
-                     NormalComponent, ConfigComponent, HintedComponent,
+                     DynamicDeviceComponent,
                      RESPECT_KIND, kind_context)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -69,6 +69,7 @@ from .device import (Device, Component, FormattedComponent,
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM
+from .ophydobj import Kind
 
 # Areadetector-related
 from .areadetector import *

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -68,7 +68,7 @@ from .pseudopos import (PseudoPositioner, PseudoSingle)
 from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
                      DynamicDeviceComponent,
-                     RESPECT_KIND, kind_context)
+                     ALL_COMPONENTS, kind_context)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -53,6 +53,8 @@ def get_cl():
 
 set_cl()
 
+from .ophydobj import Kind
+
 # Signals
 from .signal import (Signal, EpicsSignal, EpicsSignalRO, DerivedSignal)
 
@@ -71,7 +73,6 @@ from .device import (Device, Component, FormattedComponent,
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM
-from .ophydobj import Kind
 
 # Areadetector-related
 from .areadetector import *

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -65,7 +65,8 @@ from .pseudopos import (PseudoPositioner, PseudoSingle)
 # Devices
 from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
-                     DynamicDeviceComponent)
+                     DynamicDeviceComponent, OmittedComponent,
+                     NormalComponent, ConfigComponent, HintedComponent)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM

--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -66,7 +66,8 @@ from .pseudopos import (PseudoPositioner, PseudoSingle)
 from .scaler import EpicsScaler
 from .device import (Device, Component, FormattedComponent,
                      DynamicDeviceComponent, OmittedComponent,
-                     NormalComponent, ConfigComponent, HintedComponent)
+                     NormalComponent, ConfigComponent, HintedComponent,
+                     RESPECT_KIND)
 from .status import StatusBase
 from .mca import EpicsMCA, EpicsDXP
 from .quadem import QuadEM, NSLS_EM, TetrAMM, APS_EM

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -629,7 +629,7 @@ class ROIPlugin(PluginBase):
                             ('min_y', 'MinY'),
                             ('min_z', 'MinZ'))),
                   doc='Minimum size of the ROI in XYZ',
-                  default_read_attrs=('x', 'y', 'z'))
+                  default_read_attrs=('min_x', 'min_y', 'min_z'))
 
     name_ = C(SignalWithRBV, 'Name', doc='ROI name')
     reverse = DDC(ad_group(SignalWithRBV,

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -752,14 +752,16 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
                 read_attrs = (self._default_read_attrs if
                               self._default_read_attrs is not None
                               else self.component_names)
+        if read_attrs is not None:
             self.read_attrs = list(read_attrs)
 
         if self._default_configuration_attrs is not RESPECT_KIND:
             if configuration_attrs is None:
-                    dflt_c_attrs = self._default_configuration_attrs
-                    configuration_attrs = (dflt_c_attrs if
-                                           dflt_c_attrs is not None
-                                           else [])
+                dflt_c_attrs = self._default_configuration_attrs
+                configuration_attrs = (dflt_c_attrs if
+                                       dflt_c_attrs is not None
+                                       else [])
+        if configuration_attrs is not None:
             self.configuration_attrs = list(configuration_attrs)
 
         # Instantiate non-lazy signals

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1,3 +1,4 @@
+import functools
 import time as ttime
 import logging
 import textwrap
@@ -436,6 +437,12 @@ class ComponentMeta(type):
 
         return clsobj
 
+# Convenience wrappers to avoid screens full of kind=Kind.OMITTED, etc.
+OmittedComponent = functools.partial(Component, kind=Kind.OMITTED)
+NormalComponent = Component  # for completeness
+ConfigComponent = functools.partial(Component, kind=Kind.CONFIG)
+HintedComponent = functools.partial(Component, kind=Kind.HINTED)
+
 
 # These stub 'Interface' classes are the apex of the mro heirarchy for
 # their respective methods. They make multiple interitance more
@@ -759,7 +766,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
 
     def _validate_kind(self, val):
         if Kind.NORMAL & val:
-            val = val | Kind.CONFIGURATION
+            val = val | Kind.CONFIG
         return val
 
     @property
@@ -787,10 +794,10 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         # TODO deal with dotted names
         for c in self.component_names:
             if c in val:
-                getattr(self, c).kind |= Kind.CONFIGURATION
+                getattr(self, c).kind |= Kind.CONFIG
 
             else:
-                getattr(self, c).kind ^= Kind.CONFIGURATION
+                getattr(self, c).kind ^= Kind.CONFIG
 
     @property
     def signal_names(self):
@@ -966,7 +973,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         res = OrderedDict()
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind & Kind.CONFIGURATION:
+            if component.kind & Kind.CONFIG:
                 res.update(component.read_configuration())
         return res
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -261,8 +261,8 @@ class DynamicDeviceComponent:
             default_read_attrs = tuple(default_read_attrs)
         if isinstance(default_configuration_attrs, collections.Iterable):
             default_configuration_attrs = tuple(default_configuration_attrs)
-        self.default_read_attrs = default_read_attrs or []
-        self.default_configuration_attrs = default_configuration_attrs or []
+        self.default_read_attrs = default_read_attrs
+        self.default_configuration_attrs = default_configuration_attrs
         self.kind = kind
 
         # TODO: component compatibility
@@ -327,13 +327,8 @@ class DynamicDeviceComponent:
 
         clsdict = OrderedDict(
             __doc__=docstring,
-            _default_read_attrs=(self.default_read_attrs
-                                 if self.default_read_attrs is not None
-                                 else ()),
-            _default_configuration_attrs=(
-                self.default_configuration_attrs
-                if self.default_configuration_attrs is not None
-                else ())
+            _default_read_attrs=self.default_read_attrs,
+            _default_configuration_attrs=self.default_configuration_attrs
         )
 
         for attr in self.defn.keys():

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import time as ttime
 import logging
@@ -17,6 +18,7 @@ from itertools import groupby
 
 A, B = TypeVar('A'), TypeVar('B')
 RESPECT_KIND = object()
+
 
 class OrderedDictType(Dict[A, B]):
     ...
@@ -680,6 +682,9 @@ class BlueskyInterface:
         """
         pass
 
+    def _validate_kind(self, val):
+        return super()._validate_kind(val)
+
 
 class GenerateDatumInterface:
     """Classes that inherit from this can safely customize the
@@ -769,7 +774,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             val = getattr(Kind, val.upper())
         if Kind.NORMAL & val:
             val = val | Kind.CONFIG
-        return val
+        return super()._validate_kind(val)
 
     @property
     def read_attrs(self):
@@ -1226,3 +1231,8 @@ class _OphydAttrList(MutableSequence):
 
     def __add__(self, other):
         return list(self) + list(other)
+
+
+@contextlib.contextmanager
+def kind_context(kind):
+    yield functools.partial(Component, kind=kind)

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1189,3 +1189,6 @@ class _OphydAttrList(MutableSequence):
 
     def insert(self, index, object):
         getattr(self._parent, object).kind |= self._kind
+
+    def __eq__(self, other):
+        return list(self) == other

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -421,9 +421,9 @@ class ComponentMeta(type):
 
         # The namedtuple associated with the device
         clsobj._device_tuple = namedtuple(
-                                    name + 'Tuple',
-                                    [comp for comp in clsobj.component_names
-                                     if not comp.startswith('_')])
+            name + 'Tuple',
+            [comp for comp in clsobj.component_names
+             if not comp.startswith('_')])
         # Finally, create all the component docstrings
         for cpt in clsobj._sig_attrs.values():
             cpt.__doc__ = cpt.make_docstring(clsobj)
@@ -439,6 +439,7 @@ class ComponentMeta(type):
             clsobj._sub_devices.append(attr)
 
         return clsobj
+
 
 # Convenience wrappers to avoid screens full of kind=Kind.OMITTED, etc.
 OmittedComponent = functools.partial(Component, kind=Kind.OMITTED)
@@ -599,8 +600,8 @@ class BlueskyInterface:
         try:
             for sig, val in stage_sigs.items():
                 self.log.debug("Setting %s to %r (original value: %r)",
-                             self.name,
-                             val, original_vals[sig])
+                               self.name,
+                               val, original_vals[sig])
                 set_and_wait(sig, val)
                 # It worked -- now add it to this list of sigs to unstage.
                 self._original_vals[sig] = original_vals[sig]
@@ -614,9 +615,9 @@ class BlueskyInterface:
                     devices_staged.append(device)
         except Exception:
             self.log.debug("An exception was raised while staging %s or "
-                         "one of its children. Attempting to restore "
-                         "original settings before re-raising the "
-                         "exception.", self.name)
+                           "one of its children. Attempting to restore "
+                           "original settings before re-raising the "
+                           "exception.", self.name)
             self.unstage()
             raise
         else:
@@ -655,8 +656,8 @@ class BlueskyInterface:
         # Restore original values.
         for sig, val in reversed(list(self._original_vals.items())):
             self.log.debug("Setting %s back to its original value: %r)",
-                         self.name,
-                         val)
+                           self.name,
+                           val)
             set_and_wait(sig, val)
             self._original_vals.pop(sig)
         devices_unstaged.append(self)
@@ -1098,7 +1099,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
 
             if not dev.connected:
                 self.log.debug('stop: device %s (%s) is not connected; '
-                             'skipping', attr, dev)
+                               'skipping', attr, dev)
                 continue
 
             try:

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1043,8 +1043,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         fields = []
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind == Kind.HINTED:
-                fields.append(component.name)
+            if Kind.NORMAL & component.kind:
+                c_hints = component.hints
+                fields.extend(c_hints.get('fields', []))
         return {'fields': fields}
 
     @property

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -90,7 +90,7 @@ class Component:
 
         if add_prefix is None:
             add_prefix = ('suffix', 'write_pv')
-
+        self.kwargs.setdefault('kind', Kind.NORMAL)
         self.add_prefix = tuple(add_prefix)
 
     def maybe_add_prefix(self, instance, kw, suffix):

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -710,10 +710,6 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         DEPRECATED
         the components to be read less often (i.e., in
         ``read_configuration()``) and to adjust via ``configure()``
-    hints : dict or None, optional
-        May be used to help downstream consumers infer interesting keys.
-        Example: ``{'fields': ['motor_readback']}``. If `None`, a default
-        is derived from the class attribute `_default_hints`
     parent : instance or None, optional
         The instance of the parent device, if applicable
     """
@@ -1031,8 +1027,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         fields = []
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind & Kind.HINTED:
-                fields.append(component).name
+            if component.kind == Kind.HINTED:
+                fields.append(component.name)
         return {'fields': fields}
 
     @property

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -744,24 +744,23 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
 
         super().__init__(name=name, parent=parent, kind=kind, **kwargs)
 
+        # If any sub-Devices are to be removed from configuration_attrs and
+        # read_attrs, we have to remove them from read_attrs first, or they
+        # will not allow themselves to be removed from configuration_attrs.
+        if self._default_read_attrs is not RESPECT_KIND:
+            if read_attrs is None:
+                read_attrs = (self._default_read_attrs if
+                              self._default_read_attrs is not None
+                              else self.component_names)
+            self.read_attrs = list(read_attrs)
+
         if self._default_configuration_attrs is not RESPECT_KIND:
             if configuration_attrs is None:
                     dflt_c_attrs = self._default_configuration_attrs
                     configuration_attrs = (dflt_c_attrs if
-                                        dflt_c_attrs is not None
-                                        else [])
+                                           dflt_c_attrs is not None
+                                           else [])
             self.configuration_attrs = list(configuration_attrs)
-
-<<<<<<< HEAD
-        if self._default_read_attrs is not RESPECT_KIND:
-            if read_attrs is None:
-                read_attrs = (self._default_read_attrs if
-                            self._default_read_attrs is not None
-                            else self.component_names)
-            self.read_attrs = list(read_attrs)
-=======
-        self.read_attrs = list(read_attrs)
-        self.configuration_attrs = list(configuration_attrs)
 
         # Instantiate non-lazy signals
         [getattr(self, attr) for attr, cpt in self._sig_attrs.items()

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -90,7 +90,7 @@ class Component:
 
         if add_prefix is None:
             add_prefix = ('suffix', 'write_pv')
-        self.kwargs.setdefault('kind', Kind.NORMAL)
+        self.kwargs.setdefault('kind', Kind.normal)
         self.add_prefix = tuple(add_prefix)
 
     def maybe_add_prefix(self, instance, kw, suffix):
@@ -711,7 +711,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
     name : str, keyword only
         The name of the device
     kind : a member the Kind IntEnum (or equivalent integer), optional
-        Default is Kind.NORMAL. See Kind for options.
+        Default is Kind.normal. See Kind for options.
     read_attrs : sequence of attribute names
         DEPRECATED
         the components to include in a normal reading (i.e., in ``read()``)
@@ -785,27 +785,27 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
 
     def _validate_kind(self, val):
         if isinstance(val, str):
-            val = getattr(Kind, val.upper())
-        if Kind.NORMAL & val:
-            val = val | Kind.CONFIG
+            val = getattr(Kind, val.lower())
+        if Kind.normal & val:
+            val = val | Kind.config
         return super()._validate_kind(val)
 
     @property
     def read_attrs(self):
-        return _OphydAttrList(self, Kind.NORMAL, Kind.HINTED, 'read_attrs')
+        return _OphydAttrList(self, Kind.normal, Kind.hinted, 'read_attrs')
 
     @read_attrs.setter
     def read_attrs(self, val):
-        self.__attr_list_helper(val, Kind.NORMAL, Kind.HINTED, 'read_attrs')
+        self.__attr_list_helper(val, Kind.normal, Kind.hinted, 'read_attrs')
 
     @property
     def configuration_attrs(self):
-        return _OphydAttrList(self, Kind.CONFIG, Kind.CONFIG,
+        return _OphydAttrList(self, Kind.config, Kind.config,
                               'configuration_attrs')
 
     @configuration_attrs.setter
     def configuration_attrs(self, val):
-        self.__attr_list_helper(val, Kind.CONFIG, Kind.CONFIG,
+        self.__attr_list_helper(val, Kind.config, Kind.config,
                                 'configuration_attrs')
 
     def __attr_list_helper(self, val, set_kind, unset_kind, recurse_name):
@@ -994,7 +994,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         res = super().read()
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind & Kind.NORMAL:
+            if component.kind & Kind.normal:
                 res.update(component.read())
         return res
 
@@ -1008,7 +1008,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         res = OrderedDict()
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind & Kind.CONFIG:
+            if component.kind & Kind.config:
                 res.update(component.read_configuration())
         return res
 
@@ -1017,7 +1017,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         res = super().describe()
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind & Kind.NORMAL:
+            if component.kind & Kind.normal:
                 res.update(component.describe())
         return res
 
@@ -1039,7 +1039,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         res = OrderedDict()
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if component.kind & Kind.CONFIG:
+            if component.kind & Kind.config:
                 res.update(component.describe_configuration())
         return res
 
@@ -1048,7 +1048,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         fields = []
         for component_name in self.component_names:
             component = getattr(self, component_name)
-            if Kind.NORMAL & component.kind:
+            if Kind.normal & component.kind:
                 c_hints = component.hints
                 fields.extend(c_hints.get('fields', []))
         return {'fields': fields}

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -441,13 +441,6 @@ class ComponentMeta(type):
         return clsobj
 
 
-# Convenience wrappers to avoid screens full of kind=Kind.OMITTED, etc.
-OmittedComponent = functools.partial(Component, kind=Kind.OMITTED)
-NormalComponent = Component  # for completeness
-ConfigComponent = functools.partial(Component, kind=Kind.CONFIG)
-HintedComponent = functools.partial(Component, kind=Kind.HINTED)
-
-
 # These stub 'Interface' classes are the apex of the mro heirarchy for
 # their respective methods. They make multiple interitance more
 # forgiving, and let us define classes that customize these methods

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1207,3 +1207,6 @@ class _OphydAttrList(MutableSequence):
 
     def __repr__(self):
         return repr(list(self))
+
+    def __add__(self, other):
+        return list(self) + list(other)

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -824,6 +824,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
                                                 for c in extra)),
                         lambda x: x[0])
         for child, cf_list in group:
+            getattr(self, child).kind |= set_kind
             setattr(getattr(self, child),
                     recurse_name,
                     [c[1] for c in cf_list])

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -769,6 +769,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
          if not cpt.lazy]
 
     def _validate_kind(self, val):
+        if isinstance(val, str):
+            val = getattr(Kind, val.upper())
         if Kind.NORMAL & val:
             val = val | Kind.CONFIG
         return val

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Any, TypeVar, Tuple
 from collections.abc import MutableSequence
 
 A, B = TypeVar('A'), TypeVar('B')
-
+RESPECT_KIND = object()
 
 class OrderedDictType(Dict[A, B]):
     ...
@@ -718,6 +718,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
     # over ride in sub-classes to control the default
     # contents of read and configuration attrs lists
 
+    # To use the new 'kind' parameter, set these equal to the sentinel
+    # REPSECT_KIND, defined in this module.
+
     # If `None`, defaults to `self.component_names'
     _default_read_attrs = None
     # If `None`, defaults to `[]`
@@ -736,19 +739,20 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
 
         super().__init__(name=name, parent=parent, kind=kind, **kwargs)
 
-        if configuration_attrs is None:
-            dflt_c_attrs = self._default_configuration_attrs
-            configuration_attrs = (dflt_c_attrs if
-                                   dflt_c_attrs is not None
-                                   else [])
+        if self._default_configuration_attrs is not RESPECT_KIND:
+            if configuration_attrs is None:
+                    dflt_c_attrs = self._default_configuration_attrs
+                    configuration_attrs = (dflt_c_attrs if
+                                        dflt_c_attrs is not None
+                                        else [])
+            self.configuration_attrs = list(configuration_attrs)
 
-        if read_attrs is None:
-            read_attrs = (self._default_read_attrs if
-                          self._default_read_attrs is not None
-                          else self.component_names)
-
-        self.read_attrs = list(read_attrs)
-        self.configuration_attrs = list(configuration_attrs)
+        if self._default_read_attrs is not RESPECT_KIND:
+            if read_attrs is None:
+                read_attrs = (self._default_read_attrs if
+                            self._default_read_attrs is not None
+                            else self.component_names)
+            self.read_attrs = list(read_attrs)
 
         # Instantiate non-lazy signals
         [getattr(self, attr) for attr, cpt in self._sig_attrs.items()

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1190,3 +1190,6 @@ class _OphydAttrList(MutableSequence):
 
     def __eq__(self, other):
         return list(self) == other
+
+    def __repr__(self):
+        return repr(list(self))

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -326,18 +326,8 @@ class DynamicDeviceComponent:
         for attr in self.defn.keys():
             clsdict[attr] = self.create_attr(attr)
 
-        attrs = set(self.defn.keys())
-        inst_read = set(instance.read_attrs)
-        if self.attr in inst_read:
-            # if the sub-device is in the read list, then add all attrs
-            read_attrs = attrs
-        else:
-            # otherwise, only add the attributes that exist in the sub-device
-            # to the read_attrs list
-            read_attrs = inst_read.intersection(attrs)
-
         cls = type(clsname, (Device, ), clsdict)
-        return cls(instance.prefix, read_attrs=list(read_attrs),
+        return cls(instance.prefix,
                    name='{}_{}'.format(instance.name, self.attr),
                    parent=instance)
 

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -774,10 +774,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         for c in self.component_names:
             if c in val:
                 getattr(self, c).kind |= Kind.NORMAL
-
             else:
                 # need to remove both read and hint behavior
-                getattr(self, c).kind ^= Kind.HINTED
+                getattr(self, c).kind &= ~Kind.HINTED
 
     @property
     def configuration_attrs(self):
@@ -790,9 +789,8 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         for c in self.component_names:
             if c in val:
                 getattr(self, c).kind |= Kind.CONFIG
-
             else:
-                getattr(self, c).kind ^= Kind.CONFIG
+                getattr(self, c).kind &= ~Kind.CONFIG
 
     @property
     def signal_names(self):
@@ -1182,7 +1180,7 @@ class _OphydAttrList(MutableSequence):
         if not isinstance(key, slice):
             o = [o]
         for k in o:
-            getattr(self._parent, k).kind ^= self._kind
+            getattr(self._parent, k).kind &= ~self._kind
 
     def __len__(self):
         return len(self.__internal_list())

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -287,12 +287,3 @@ class MotorBundle(Device):
     """
     _default_read_attrs = RESPECT_KIND
     _default_configuration_attrs = RESPECT_KIND
-
-    @property
-    def hints(self):
-        """Provide the union of all the children's hints as hints."""
-        return {'fields':
-                [h
-                    for s in self.component_names
-                    for h in getattr(getattr(self, s),
-                                    'hints', {}).get('fields', [])]}

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -6,7 +6,9 @@ from .signal import (EpicsSignal, EpicsSignalRO)
 from .utils import DisconnectedError
 from .utils.epics_pvs import (raise_if_disconnected, AlarmSeverity)
 from .positioner import PositionerBase
-from .device import (Device, Component as Cpt)
+from .device import (Device, Component as Cpt, OmittedComponent as OCpt,
+                     ConfigComponent as CCpt, HintedComponent as HCpt,
+                     RESPECT_KIND)
 from .status import wait as status_wait
 from enum import Enum
 
@@ -40,37 +42,35 @@ class EpicsMotor(Device, PositionerBase):
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
     '''
-    _default_read_attrs = ('user_readback', 'user_setpoint')
-    _default_configuration_attrs = ('motor_egu', 'velocity', 'acceleration',
-                                    'user_offset', 'user_offset_dir')
-    _default_hints = {'fields': ['user_readback']}
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
     # position
-    user_readback = Cpt(EpicsSignalRO, '.RBV')
+    user_readback = HCpt(EpicsSignalRO, '.RBV')
     user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
 
     # calibration dial <-> user
-    user_offset = Cpt(EpicsSignal, '.OFF')
-    user_offset_dir = Cpt(EpicsSignal, '.DIR')
-    offset_freeze_switch = Cpt(EpicsSignal, '.FOFF')
-    set_use_switch = Cpt(EpicsSignal, '.SET')
+    user_offset = CCpt(EpicsSignal, '.OFF')
+    user_offset_dir = CCpt(EpicsSignal, '.DIR')
+    offset_freeze_switch = OCpt(EpicsSignal, '.FOFF')
+    set_use_switch = OCpt(EpicsSignal, '.SET')
 
     # configuration
-    velocity = Cpt(EpicsSignal, '.VELO')
-    acceleration = Cpt(EpicsSignal, '.ACCL')
-    motor_egu = Cpt(EpicsSignal, '.EGU')
+    velocity = CCpt(EpicsSignal, '.VELO')
+    acceleration = CCpt(EpicsSignal, '.ACCL')
+    motor_egu = CCpt(EpicsSignal, '.EGU')
 
     # motor status
-    motor_is_moving = Cpt(EpicsSignalRO, '.MOVN')
-    motor_done_move = Cpt(EpicsSignalRO, '.DMOV')
-    high_limit_switch = Cpt(EpicsSignal, '.HLS')
-    low_limit_switch = Cpt(EpicsSignal, '.LLS')
-    direction_of_travel = Cpt(EpicsSignal, '.TDIR')
+    motor_is_moving = OCpt(EpicsSignalRO, '.MOVN')
+    motor_done_move = OCpt(EpicsSignalRO, '.DMOV')
+    high_limit_switch = OCpt(EpicsSignal, '.HLS')
+    low_limit_switch = OCpt(EpicsSignal, '.LLS')
+    direction_of_travel = OCpt(EpicsSignal, '.TDIR')
 
     # commands
-    motor_stop = Cpt(EpicsSignal, '.STOP')
-    home_forward = Cpt(EpicsSignal, '.HOMF')
-    home_reverse = Cpt(EpicsSignal, '.HOMR')
+    motor_stop = OCpt(EpicsSignal, '.STOP')
+    home_forward = OCpt(EpicsSignal, '.HOMF')
+    home_reverse = OCpt(EpicsSignal, '.HOMR')
 
     # alarm information
     tolerated_alarm = AlarmSeverity.NO_ALARM

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -287,6 +287,8 @@ class MotorBundle(Device):
 
     This provides better default behavior for ``hints``.
     """
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
     @property
     def hints(self):

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -285,41 +285,14 @@ class EpicsMotor(Device, PositionerBase):
 class MotorBundle(Device):
     """Sub-class this to device a bundle of motors
 
-    This provides better default behavior for ``hints``,
-    ``read_attrs`` and ``configuration_attrs``
+    This provides better default behavior for ``hints``.
     """
-    _hints = None
 
     @property
     def hints(self):
-        """Provide hints to bluesky
-
-        The default value is the union of all the children's hints.
-
-        To override this, set another dictionary.
-
-        To restore the default value set ``None``
-
-        To suppress all hints set ``{}``
-        """
-        if self._hints is None:
-            return {'fields':
-                    [h
-                     for s in self.component_names
-                     for h in getattr(getattr(self, s),
-                                      'hints', {}).get('fields', [])]}
-
-        return self._hints
-
-    @hints.setter
-    def hints(self, val):
-        if val is None:
-            self._hints = None
-        else:
-            self._hints = dict(val)
-
-    def __init__(self, *args, configuration_attrs=None, **kwargs):
-        if configuration_attrs is None:
-            configuration_attrs = self.component_names
-        super().__init__(*args, configuration_attrs=configuration_attrs,
-                         **kwargs)
+        """Provide the union of all the children's hints as hints."""
+        return {'fields':
+                [h
+                    for s in self.component_names
+                    for h in getattr(getattr(self, s),
+                                    'hints', {}).get('fields', [])]}

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -6,7 +6,7 @@ from .signal import (EpicsSignal, EpicsSignalRO)
 from .utils import DisconnectedError
 from .utils.epics_pvs import (raise_if_disconnected, AlarmSeverity)
 from .positioner import PositionerBase
-from .device import (Device, Component as Cpt, RESPECT_KIND)
+from .device import (Device, Component as Cpt)
 from .status import wait as status_wait
 from enum import Enum
 
@@ -40,9 +40,6 @@ class EpicsMotor(Device, PositionerBase):
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
     '''
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
-
     # position
     user_readback = Cpt(EpicsSignalRO, '.RBV', kind='hinted')
     user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
@@ -285,5 +282,4 @@ class MotorBundle(Device):
 
     This provides better default behavior for ``hints``.
     """
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
+    ...

--- a/ophyd/epics_motor.py
+++ b/ophyd/epics_motor.py
@@ -6,9 +6,7 @@ from .signal import (EpicsSignal, EpicsSignalRO)
 from .utils import DisconnectedError
 from .utils.epics_pvs import (raise_if_disconnected, AlarmSeverity)
 from .positioner import PositionerBase
-from .device import (Device, Component as Cpt, OmittedComponent as OCpt,
-                     ConfigComponent as CCpt, HintedComponent as HCpt,
-                     RESPECT_KIND)
+from .device import (Device, Component as Cpt, RESPECT_KIND)
 from .status import wait as status_wait
 from enum import Enum
 
@@ -46,31 +44,31 @@ class EpicsMotor(Device, PositionerBase):
     _default_configuration_attrs = RESPECT_KIND
 
     # position
-    user_readback = HCpt(EpicsSignalRO, '.RBV')
+    user_readback = Cpt(EpicsSignalRO, '.RBV', kind='hinted')
     user_setpoint = Cpt(EpicsSignal, '.VAL', limits=True)
 
     # calibration dial <-> user
-    user_offset = CCpt(EpicsSignal, '.OFF')
-    user_offset_dir = CCpt(EpicsSignal, '.DIR')
-    offset_freeze_switch = OCpt(EpicsSignal, '.FOFF')
-    set_use_switch = OCpt(EpicsSignal, '.SET')
+    user_offset = Cpt(EpicsSignal, '.OFF', kind='config')
+    user_offset_dir = Cpt(EpicsSignal, '.DIR', kind='config')
+    offset_freeze_switch = Cpt(EpicsSignal, '.FOFF', kind='omitted')
+    set_use_switch = Cpt(EpicsSignal, '.SET', kind='omitted')
 
     # configuration
-    velocity = CCpt(EpicsSignal, '.VELO')
-    acceleration = CCpt(EpicsSignal, '.ACCL')
-    motor_egu = CCpt(EpicsSignal, '.EGU')
+    velocity = Cpt(EpicsSignal, '.VELO', kind='config')
+    acceleration = Cpt(EpicsSignal, '.ACCL', kind='config')
+    motor_egu = Cpt(EpicsSignal, '.EGU', kind='config')
 
     # motor status
-    motor_is_moving = OCpt(EpicsSignalRO, '.MOVN')
-    motor_done_move = OCpt(EpicsSignalRO, '.DMOV')
-    high_limit_switch = OCpt(EpicsSignal, '.HLS')
-    low_limit_switch = OCpt(EpicsSignal, '.LLS')
-    direction_of_travel = OCpt(EpicsSignal, '.TDIR')
+    motor_is_moving = Cpt(EpicsSignalRO, '.MOVN', kind='omitted')
+    motor_done_move = Cpt(EpicsSignalRO, '.DMOV', kind='omitted')
+    high_limit_switch = Cpt(EpicsSignal, '.HLS', kind='omitted')
+    low_limit_switch = Cpt(EpicsSignal, '.LLS', kind='omitted')
+    direction_of_travel = Cpt(EpicsSignal, '.TDIR', kind='omitted')
 
     # commands
-    motor_stop = OCpt(EpicsSignal, '.STOP')
-    home_forward = OCpt(EpicsSignal, '.HOMF')
-    home_reverse = OCpt(EpicsSignal, '.HOMR')
+    motor_stop = Cpt(EpicsSignal, '.STOP', kind='omitted')
+    home_forward = Cpt(EpicsSignal, '.HOMF', kind='omitted')
+    home_reverse = Cpt(EpicsSignal, '.HOMR', kind='omitted')
 
     # alarm information
     tolerated_alarm = AlarmSeverity.NO_ALARM

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -177,7 +177,7 @@ class WaveformCollector(Device):
     data_is_time : bool, optional
         Use time as the data being acquired
     '''
-    _default_configuration_attrs = ('num_points', )
+    _default_configuration_attrs = ()
     _default_read_attrs = ()
 
     select = C(EpicsSignal, "Sw-Sel")

--- a/ophyd/flyers.py
+++ b/ophyd/flyers.py
@@ -161,7 +161,9 @@ class AreaDetectorTimeseriesCollector(Device):
 
     def describe_collect(self):
         '''Describe details for the flyer collect() method'''
-        desc = self._describe_attr_list(['waveform', 'waveform_ts'])
+        desc = OrderedDict()
+        desc.update(self.waveform.describe())
+        desc.update(self.waveform_ts.describe())
         return {self.stream_name: desc}
 
 
@@ -335,6 +337,12 @@ class MonitorFlyerMixin(BlueskyInterface):
     def _get_stream_name(self, attr):
         obj = getattr(self, attr)
         return self.stream_names.get(attr, obj.name)
+
+    def _describe_attr_list(self, attrs):
+        desc = OrderedDict()
+        for attr in attrs:
+            desc.update(getattr(self, attr).describe())
+        return desc
 
     def _describe_with_dtype(self, attr, *, dtype='array'):
         '''Describe an attribute and change its dtype'''

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from .status import DeviceStatus
 from .signal import (Signal, EpicsSignal, EpicsSignalRO)
 from .device import (Device, Component as C, DynamicDeviceComponent as DDC,
-                     Staged, BlueskyInterface, RESPECT_KIND, Kind)
+                     Staged, BlueskyInterface, ALL_COMPONENTS, Kind)
 from .areadetector import EpicsSignalWithRBV as SignalWithRBV
 
 
@@ -60,9 +60,6 @@ def add_rois(range_, **kwargs):
 
 class EpicsMCARecord(Device):
     '''SynApps MCA Record interface'''
-    _default_configuration_attrs = RESPECT_KIND
-    _default_read_attrs = RESPECT_KIND
-
     stop_signal = C(EpicsSignal, '.STOP', kind='omitted')
     preset_real_time = C(EpicsSignal, '.PRTM', kind=Kind.CONFIG | Kind.NORMAL)
     preset_live_time = C(EpicsSignal, '.PLTM', kind='omitted')
@@ -73,9 +70,7 @@ class EpicsMCARecord(Device):
     background = C(EpicsSignalRO, '.BG', kind='omitted')
     mode = C(EpicsSignal, '.MODE', string=True, kind='omitted')
 
-    rois = DDC(add_rois(range(0, 32), kind='omitted'),
-               default_read_attrs=RESPECT_KIND,
-               default_configuration_attrs=RESPECT_KIND, kind='omitted')
+    rois = DDC(add_rois(range(0, 32), kind='omitted'), kind='omitted')
 
     def __init__(self, *args, **kwargs):
 

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -61,7 +61,7 @@ def add_rois(range_, **kwargs):
 class EpicsMCARecord(Device):
     '''SynApps MCA Record interface'''
     stop_signal = C(EpicsSignal, '.STOP', kind='omitted')
-    preset_real_time = C(EpicsSignal, '.PRTM', kind=Kind.CONFIG | Kind.NORMAL)
+    preset_real_time = C(EpicsSignal, '.PRTM', kind=Kind.config | Kind.normal)
     preset_live_time = C(EpicsSignal, '.PLTM', kind='omitted')
     elapsed_real_time = C(EpicsSignalRO, '.ERTM')
     elapsed_live_time = C(EpicsSignalRO, '.ELTM', kind='omitted')

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from .status import DeviceStatus
 from .signal import (Signal, EpicsSignal, EpicsSignalRO)
 from .device import (Device, Component as C, DynamicDeviceComponent as DDC,
-                     Staged, BlueskyInterface)
+                     Staged, BlueskyInterface, RESPECT_KIND, Kind)
 from .areadetector import EpicsSignalWithRBV as SignalWithRBV
 
 
@@ -60,20 +60,22 @@ def add_rois(range_, **kwargs):
 
 class EpicsMCARecord(Device):
     '''SynApps MCA Record interface'''
-    _default_configuration_attrs = ('preset_real_time', )
-    _default_read_attrs = ('spectrum', 'preset_real_time', 'elapsed_real_time')
+    _default_configuration_attrs = RESPECT_KIND
+    _default_read_attrs = RESPECT_KIND
 
-    stop_signal = C(EpicsSignal, '.STOP')
-    preset_real_time = C(EpicsSignal, '.PRTM')
-    preset_live_time = C(EpicsSignal, '.PLTM')
+    stop_signal = C(EpicsSignal, '.STOP', kind='omitted')
+    preset_real_time = C(EpicsSignal, '.PRTM', kind=Kind.CONFIG|Kind.NORMAL)
+    preset_live_time = C(EpicsSignal, '.PLTM', kind='omitted')
     elapsed_real_time = C(EpicsSignalRO, '.ERTM')
-    elapsed_live_time = C(EpicsSignalRO, '.ELTM')
+    elapsed_live_time = C(EpicsSignalRO, '.ELTM', kind='omitted')
 
     spectrum = C(EpicsSignalRO, '.VAL')
-    background = C(EpicsSignalRO, '.BG')
-    mode = C(EpicsSignal, '.MODE', string=True)
+    background = C(EpicsSignalRO, '.BG', kind='omitted')
+    mode = C(EpicsSignal, '.MODE', string=True, kind='omitted')
 
-    rois = DDC(add_rois(range(0, 32)))
+    rois = DDC(add_rois(range(0, 32), kind='omitted'),
+               default_read_attrs=RESPECT_KIND,
+               default_configuration_attrs=RESPECT_KIND, kind='omitted')
 
     def __init__(self, *args, **kwargs):
 
@@ -88,37 +90,37 @@ class EpicsMCARecord(Device):
 
 class EpicsMCA(EpicsMCARecord):
     '''mca records with extras from mca.db'''
-    start = C(EpicsSignal, 'Start')
-    stop_signal = C(EpicsSignal, 'Stop')
-    erase = C(EpicsSignal, 'Erase')
-    erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1)
+    start = C(EpicsSignal, 'Start', kind='omitted')
+    stop_signal = C(EpicsSignal, 'Stop', kind='omitted')
+    erase = C(EpicsSignal, 'Erase', kind='omitted')
+    erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1, kind='omitted')
 
-    check_acquiring = C(EpicsSignal, 'CheckACQG')
-    client_wait = C(EpicsSignal, 'ClientWait')
-    enable_wait = C(EpicsSignal, 'EnableWait')
-    force_read = C(EpicsSignal, 'Read')
-    set_client_wait = C(EpicsSignal, 'SetClientWait')
-    status = C(EpicsSignal, 'Status')
-    when_acq_stops = C(EpicsSignal, 'WhenAcqStops')
-    why1 = C(EpicsSignal, 'Why1')
-    why2 = C(EpicsSignal, 'Why2')
-    why3 = C(EpicsSignal, 'Why3')
-    why4 = C(EpicsSignal, 'Why4')
+    check_acquiring = C(EpicsSignal, 'CheckACQG', kind='omitted')
+    client_wait = C(EpicsSignal, 'ClientWait', kind='omitted')
+    enable_wait = C(EpicsSignal, 'EnableWait', kind='omitted')
+    force_read = C(EpicsSignal, 'Read', kind='omitted')
+    set_client_wait = C(EpicsSignal, 'SetClientWait', kind='omitted')
+    status = C(EpicsSignal, 'Status', kind='omitted')
+    when_acq_stops = C(EpicsSignal, 'WhenAcqStops', kind='omitted')
+    why1 = C(EpicsSignal, 'Why1', kind='omitted')
+    why2 = C(EpicsSignal, 'Why2', kind='omitted')
+    why3 = C(EpicsSignal, 'Why3', kind='omitted')
+    why4 = C(EpicsSignal, 'Why4', kind='omitted')
 
 
 class EpicsMCAReadNotify(EpicsMCARecord):
     '''mca record with extras from mcaReadNotify.db'''
-    start = C(EpicsSignal, 'Start')
-    stop_signal = C(EpicsSignal, 'Stop')
-    erase = C(EpicsSignal, 'Erase')
-    erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1)
+    start = C(EpicsSignal, 'Start', kind='omitted')
+    stop_signal = C(EpicsSignal, 'Stop', kind='omitted')
+    erase = C(EpicsSignal, 'Erase', kind='omitted')
+    erase_start = C(EpicsSignal, 'EraseStart', trigger_value=1, kind='omitted')
 
-    check_acquiring = C(EpicsSignal, 'CheckACQG')
-    client_wait = C(EpicsSignal, 'ClientWait')
-    enable_wait = C(EpicsSignal, 'EnableWait')
-    force_read = C(EpicsSignal, 'Read')
-    set_client_wait = C(EpicsSignal, 'SetClientWait')
-    status = C(EpicsSignal, 'Status')
+    check_acquiring = C(EpicsSignal, 'CheckACQG', kind='omitted')
+    client_wait = C(EpicsSignal, 'ClientWait', kind='omitted')
+    enable_wait = C(EpicsSignal, 'EnableWait', kind='omitted')
+    force_read = C(EpicsSignal, 'Read', kind='omitted')
+    set_client_wait = C(EpicsSignal, 'SetClientWait', kind='omitted')
+    status = C(EpicsSignal, 'Status', kind='omitted')
 
 
 class EpicsMCACallback(Device):

--- a/ophyd/mca.py
+++ b/ophyd/mca.py
@@ -64,7 +64,7 @@ class EpicsMCARecord(Device):
     _default_read_attrs = RESPECT_KIND
 
     stop_signal = C(EpicsSignal, '.STOP', kind='omitted')
-    preset_real_time = C(EpicsSignal, '.PRTM', kind=Kind.CONFIG|Kind.NORMAL)
+    preset_real_time = C(EpicsSignal, '.PRTM', kind=Kind.CONFIG | Kind.NORMAL)
     preset_live_time = C(EpicsSignal, '.PLTM', kind='omitted')
     elapsed_real_time = C(EpicsSignalRO, '.ERTM')
     elapsed_live_time = C(EpicsSignalRO, '.ELTM', kind='omitted')

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -20,10 +20,10 @@ class Kind(IntFlag):
     traverse it in read(), read_configuration(), or neither. Additionally, if
     decides whether to include its name in `.hints['fields']`.
     """
-    OMITTED = 0
-    NORMAL = 1
-    CONFIG = 2
-    HINTED = 5  # Notice that bool(HINTED & NORMAL) is True.
+    omitted = 0
+    normal = 1
+    config = 2
+    hinted = 5  # Notice that bool(hinted & normal) is True.
 
 
 class UnknownSubscription(KeyError):
@@ -45,7 +45,7 @@ class OphydObject:
     parent : parent, optional
         The object's parent, if it exists in a hierarchy
     kind : a member the Kind IntEnum (or equivalent integer), optional
-        Default is Kind.NORMAL. See Kind for options.
+        Default is Kind.normal. See Kind for options.
 
     Attributes
     ----------
@@ -60,7 +60,7 @@ class OphydObject:
             labels = set()
         self._ophyd_labels_ = set(labels)
         if kind is None:
-            kind = Kind.NORMAL
+            kind = Kind.normal
         self.kind = kind
 
         super().__init__()
@@ -99,7 +99,7 @@ class OphydObject:
 
     def _validate_kind(self, val):
         if isinstance(val, str):
-            val = getattr(Kind, val.upper())
+            val = getattr(Kind, val.lower())
         return val
 
     @property

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -9,11 +9,17 @@ from .status import (StatusBase, MoveStatus, DeviceStatus)
 
 
 class Kind(enum.IntFlag):
-    OMIT = 0
+    """
+    This is used in the .kind attribute of all OphydObj (Signals, Devices).
+
+    A Device examines its components' .kind atttribute to decide whether to
+    traverse it in read(), read_configuration(), or neither. Additionally, if
+    decides whether to include its name in `.hints['fields']`.
+    """
+    OMITTED = 0
     NORMAL = 1
-    CONFIGURATION = 2
-    __PRIVATE = 4
-    PRINCIPAL = NORMAL | __PRIVATE
+    CONFIG = 2
+    HINTED = 5  # Notice that bool(HINTED & NORMAL) is True.
 
 
 class UnknownSubscription(KeyError):

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -1,5 +1,3 @@
-import enum
-import warnings
 from itertools import count
 
 import time
@@ -7,8 +5,14 @@ import logging
 
 from .status import (StatusBase, MoveStatus, DeviceStatus)
 
+try:
+    from enum import IntFlag
+except ImportError:
+    # we must be in python 3.5
+    from .utils._backport_enum import IntFlag
 
-class Kind(enum.IntFlag):
+
+class Kind(IntFlag):
     """
     This is used in the .kind attribute of all OphydObj (Signals, Devices).
 

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -93,9 +93,10 @@ class OphydObject:
         # Instantiate logger
         self.log = logging.getLogger(base_log + '.' + name)
 
-    def _validate_kind(self, kind):
-        # To be customized by subclasses.
-        return kind
+    def _validate_kind(self, val):
+        if isinstance(val, str):
+            val = getattr(Kind, val.upper())
+        return val
 
     @property
     def kind(self):

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import OrderedDict
 import functools
-from .ophydobj import OphydObject
+from .ophydobj import OphydObject, Kind
 from .status import (MoveStatus, wait as status_wait, StatusBase)
 from .utils.epics_pvs import (data_type, data_shape)
 from typing import Any, Callable
@@ -237,6 +237,13 @@ class PositionerBase(OphydObject):
         yield ('settle_time', self._settle_time)
         yield ('timeout', self._timeout)
 
+    @property
+    def hints(self):
+        if (~Kind.NORMAL & Kind.HINTED) & self.kind:
+            return {'fields': [self.name]}
+        else:
+            return {'fields': []}
+
 
 class SoftPositioner(PositionerBase):
     '''A positioner which does not communicate with any hardware
@@ -354,10 +361,6 @@ class SoftPositioner(PositionerBase):
         d[self.name] = {'value': self.position,
                         'timestamp': time.time()}
         return d
-
-    @property
-    def hints(self):
-        return {'fields': [self.name]}
 
     def describe(self):
         """Return the description as a dictionary

--- a/ophyd/positioner.py
+++ b/ophyd/positioner.py
@@ -239,7 +239,7 @@ class PositionerBase(OphydObject):
 
     @property
     def hints(self):
-        if (~Kind.NORMAL & Kind.HINTED) & self.kind:
+        if (~Kind.normal & Kind.hinted) & self.kind:
             return {'fields': [self.name]}
         else:
             return {'fields': []}

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -47,8 +47,8 @@ class PseudoSingle(Device, SoftPositioner):
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
     '''
-    readback = Cpt(AttributeSignal, attr='position', kind=Kind.HINTED)
-    setpoint = Cpt(AttributeSignal, attr='target', kind=Kind.NORMAL)
+    readback = Cpt(AttributeSignal, attr='position', kind=Kind.hinted)
+    setpoint = Cpt(AttributeSignal, attr='target', kind=Kind.normal)
 
     def __init__(self, prefix='', *, limits=None, egu='', parent=None,
                  name=None, source='computed',

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -662,14 +662,6 @@ class PseudoPositioner(Device, SoftPositioner):
         '''Real motor position namedtuple'''
         return self.RealPosition(*self._real_cur_pos.values())
 
-    @property
-    def hints(self):
-        return {'fields':
-                [h for hints in [
-                    getattr(c, 'hints', {}).get('fields', [])
-                    for c in self.pseudo_positioners]
-                 for h in hints]}
-
     def _update_position(self):
         '''Update the internal position based on all of the real positioners'''
         real_cur_pos = self.real_position

--- a/ophyd/pseudopos.py
+++ b/ophyd/pseudopos.py
@@ -11,7 +11,7 @@ from collections import (OrderedDict, namedtuple, Sequence, Mapping)
 
 from .utils import (DisconnectedError, ExceptionBundle)
 from .positioner import (PositionerBase, SoftPositioner)
-from .device import (Device, Component as Cpt)
+from .device import (Device, Component as Cpt, Kind)
 from .signal import AttributeSignal
 
 
@@ -47,11 +47,8 @@ class PseudoSingle(Device, SoftPositioner):
     timeout : float, optional
         The default timeout to use for motion requests, in seconds.
     '''
-    _default_read_attrs = ('setpoint', 'readback')
-    _default_hints = {'fields': ['readback']}
-
-    readback = Cpt(AttributeSignal, attr='position')
-    setpoint = Cpt(AttributeSignal, attr='target')
+    readback = Cpt(AttributeSignal, attr='position', kind=Kind.HINTED)
+    setpoint = Cpt(AttributeSignal, attr='target', kind=Kind.NORMAL)
 
     def __init__(self, prefix='', *, limits=None, egu='', parent=None,
                  name=None, source='computed',

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -5,6 +5,7 @@ import logging
 from .utils.epics_pvs import fmt_time
 
 from .device import Device
+from .ophydobj import Kind
 from .positioner import PositionerBase
 from .status import wait as status_wait
 
@@ -89,6 +90,7 @@ class PVPositioner(Device, PositionerBase):
 
         if self.readback is not None:
             self.readback.subscribe(self._pos_changed)
+            self.readback.kind = Kind.HINTED
         elif self.setpoint is not None:
             self.setpoint.subscribe(self._pos_changed)
         else:

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -70,8 +70,6 @@ class PVPositioner(Device, PositionerBase):
     done_value = 1
     put_complete = False
 
-    _default_hints = {'fields': ['readback']}
-
     def __init__(self, prefix='', *, limits=None, name=None, read_attrs=None,
                  configuration_attrs=None, parent=None, egu='', **kwargs):
         super().__init__(prefix=prefix, read_attrs=read_attrs,

--- a/ophyd/pv_positioner.py
+++ b/ophyd/pv_positioner.py
@@ -90,7 +90,7 @@ class PVPositioner(Device, PositionerBase):
 
         if self.readback is not None:
             self.readback.subscribe(self._pos_changed)
-            self.readback.kind = Kind.HINTED
+            self.readback.kind = Kind.hinted
         elif self.setpoint is not None:
             self.setpoint.subscribe(self._pos_changed)
         else:

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -99,7 +99,7 @@ class QuadEM(SingleTrigger, DetectorBase):
 
         for i in range(1, 5):
             current = getattr(self, 'current{}'.format(i))
-            current.mean_value.kind = Kind.HINTED
+            current.mean_value.kind = Kind.hinted
 
 
 class NSLS_EM(QuadEM):

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -20,6 +20,11 @@ def _current_fields(attr_base, field_base, range_, **kwargs):
 
 
 class QuadEM(SingleTrigger, DetectorBase):
+    # These settings intentionally shadow the settings inherited from
+    # DetectorBase.
+    _default_read_attrs = None
+    _default_configuration_attrs = None
+
     _status_type = DeviceStatus  # overrriding the default in SingleTrigger
 
     # This is needed because ophyd verifies that it can see all

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -2,8 +2,7 @@ from collections import OrderedDict
 
 from . import (EpicsSignalRO, EpicsSignal, Component as Cpt,
                DynamicDeviceComponent as DDCpt, Signal,
-               Kind, RESPECT_KIND, HintedComponent as HCpt,
-               ConfigComponent as CCpt, OmittedComponent as OCpt)
+               Kind, RESPECT_KIND, kind_context)
 from .areadetector import (ADComponent as ADCpt, EpicsSignalWithRBV,
                            ImagePlugin, StatsPlugin, DetectorBase,
                            SingleTrigger)
@@ -30,40 +29,42 @@ class QuadEM(SingleTrigger, DetectorBase):
     # expose their port name via a PV, but nevertheless server as the
     # root node for the plugins.
     # Leaving this port_name here for compatibility
-    port_name = OCpt(Signal, value='NSLS_EM')
-    model = OCpt(EpicsSignalRO, 'Model')
-    firmware = OCpt(EpicsSignalRO, 'Firmware')
+    integration_time = Cpt(EpicsSignalWithRBV, 'IntegrationTime',
+                           kind='config')
+    averaging_time = Cpt(EpicsSignalWithRBV, 'AveragingTime', kind='config')
+    with kind_context('omitted') as OCpt:
+        port_name = OCpt(Signal, value='NSLS_EM')
+        model = OCpt(EpicsSignalRO, 'Model')
+        firmware = OCpt(EpicsSignalRO, 'Firmware')
 
-    acquire_mode = OCpt(EpicsSignalWithRBV, 'AcquireMode')
-    acquire = OCpt(EpicsSignal, 'Acquire')
+        acquire_mode = OCpt(EpicsSignalWithRBV, 'AcquireMode')
+        acquire = OCpt(EpicsSignal, 'Acquire')
 
-    read_format = OCpt(EpicsSignalWithRBV, 'ReadFormat')
-    em_range = OCpt(EpicsSignalWithRBV, 'Range')
-    ping_pong = OCpt(EpicsSignalWithRBV, 'PingPong')
+        read_format = OCpt(EpicsSignalWithRBV, 'ReadFormat')
+        em_range = OCpt(EpicsSignalWithRBV, 'Range')
+        ping_pong = OCpt(EpicsSignalWithRBV, 'PingPong')
 
-    integration_time = CCpt(EpicsSignalWithRBV, 'IntegrationTime')
-    num_channels = OCpt(EpicsSignalWithRBV, 'NumChannels')
-    geometry = OCpt(EpicsSignalWithRBV, 'Geometry')
-    resolution = OCpt(EpicsSignalWithRBV, 'Resolution')
+        num_channels = OCpt(EpicsSignalWithRBV, 'NumChannels')
+        geometry = OCpt(EpicsSignalWithRBV, 'Geometry')
+        resolution = OCpt(EpicsSignalWithRBV, 'Resolution')
 
-    bias_state = OCpt(EpicsSignalWithRBV, 'BiasState')
-    bias_interlock = OCpt(EpicsSignalWithRBV, 'BiasInterlock')
-    bias_voltage = OCpt(EpicsSignalWithRBV, 'BiasVoltage')
-    hvs_readback = OCpt(EpicsSignalRO, 'HVSReadback')
-    hvv_readback = OCpt(EpicsSignalRO, 'HVVReadback')
-    hvi_readback = OCpt(EpicsSignalRO, 'HVIReadback')
+        bias_state = OCpt(EpicsSignalWithRBV, 'BiasState')
+        bias_interlock = OCpt(EpicsSignalWithRBV, 'BiasInterlock')
+        bias_voltage = OCpt(EpicsSignalWithRBV, 'BiasVoltage')
+        hvs_readback = OCpt(EpicsSignalRO, 'HVSReadback')
+        hvv_readback = OCpt(EpicsSignalRO, 'HVVReadback')
+        hvi_readback = OCpt(EpicsSignalRO, 'HVIReadback')
 
-    values_per_read = OCpt(EpicsSignalWithRBV, 'ValuesPerRead')
-    sample_time = OCpt(EpicsSignalRO, 'SampleTime_RBV')  # yay for consistency
-    averaging_time = CCpt(EpicsSignalWithRBV, 'AveragingTime')
-    num_average = OCpt(EpicsSignalRO, 'NumAverage_RBV')
-    num_averaged = OCpt(EpicsSignalRO, 'NumAveraged_RBV')
-    num_acquire = OCpt(EpicsSignalWithRBV, 'NumAcquire')
-    num_acquired = OCpt(EpicsSignalRO, 'NumAcquired')
-    read_data = OCpt(EpicsSignalRO, 'ReadData')
-    ring_overflows = OCpt(EpicsSignalRO, 'RingOverflows')
-    trigger_mode = OCpt(EpicsSignal, 'TriggerMode')
-    reset = OCpt(EpicsSignal, 'Reset')
+        values_per_read = OCpt(EpicsSignalWithRBV, 'ValuesPerRead')
+        sample_time = OCpt(EpicsSignalRO, 'SampleTime_RBV')  # yay consistency
+        num_average = OCpt(EpicsSignalRO, 'NumAverage_RBV')
+        num_averaged = OCpt(EpicsSignalRO, 'NumAveraged_RBV')
+        num_acquire = OCpt(EpicsSignalWithRBV, 'NumAcquire')
+        num_acquired = OCpt(EpicsSignalRO, 'NumAcquired')
+        read_data = OCpt(EpicsSignalRO, 'ReadData')
+        ring_overflows = OCpt(EpicsSignalRO, 'RingOverflows')
+        trigger_mode = OCpt(EpicsSignal, 'TriggerMode')
+        reset = OCpt(EpicsSignal, 'Reset')
 
     current_names = DDCpt(_current_fields('ch', 'CurrentName', range(1, 5),
                                           string=True))

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -1,7 +1,9 @@
 from collections import OrderedDict
 
 from . import (EpicsSignalRO, EpicsSignal, Component as Cpt,
-               DynamicDeviceComponent as DDCpt, Signal)
+               DynamicDeviceComponent as DDCpt, Signal,
+               Kind, RESPECT_KIND, HintedComponent as HCpt,
+               ConfigComponent as CCpt, OmittedComponent as OCpt)
 from .areadetector import (ADComponent as ADCpt, EpicsSignalWithRBV,
                            ImagePlugin, StatsPlugin, DetectorBase,
                            SingleTrigger)
@@ -19,10 +21,8 @@ def _current_fields(attr_base, field_base, range_, **kwargs):
 
 
 class QuadEM(SingleTrigger, DetectorBase):
-    _default_configuration_attrs = ('integration_time', 'averaging_time')
-    _default_read_attrs = ('current1.mean_value', 'current2.mean_value',
-                           'current3.mean_value', 'current4.mean_value')
-    _default_hints = {'fields': list(_default_read_attrs)}
+    _default_configuration_attrs = RESPECT_KIND
+    _default_read_attrs = RESPECT_KIND
     _status_type = DeviceStatus  # overrriding the default in SingleTrigger
 
     # This is needed because ophyd verifies that it can see all
@@ -30,40 +30,40 @@ class QuadEM(SingleTrigger, DetectorBase):
     # expose their port name via a PV, but nevertheless server as the
     # root node for the plugins.
     # Leaving this port_name here for compatibility
-    port_name = Cpt(Signal, value='NSLS_EM')
-    model = Cpt(EpicsSignalRO, 'Model')
-    firmware = Cpt(EpicsSignalRO, 'Firmware')
+    port_name = OCpt(Signal, value='NSLS_EM')
+    model = OCpt(EpicsSignalRO, 'Model')
+    firmware = OCpt(EpicsSignalRO, 'Firmware')
 
-    acquire_mode = Cpt(EpicsSignalWithRBV, 'AcquireMode')
-    acquire = Cpt(EpicsSignal, 'Acquire')
+    acquire_mode = OCpt(EpicsSignalWithRBV, 'AcquireMode')
+    acquire = OCpt(EpicsSignal, 'Acquire')
 
-    read_format = Cpt(EpicsSignalWithRBV, 'ReadFormat')
-    em_range = Cpt(EpicsSignalWithRBV, 'Range')
-    ping_pong = Cpt(EpicsSignalWithRBV, 'PingPong')
+    read_format = OCpt(EpicsSignalWithRBV, 'ReadFormat')
+    em_range = OCpt(EpicsSignalWithRBV, 'Range')
+    ping_pong = OCpt(EpicsSignalWithRBV, 'PingPong')
 
-    integration_time = Cpt(EpicsSignalWithRBV, 'IntegrationTime')
-    num_channels = Cpt(EpicsSignalWithRBV, 'NumChannels')
-    geometry = Cpt(EpicsSignalWithRBV, 'Geometry')
-    resolution = Cpt(EpicsSignalWithRBV, 'Resolution')
+    integration_time = CCpt(EpicsSignalWithRBV, 'IntegrationTime')
+    num_channels = OCpt(EpicsSignalWithRBV, 'NumChannels')
+    geometry = OCpt(EpicsSignalWithRBV, 'Geometry')
+    resolution = OCpt(EpicsSignalWithRBV, 'Resolution')
 
-    bias_state = Cpt(EpicsSignalWithRBV, 'BiasState')
-    bias_interlock = Cpt(EpicsSignalWithRBV, 'BiasInterlock')
-    bias_voltage = Cpt(EpicsSignalWithRBV, 'BiasVoltage')
-    hvs_readback = Cpt(EpicsSignalRO, 'HVSReadback')
-    hvv_readback = Cpt(EpicsSignalRO, 'HVVReadback')
-    hvi_readback = Cpt(EpicsSignalRO, 'HVIReadback')
+    bias_state = OCpt(EpicsSignalWithRBV, 'BiasState')
+    bias_interlock = OCpt(EpicsSignalWithRBV, 'BiasInterlock')
+    bias_voltage = OCpt(EpicsSignalWithRBV, 'BiasVoltage')
+    hvs_readback = OCpt(EpicsSignalRO, 'HVSReadback')
+    hvv_readback = OCpt(EpicsSignalRO, 'HVVReadback')
+    hvi_readback = OCpt(EpicsSignalRO, 'HVIReadback')
 
-    values_per_read = Cpt(EpicsSignalWithRBV, 'ValuesPerRead')
-    sample_time = Cpt(EpicsSignalRO, 'SampleTime_RBV')  # yay for consistency
-    averaging_time = Cpt(EpicsSignalWithRBV, 'AveragingTime')
-    num_average = Cpt(EpicsSignalRO, 'NumAverage_RBV')
-    num_averaged = Cpt(EpicsSignalRO, 'NumAveraged_RBV')
-    num_acquire = Cpt(EpicsSignalWithRBV, 'NumAcquire')
-    num_acquired = Cpt(EpicsSignalRO, 'NumAcquired')
-    read_data = Cpt(EpicsSignalRO, 'ReadData')
-    ring_overflows = Cpt(EpicsSignalRO, 'RingOverflows')
-    trigger_mode = Cpt(EpicsSignal, 'TriggerMode')
-    reset = Cpt(EpicsSignal, 'Reset')
+    values_per_read = OCpt(EpicsSignalWithRBV, 'ValuesPerRead')
+    sample_time = OCpt(EpicsSignalRO, 'SampleTime_RBV')  # yay for consistency
+    averaging_time = CCpt(EpicsSignalWithRBV, 'AveragingTime')
+    num_average = OCpt(EpicsSignalRO, 'NumAverage_RBV')
+    num_averaged = OCpt(EpicsSignalRO, 'NumAveraged_RBV')
+    num_acquire = OCpt(EpicsSignalWithRBV, 'NumAcquire')
+    num_acquired = OCpt(EpicsSignalRO, 'NumAcquired')
+    read_data = OCpt(EpicsSignalRO, 'ReadData')
+    ring_overflows = OCpt(EpicsSignalRO, 'RingOverflows')
+    trigger_mode = OCpt(EpicsSignal, 'TriggerMode')
+    reset = OCpt(EpicsSignal, 'Reset')
 
     current_names = DDCpt(_current_fields('ch', 'CurrentName', range(1, 5),
                                           string=True))
@@ -97,6 +97,10 @@ class QuadEM(SingleTrigger, DetectorBase):
                                 ('acquire_mode', 2)  # single mode
                                 ])
         self._acquisition_signal = self.acquire
+
+        for i in range(1, 5):
+            current = getattr(self, 'current{}'.format(i))
+            current.mean_value.kind = Kind.HINTED
 
 
 class NSLS_EM(QuadEM):

--- a/ophyd/quadem.py
+++ b/ophyd/quadem.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from . import (EpicsSignalRO, EpicsSignal, Component as Cpt,
                DynamicDeviceComponent as DDCpt, Signal,
-               Kind, RESPECT_KIND, kind_context)
+               Kind, kind_context)
 from .areadetector import (ADComponent as ADCpt, EpicsSignalWithRBV,
                            ImagePlugin, StatsPlugin, DetectorBase,
                            SingleTrigger)
@@ -20,8 +20,6 @@ def _current_fields(attr_base, field_base, range_, **kwargs):
 
 
 class QuadEM(SingleTrigger, DetectorBase):
-    _default_configuration_attrs = RESPECT_KIND
-    _default_read_attrs = RESPECT_KIND
     _status_type = DeviceStatus  # overrriding the default in SingleTrigger
 
     # This is needed because ophyd verifies that it can see all

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -6,7 +6,7 @@ from .ophydobj import Kind
 from .signal import (EpicsSignal, EpicsSignalRO)
 from .device import Device
 from .device import (Component as C, DynamicDeviceComponent as DDC,
-                     FormattedComponent as FC, RESPECT_KIND)
+                     FormattedComponent as FC)
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,6 @@ def _scaler_fields(cls, attr_base, field_base, range_, **kwargs):
 
 class EpicsScaler(Device):
     '''SynApps Scaler Record interface'''
-    _default_configuration_attrs = RESPECT_KIND
-    _default_read_attrs = RESPECT_KIND
     # tigger + trigger mode
     count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)
     count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.CONFIG)
@@ -35,13 +33,9 @@ class EpicsScaler(Device):
 
     # the data
     channels = DDC(_scaler_fields(EpicsSignalRO, 'chan', '.S', range(1, 33),
-                                  kind=Kind.HINTED),
-                   default_read_attrs=RESPECT_KIND,
-                   default_configuration_attrs=RESPECT_KIND)
+                                  kind=Kind.HINTED))
     names = DDC(_scaler_fields(EpicsSignal, 'name', '.NM', range(1, 33),
-                               kind=Kind.CONFIG),
-                default_read_attrs=RESPECT_KIND,
-                default_configuration_attrs=RESPECT_KIND)
+                               kind=Kind.CONFIG))
 
     time = C(EpicsSignal, '.T', kind=Kind.CONFIG)
     freq = C(EpicsSignal, '.FREQ', kind=Kind.CONFIG)
@@ -50,13 +44,9 @@ class EpicsScaler(Device):
     auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.CONFIG)
 
     presets = DDC(_scaler_fields(EpicsSignal, 'preset', '.PR', range(1, 33),
-                                 kind=Kind.OMITTED),
-                  default_read_attrs=RESPECT_KIND,
-                  default_configuration_attrs=RESPECT_KIND)
+                                 kind=Kind.OMITTED))
     gates = DDC(_scaler_fields(EpicsSignal, 'gate', '.G', range(1, 33),
-                               kind=Kind.OMITTED),
-                default_read_attrs=RESPECT_KIND,
-                default_configuration_attrs=RESPECT_KIND)
+                               kind=Kind.OMITTED))
 
     update_rate = C(EpicsSignal, '.RATE', kind=Kind.CONFIG)
     auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.CONFIG)
@@ -71,8 +61,6 @@ class EpicsScaler(Device):
 
 
 class ScalerChannel(Device):
-    _default_configuration_attrs = RESPECT_KIND
-    _default_read_attrs = RESPECT_KIND
 
     # TODO set up monitor on this to automatically change the name
     chname = FC(EpicsSignal, '{self.prefix}.NM{self._ch_num}',
@@ -105,13 +93,9 @@ def _sc_chans(attr_fix, id_range):
 
 
 class ScalerCH(Device):
-    _default_configuration_attrs = RESPECT_KIND
-    _default_read_attrs = RESPECT_KIND
 
     # The data
-    channels = DDC(_sc_chans('chan', range(1, 33)),
-                   default_read_attrs=RESPECT_KIND,
-                   default_configuration_attrs=RESPECT_KIND)
+    channels = DDC(_sc_chans('chan', range(1, 33)))
 
     # tigger + trigger mode
     count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -35,9 +35,13 @@ class EpicsScaler(Device):
 
     # the data
     channels = DDC(_scaler_fields(EpicsSignalRO, 'chan', '.S', range(1, 33),
-                                  kind=Kind.HINTED))
+                                  kind=Kind.HINTED),
+                   default_read_attrs=RESPECT_KIND,
+                   default_configuration_attrs=RESPECT_KIND)
     names = DDC(_scaler_fields(EpicsSignal, 'name', '.NM', range(1, 33),
-                               kind=Kind.CONFIG))
+                               kind=Kind.CONFIG),
+                default_read_attrs=RESPECT_KIND,
+                default_configuration_attrs=RESPECT_KIND)
 
     time = C(EpicsSignal, '.T')
     freq = CC(EpicsSignal, '.FREQ')
@@ -46,9 +50,13 @@ class EpicsScaler(Device):
     auto_count_time = CC(EpicsSignal, '.TP1')
 
     presets = DDC(_scaler_fields(EpicsSignal, 'preset', '.PR', range(1, 33),
-                                 kind=Kind.OMITTED))
+                                 kind=Kind.OMITTED),
+                  default_read_attrs=RESPECT_KIND,
+                  default_configuration_attrs=RESPECT_KIND)
     gates = DDC(_scaler_fields(EpicsSignal, 'gate', '.G', range(1, 33),
-                               kind=Kind.OMITTED))
+                               kind=Kind.OMITTED),
+                default_read_attrs=RESPECT_KIND,
+                default_configuration_attrs=RESPECT_KIND)
 
     update_rate = OC(EpicsSignal, '.RATE')
     auto_count_update_rate = OC(EpicsSignal, '.RAT1')
@@ -97,7 +105,9 @@ class ScalerCH(Device):
     _default_read_attrs = RESPECT_KIND
 
     # The data
-    channels = DDC(_sc_chans('chan', range(1, 33)))
+    channels = DDC(_sc_chans('chan', range(1, 33)),
+                   default_read_attrs=RESPECT_KIND,
+                   default_configuration_attrs=RESPECT_KIND)
 
     # tigger + trigger mode
     count = OC(EpicsSignal, '.CNT', trigger_value=1)

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -167,7 +167,8 @@ class ScalerCH(Device):
                 raise RuntimeError("The channel {} is not configured "
                                    "on the scaler.  The named channels are "
                                    "{}".format(ch, tuple(name_map)))
+        self.channels.kind = Kind.NORMAL
         self.channels.read_attrs = list(read_attrs)
         self.channels.configuration_attrs = list(read_attrs)
-        self.hints = {'fields': [getattr(self.channels, ch).s.name
-                                 for ch in read_attrs[1:]]}
+        for ch in read_attrs[1:]:
+            getattr(self.channels, ch).s.kind = Kind.HINTED

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -6,8 +6,7 @@ from .ophydobj import Kind
 from .signal import (EpicsSignal, EpicsSignalRO)
 from .device import Device
 from .device import (Component as C, DynamicDeviceComponent as DDC,
-                     FormattedComponent as FC, RESPECT_KIND,
-                     ConfigComponent as CC, OmittedComponent as OC)
+                     FormattedComponent as FC, RESPECT_KIND)
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +26,12 @@ class EpicsScaler(Device):
     _default_configuration_attrs = RESPECT_KIND
     _default_read_attrs = RESPECT_KIND
     # tigger + trigger mode
-    count = OC(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)
-    count_mode = CC(EpicsSignal, '.CONT', string=True, kind=Kind.CONFIG)
+    count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)
+    count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.CONFIG)
 
     # delay from triggering to starting counting
-    delay = CC(EpicsSignal, '.DLY', kind=Kind.CONFIG)
-    auto_count_delay = CC(EpicsSignal, '.DLY1', kind=Kind.CONFIG)
+    delay = C(EpicsSignal, '.DLY', kind=Kind.CONFIG)
+    auto_count_delay = C(EpicsSignal, '.DLY1', kind=Kind.CONFIG)
 
     # the data
     channels = DDC(_scaler_fields(EpicsSignalRO, 'chan', '.S', range(1, 33),
@@ -45,10 +44,10 @@ class EpicsScaler(Device):
                 default_configuration_attrs=RESPECT_KIND)
 
     time = C(EpicsSignal, '.T', kind=Kind.CONFIG)
-    freq = CC(EpicsSignal, '.FREQ', kind=Kind.CONFIG)
+    freq = C(EpicsSignal, '.FREQ', kind=Kind.CONFIG)
 
-    preset_time = CC(EpicsSignal, '.TP', kind=Kind.CONFIG)
-    auto_count_time = CC(EpicsSignal, '.TP1', kind=Kind.CONFIG)
+    preset_time = C(EpicsSignal, '.TP', kind=Kind.CONFIG)
+    auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.CONFIG)
 
     presets = DDC(_scaler_fields(EpicsSignal, 'preset', '.PR', range(1, 33),
                                  kind=Kind.OMITTED),
@@ -59,10 +58,10 @@ class EpicsScaler(Device):
                 default_read_attrs=RESPECT_KIND,
                 default_configuration_attrs=RESPECT_KIND)
 
-    update_rate = OC(EpicsSignal, '.RATE', kind=Kind.CONFIG)
-    auto_count_update_rate = OC(EpicsSignal, '.RAT1', kind=Kind.CONFIG)
+    update_rate = C(EpicsSignal, '.RATE', kind=Kind.CONFIG)
+    auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.CONFIG)
 
-    egu = CC(EpicsSignal, '.EGU', kind=Kind.CONFIG)
+    egu = C(EpicsSignal, '.EGU', kind=Kind.CONFIG)
 
     def __init__(self, *args, **kwargs):
 
@@ -115,23 +114,23 @@ class ScalerCH(Device):
                    default_configuration_attrs=RESPECT_KIND)
 
     # tigger + trigger mode
-    count = OC(EpicsSignal, '.CNT', trigger_value=1)
-    count_mode = CC(EpicsSignal, '.CONT', string=True)
+    count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)
+    count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.CONFIG)
 
     # delay from triggering to starting counting
-    delay = CC(EpicsSignal, '.DLY')
-    auto_count_delay = CC(EpicsSignal, '.DLY1')
+    delay = C(EpicsSignal, '.DLY', kind=Kind.CONFIG)
+    auto_count_delay = C(EpicsSignal, '.DLY1', kind=Kind.CONFIG)
 
     time = C(EpicsSignal, '.T')
-    freq = CC(EpicsSignal, '.FREQ')
+    freq = C(EpicsSignal, '.FREQ', kind=Kind.CONFIG)
 
-    preset_time = CC(EpicsSignal, '.TP')
-    auto_count_time = CC(EpicsSignal, '.TP1')
+    preset_time = C(EpicsSignal, '.TP', kind=Kind.CONFIG)
+    auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.CONFIG)
 
-    update_rate = OC(EpicsSignal, '.RATE')
-    auto_count_update_rate = OC(EpicsSignal, '.RAT1')
+    update_rate = C(EpicsSignal, '.RATE', kind=Kind.OMITTED)
+    auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.OMITTED)
 
-    egu = CC(EpicsSignal, '.EGU')
+    egu = C(EpicsSignal, '.EGU', kind=Kind.CONFIG)
 
     def __init__(self, *args, **kwargs):
 

--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -24,34 +24,34 @@ def _scaler_fields(cls, attr_base, field_base, range_, **kwargs):
 class EpicsScaler(Device):
     '''SynApps Scaler Record interface'''
     # tigger + trigger mode
-    count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)
-    count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.CONFIG)
+    count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.omitted)
+    count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.config)
 
     # delay from triggering to starting counting
-    delay = C(EpicsSignal, '.DLY', kind=Kind.CONFIG)
-    auto_count_delay = C(EpicsSignal, '.DLY1', kind=Kind.CONFIG)
+    delay = C(EpicsSignal, '.DLY', kind=Kind.config)
+    auto_count_delay = C(EpicsSignal, '.DLY1', kind=Kind.config)
 
     # the data
     channels = DDC(_scaler_fields(EpicsSignalRO, 'chan', '.S', range(1, 33),
-                                  kind=Kind.HINTED))
+                                  kind=Kind.hinted))
     names = DDC(_scaler_fields(EpicsSignal, 'name', '.NM', range(1, 33),
-                               kind=Kind.CONFIG))
+                               kind=Kind.config))
 
-    time = C(EpicsSignal, '.T', kind=Kind.CONFIG)
-    freq = C(EpicsSignal, '.FREQ', kind=Kind.CONFIG)
+    time = C(EpicsSignal, '.T', kind=Kind.config)
+    freq = C(EpicsSignal, '.FREQ', kind=Kind.config)
 
-    preset_time = C(EpicsSignal, '.TP', kind=Kind.CONFIG)
-    auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.CONFIG)
+    preset_time = C(EpicsSignal, '.TP', kind=Kind.config)
+    auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.config)
 
     presets = DDC(_scaler_fields(EpicsSignal, 'preset', '.PR', range(1, 33),
-                                 kind=Kind.OMITTED))
+                                 kind=Kind.omitted))
     gates = DDC(_scaler_fields(EpicsSignal, 'gate', '.G', range(1, 33),
-                               kind=Kind.OMITTED))
+                               kind=Kind.omitted))
 
-    update_rate = C(EpicsSignal, '.RATE', kind=Kind.CONFIG)
-    auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.CONFIG)
+    update_rate = C(EpicsSignal, '.RATE', kind=Kind.config)
+    auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.config)
 
-    egu = C(EpicsSignal, '.EGU', kind=Kind.CONFIG)
+    egu = C(EpicsSignal, '.EGU', kind=Kind.config)
 
     def __init__(self, *args, **kwargs):
 
@@ -64,13 +64,13 @@ class ScalerChannel(Device):
 
     # TODO set up monitor on this to automatically change the name
     chname = FC(EpicsSignal, '{self.prefix}.NM{self._ch_num}',
-                kind=Kind.CONFIG)
+                kind=Kind.config)
     s = FC(EpicsSignalRO, '{self.prefix}.S{self._ch_num}',
-           kind=Kind.HINTED)
+           kind=Kind.hinted)
     preset = FC(EpicsSignal, '{self.prefix}.PR{self._ch_num}',
-                kind=Kind.CONFIG)
+                kind=Kind.config)
     gate = FC(EpicsSignal, '{self.prefix}.G{self._ch_num}', string=True,
-              kind=Kind.CONFIG)
+              kind=Kind.config)
 
     def __init__(self, prefix, ch_num,
                  **kwargs):
@@ -88,7 +88,7 @@ def _sc_chans(attr_fix, id_range):
     for k in id_range:
         defn['{}{:02d}'.format(attr_fix, k)] = (ScalerChannel,
                                                 '', {'ch_num': k,
-                                                     'kind': Kind.NORMAL})
+                                                     'kind': Kind.normal})
     return defn
 
 
@@ -98,23 +98,23 @@ class ScalerCH(Device):
     channels = DDC(_sc_chans('chan', range(1, 33)))
 
     # tigger + trigger mode
-    count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.OMITTED)
-    count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.CONFIG)
+    count = C(EpicsSignal, '.CNT', trigger_value=1, kind=Kind.omitted)
+    count_mode = C(EpicsSignal, '.CONT', string=True, kind=Kind.config)
 
     # delay from triggering to starting counting
-    delay = C(EpicsSignal, '.DLY', kind=Kind.CONFIG)
-    auto_count_delay = C(EpicsSignal, '.DLY1', kind=Kind.CONFIG)
+    delay = C(EpicsSignal, '.DLY', kind=Kind.config)
+    auto_count_delay = C(EpicsSignal, '.DLY1', kind=Kind.config)
 
     time = C(EpicsSignal, '.T')
-    freq = C(EpicsSignal, '.FREQ', kind=Kind.CONFIG)
+    freq = C(EpicsSignal, '.FREQ', kind=Kind.config)
 
-    preset_time = C(EpicsSignal, '.TP', kind=Kind.CONFIG)
-    auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.CONFIG)
+    preset_time = C(EpicsSignal, '.TP', kind=Kind.config)
+    auto_count_time = C(EpicsSignal, '.TP1', kind=Kind.config)
 
-    update_rate = C(EpicsSignal, '.RATE', kind=Kind.OMITTED)
-    auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.OMITTED)
+    update_rate = C(EpicsSignal, '.RATE', kind=Kind.omitted)
+    auto_count_update_rate = C(EpicsSignal, '.RAT1', kind=Kind.omitted)
 
-    egu = C(EpicsSignal, '.EGU', kind=Kind.CONFIG)
+    egu = C(EpicsSignal, '.EGU', kind=Kind.config)
 
     def __init__(self, *args, **kwargs):
 
@@ -155,8 +155,8 @@ class ScalerCH(Device):
                 raise RuntimeError("The channel {} is not configured "
                                    "on the scaler.  The named channels are "
                                    "{}".format(ch, tuple(name_map)))
-        self.channels.kind = Kind.NORMAL
+        self.channels.kind = Kind.normal
         self.channels.read_attrs = list(read_attrs)
         self.channels.configuration_attrs = list(read_attrs)
         for ch in read_attrs[1:]:
-            getattr(self.channels, ch).s.kind = Kind.HINTED
+            getattr(self.channels, ch).s.kind = Kind.hinted

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -239,7 +239,10 @@ class Signal(OphydObject):
 
     @property
     def hints(self):
-        return {'fields': [self.name]}
+        if (~Kind.NORMAL & Kind.HINTED) & self.kind:
+            return {'fields': [self.name]}
+        else:
+            return {'fields': []}
 
 
 class DerivedSignal(Signal):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -26,7 +26,7 @@ class Signal(OphydObject):
     value : any, optional
         The initial value
     kind : a member the Kind IntEnum (or equivalent integer), optional
-        Default is Kind.NORMAL. See Kind for options.
+        Default is Kind.normal. See Kind for options.
     parent : Device, optional
     timestamp : float, optional
         The timestamp associated with the initial value. Defaults to the
@@ -53,7 +53,7 @@ class Signal(OphydObject):
     _default_sub = SUB_VALUE
 
     def __init__(self, *, name, value=None, timestamp=None, parent=None,
-                 kind=Kind.HINTED, tolerance=None, rtolerance=None, cl=None):
+                 kind=Kind.hinted, tolerance=None, rtolerance=None, cl=None):
         super().__init__(name=name, parent=parent, kind=kind)
         if cl is None:
             cl = get_cl()
@@ -239,7 +239,7 @@ class Signal(OphydObject):
 
     @property
     def hints(self):
-        if (~Kind.NORMAL & Kind.HINTED) & self.kind:
+        if (~Kind.normal & Kind.hinted) & self.kind:
             return {'fields': [self.name]}
         else:
             return {'fields': []}

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -25,6 +25,9 @@ class Signal(OphydObject):
     name : string, keyword only
     value : any, optional
         The initial value
+    kind : a member the Kind IntEnum (or equivalent integer), optional
+        Default is Kind.NORMAL. See Kind for options.
+    parent : Device, optional
     timestamp : float, optional
         The timestamp associated with the initial value. Defaults to the
         current local time.
@@ -50,8 +53,8 @@ class Signal(OphydObject):
     _default_sub = SUB_VALUE
 
     def __init__(self, *, name, value=None, timestamp=None, parent=None,
-                 tolerance=None, rtolerance=None, cl=None):
-        super().__init__(name=name, parent=parent)
+                 kind=None, tolerance=None, rtolerance=None, cl=None):
+        super().__init__(name=name, parent=parent, kind=kind)
         if cl is None:
             cl = get_cl()
         self.cl = cl

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -9,7 +9,7 @@ from .utils import (ReadOnlyError, LimitError)
 from .utils.epics_pvs import (waveform_to_string,
                               raise_if_disconnected, data_type, data_shape,
                               AlarmStatus, AlarmSeverity, validate_pv_name)
-from .ophydobj import OphydObject
+from .ophydobj import OphydObject, Kind
 from .status import Status
 from .utils import set_and_wait
 from . import get_cl
@@ -53,7 +53,7 @@ class Signal(OphydObject):
     _default_sub = SUB_VALUE
 
     def __init__(self, *, name, value=None, timestamp=None, parent=None,
-                 kind=None, tolerance=None, rtolerance=None, cl=None):
+                 kind=Kind.HINTED, tolerance=None, rtolerance=None, cl=None):
         super().__init__(name=name, parent=parent, kind=kind)
         if cl is None:
             cl = get_cl()

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -13,7 +13,7 @@ import uuid
 
 from .signal import Signal
 from .status import DeviceStatus, StatusBase
-from .device import Device, Component, Component as C, Kind
+from .device import Device, Component, Component as C, Kind, RESPECT_KIND
 from types import SimpleNamespace
 from .pseudopos import (PseudoPositioner, PseudoSingle,
                         real_position_argument, pseudo_position_argument)
@@ -747,9 +747,10 @@ class NumpySeqHandler:
 
 
 class ABDetector(Device):
-    _default_hints = {'fields': ['a']}
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
-    a = Component(SynSignal, func=random.random)
+    a = Component(SynSignal, func=random.random, kind=Kind.HINTED)
     b = Component(SynSignal, func=random.random)
 
     def trigger(self):
@@ -757,17 +758,19 @@ class ABDetector(Device):
 
 
 class DetWithCountTime(Device):
-    _default_read_attrs = ('intensity',)
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
-    intensity = Component(SynSignal, func=lambda: 0)
+    intensity = Component(SynSignal, func=lambda: 0, kind=Kind.HINTED)
     count_time = Component(Signal)
 
 
 class DetWithConf(Device):
-    _default_hints = {'fields': ['a', 'b']}
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
-    a = Component(SynSignal, func=lambda: 1)
-    b = Component(SynSignal, func=lambda: 2)
+    a = Component(SynSignal, func=lambda: 1, kind=Kind.HINTED)
+    b = Component(SynSignal, func=lambda: 2, kind=Kind.HINTED)
     c = Component(SynSignal, func=lambda: 3)
     d = Component(SynSignal, func=lambda: 4)
 
@@ -793,11 +796,12 @@ class InvariantSignal(SynSignal):
 
 
 class SPseudo3x3(PseudoPositioner):
-    _default_hints = {'fields': ['pseudo1']}
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
-    pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a')
-    pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b')
-    pseudo3 = C(PseudoSingle, limits=None, egu='c')
+    pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a', kind=Kind.HINTED)
+    pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b', kind=Kind.HINTED)
+    pseudo3 = C(PseudoSingle, limits=None, egu='c', kind=Kind.HINTED)
     real1 = C(SoftPositioner, init_pos=0)
     real2 = C(SoftPositioner, init_pos=0)
     real3 = C(SoftPositioner, init_pos=0)
@@ -822,9 +826,10 @@ class SPseudo3x3(PseudoPositioner):
 
 
 class SPseudo1x3(PseudoPositioner):
-    _default_hints = {'fields': ['pseudo1', 'real1', 'real2', 'real3']}
+    _default_read_attrs = RESPECT_KIND
+    _default_configuration_attrs = RESPECT_KIND
 
-    pseudo1 = C(PseudoSingle, limits=(-10, 10))
+    pseudo1 = C(PseudoSingle, limits=(-10, 10), kind=Kind.HINTED)
     real1 = C(SoftPositioner, init_pos=0)
     real2 = C(SoftPositioner, init_pos=0)
     real3 = C(SoftPositioner, init_pos=0)

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -13,7 +13,7 @@ import uuid
 
 from .signal import Signal
 from .status import DeviceStatus, StatusBase
-from .device import Device, Component, Component as C, Kind, RESPECT_KIND
+from .device import Device, Component, Component as C, Kind
 from types import SimpleNamespace
 from .pseudopos import (PseudoPositioner, PseudoSingle,
                         real_position_argument, pseudo_position_argument)
@@ -747,9 +747,6 @@ class NumpySeqHandler:
 
 
 class ABDetector(Device):
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
-
     a = Component(SynSignal, func=random.random, kind=Kind.HINTED)
     b = Component(SynSignal, func=random.random)
 
@@ -758,17 +755,11 @@ class ABDetector(Device):
 
 
 class DetWithCountTime(Device):
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
-
     intensity = Component(SynSignal, func=lambda: 0, kind=Kind.HINTED)
     count_time = Component(Signal)
 
 
 class DetWithConf(Device):
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
-
     a = Component(SynSignal, func=lambda: 1, kind=Kind.HINTED)
     b = Component(SynSignal, func=lambda: 2, kind=Kind.HINTED)
     c = Component(SynSignal, func=lambda: 3)
@@ -796,9 +787,6 @@ class InvariantSignal(SynSignal):
 
 
 class SPseudo3x3(PseudoPositioner):
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
-
     pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a', kind=Kind.HINTED)
     pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b', kind=Kind.HINTED)
     pseudo3 = C(PseudoSingle, limits=None, egu='c', kind=Kind.HINTED)
@@ -826,9 +814,6 @@ class SPseudo3x3(PseudoPositioner):
 
 
 class SPseudo1x3(PseudoPositioner):
-    _default_read_attrs = RESPECT_KIND
-    _default_configuration_attrs = RESPECT_KIND
-
     pseudo1 = C(PseudoSingle, limits=(-10, 10), kind=Kind.HINTED)
     real1 = C(SoftPositioner, init_pos=0)
     real2 = C(SoftPositioner, init_pos=0)

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -62,7 +62,7 @@ class SynSignal(Signal):
     parent : Device, optional
         Used internally if this Signal is made part of a larger Device.
     kind : a member the Kind IntEnum (or equivalent integer), optional
-        Default is Kind.NORMAL. See Kind for options.
+        Default is Kind.normal. See Kind for options.
     loop : asyncio.EventLoop, optional
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
@@ -174,7 +174,7 @@ class SynPeriodicSignal(SynSignal):
     parent : Device, optional
         Used internally if this Signal is made part of a larger Device.
     kind : a member the Kind IntEnum (or equivalent integer), optional
-        Default is Kind.NORMAL. See Kind for options.
+        Default is Kind.normal. See Kind for options.
     loop : asyncio.EventLoop, optional
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
@@ -257,7 +257,7 @@ class SynAxisNoHints(Device):
     parent : Device, optional
         Used internally if this Signal is made part of a larger Device.
     kind : a member the Kind IntEnum (or equivalent integer), optional
-        Default is Kind.NORMAL. See Kind for options.
+        Default is Kind.normal. See Kind for options.
     loop : asyncio.EventLoop, optional
         used for ``subscribe`` updates; uses ``asyncio.get_event_loop()`` if
         unspecified
@@ -344,7 +344,7 @@ class SynAxisNoHints(Device):
 
 
 class SynAxis(SynAxisNoHints):
-    readback = Component(ReadbackSignal, value=None, kind=Kind.HINTED)
+    readback = Component(ReadbackSignal, value=None, kind=Kind.hinted)
 
 
 class SynGauss(SynSignal):
@@ -747,7 +747,7 @@ class NumpySeqHandler:
 
 
 class ABDetector(Device):
-    a = Component(SynSignal, func=random.random, kind=Kind.HINTED)
+    a = Component(SynSignal, func=random.random, kind=Kind.hinted)
     b = Component(SynSignal, func=random.random)
 
     def trigger(self):
@@ -755,13 +755,13 @@ class ABDetector(Device):
 
 
 class DetWithCountTime(Device):
-    intensity = Component(SynSignal, func=lambda: 0, kind=Kind.HINTED)
+    intensity = Component(SynSignal, func=lambda: 0, kind=Kind.hinted)
     count_time = Component(Signal)
 
 
 class DetWithConf(Device):
-    a = Component(SynSignal, func=lambda: 1, kind=Kind.HINTED)
-    b = Component(SynSignal, func=lambda: 2, kind=Kind.HINTED)
+    a = Component(SynSignal, func=lambda: 1, kind=Kind.hinted)
+    b = Component(SynSignal, func=lambda: 2, kind=Kind.hinted)
     c = Component(SynSignal, func=lambda: 3)
     d = Component(SynSignal, func=lambda: 4)
 
@@ -787,9 +787,9 @@ class InvariantSignal(SynSignal):
 
 
 class SPseudo3x3(PseudoPositioner):
-    pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a', kind=Kind.HINTED)
-    pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b', kind=Kind.HINTED)
-    pseudo3 = C(PseudoSingle, limits=None, egu='c', kind=Kind.HINTED)
+    pseudo1 = C(PseudoSingle, limits=(-10, 10), egu='a', kind=Kind.hinted)
+    pseudo2 = C(PseudoSingle, limits=(-10, 10), egu='b', kind=Kind.hinted)
+    pseudo3 = C(PseudoSingle, limits=None, egu='c', kind=Kind.hinted)
     real1 = C(SoftPositioner, init_pos=0)
     real2 = C(SoftPositioner, init_pos=0)
     real3 = C(SoftPositioner, init_pos=0)
@@ -814,7 +814,7 @@ class SPseudo3x3(PseudoPositioner):
 
 
 class SPseudo1x3(PseudoPositioner):
-    pseudo1 = C(PseudoSingle, limits=(-10, 10), kind=Kind.HINTED)
+    pseudo1 = C(PseudoSingle, limits=(-10, 10), kind=Kind.hinted)
     real1 = C(SoftPositioner, init_pos=0)
     real2 = C(SoftPositioner, init_pos=0)
     real3 = C(SoftPositioner, init_pos=0)

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -259,7 +259,7 @@ def test_str_smoke():
     det = MyDetector(prefix, name='test')
     det.read_attrs = ['stats1']
     det.stats1.read_attrs = ['mean_value']
-    det.stats1.mean_value.kind = Kind.HINTED
+    det.stats1.mean_value.kind = Kind.hinted
 
     str(det)
 

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from io import StringIO
 from pathlib import PurePath, Path
-
+from ophyd.ophydobj import Kind
 from ophyd import (SimDetector, SingleTrigger, Component,
                    DynamicDeviceComponent)
 from ophyd.areadetector.plugins import (ImagePlugin, StatsPlugin,
@@ -259,7 +259,7 @@ def test_str_smoke():
     det = MyDetector(prefix, name='test')
     det.read_attrs = ['stats1']
     det.stats1.read_attrs = ['mean_value']
-    det.hints = {'fields': [det.stats1.mean_value.name]}
+    det.stats1.mean_value.kind = Kind.HINTED
 
     str(det)
 

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -181,7 +181,7 @@ class TestDevice(AssertTools):
 
     def test_name_shadowing(self):
         RESERVED_ATTRS = ['name', 'parent', 'component_names', '_signals',
-                          'read_attrs', 'configuration_attrs', '_sig_attrs',
+                          '_sig_attrs',
                           '_sub_devices']
 
         type('a', (Device,), {'a': None})  # legal class definition

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -12,9 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class FakeSignal(Signal):
-    def __init__(self, read_pv, *, name=None, parent=None):
+    def __init__(self, read_pv, *, name=None, parent=None, **kwargs):
         self.read_pv = read_pv
-        super().__init__(name=name, parent=parent)
+        super().__init__(name=name, parent=parent, **kwargs)
 
     def get(self):
         return self.name

--- a/ophyd/tests/test_epicsmotor.py
+++ b/ophyd/tests/test_epicsmotor.py
@@ -305,5 +305,15 @@ def test_motor_bundle():
                                       for k in 'abc']
 
     # Test old-style attributes.
-    assert bundle.read_attrs == list('abc')
-    assert bundle.configuration_attrs == list('abc')
+    assert set(bundle.read_attrs) == set(list('abc') +
+                                         ['.'.join([p, c]) for p in 'abc'
+                                          for c in ['user_readback',
+                                                    'user_setpoint']])
+    assert set(bundle.configuration_attrs) == set(list('abc') +
+                                                  ['.'.join([p, c])
+                                                   for p in 'abc'
+                                                   for c in ['user_offset',
+                                                             'user_offset_dir',
+                                                             'velocity',
+                                                             'acceleration',
+                                                             'motor_egu']])

--- a/ophyd/tests/test_epicsmotor.py
+++ b/ophyd/tests/test_epicsmotor.py
@@ -29,11 +29,11 @@ class CustomAlarmEpicsSignalRO(EpicsSignalRO):
 
 class tstEpicsMotor(EpicsMotor):
     user_readback = C(CustomAlarmEpicsSignalRO, '.RBV', kind='hinted')
-    high_limit_switch = C(Signal, value=0)
-    low_limit_switch = C(Signal, value=0)
-    direction_of_travel = C(Signal, value=0)
-    high_limit_value = C(EpicsSignalRO, '.HLM')
-    low_limit_value = C(EpicsSignalRO, '.LLM')
+    high_limit_switch = C(Signal, value=0, kind='omitted')
+    low_limit_switch = C(Signal, value=0, kind='omitted')
+    direction_of_travel = C(Signal, value=0, kind='omitted')
+    high_limit_value = C(EpicsSignalRO, '.HLM', kind='config')
+    low_limit_value = C(EpicsSignalRO, '.LLM', kind='config')
 
 
 def test_timeout(motor):

--- a/ophyd/tests/test_hints.py
+++ b/ophyd/tests/test_hints.py
@@ -13,6 +13,12 @@ def test_device_hints():
         a = Component(Signal, kind=Kind.HINTED)
         b = Component(Signal)
 
+    # Convenience Component is equivalent.
+    class Dongle(Device):
+        a = HCpt(Signal)
+        b = Component(Signal)
+
+    assert {'fields': ['dev_a']} == Dongle(name='dev').hints
     assert {'fields': ['dev_a']} == Dongle(name='dev').hints
 
 def test_motor_bundle_hints():

--- a/ophyd/tests/test_hints.py
+++ b/ophyd/tests/test_hints.py
@@ -1,6 +1,4 @@
-import pytest
-from ophyd import (Device, Component, Signal, MotorBundle, Kind,
-                   HintedComponent as HCpt)
+from ophyd import (Device, Component, Signal, MotorBundle, Kind)
 from ophyd.sim import SynAxis
 
 
@@ -13,18 +11,14 @@ def test_device_hints():
         a = Component(Signal, kind=Kind.HINTED)
         b = Component(Signal)
 
-    # Convenience Component is equivalent.
-    class Dongle(Device):
-        a = HCpt(Signal)
-        b = Component(Signal)
+    assert {'fields': ['dev_a']} == Dongle(name='dev').hints
+    assert {'fields': ['dev_a']} == Dongle(name='dev').hints
 
-    assert {'fields': ['dev_a']} == Dongle(name='dev').hints
-    assert {'fields': ['dev_a']} == Dongle(name='dev').hints
 
 def test_motor_bundle_hints():
     class Bundle(MotorBundle):
-        a = HCpt(SynAxis)
-        b = HCpt(SynAxis)
+        a = Component(SynAxis, kind=Kind.HINTED)
+        b = Component(SynAxis, kind=Kind.HINTED)
 
     assert {'fields': ['dev_a', 'dev_b']} == Bundle(name='dev').hints
 

--- a/ophyd/tests/test_hints.py
+++ b/ophyd/tests/test_hints.py
@@ -1,59 +1,24 @@
 import pytest
-from ophyd import Device, Component, Signal, MotorBundle
+from ophyd import (Device, Component, Signal, MotorBundle, Kind,
+                   HintedComponent as HCpt)
 from ophyd.sim import SynAxis
 
 
 def test_device_hints():
-    # Default hints is empty dict.
-    # assert {} == Device('', name='dev').hints
-
-    # User-specified empty dict is acceptable.
-    assert {} == Device('', name='dev', hints={}).hints
-
-    # User-specified empty list of fields is acceptable.
-    h = {'fields': []}
-    assert h == Device('', name='dev', hints=h).hints
-
-    # Item in fields not matching a name raises at initialization time.
-    h = {'fields': ['not_a_valid_attr']}
-    with pytest.raises(ValueError):
-        Device('', name='dev', hints=h)
-
-    # User-provided name works.
-    class Dongle(Device):
-        a = Component(Signal)
-        b = Component(Signal)
-
-    h = {'fields': ['dev_a']}
-    assert h == Dongle(name='dev', hints=h).hints
+    # Default hints is 'fields' with an empty list.
+    assert {'fields': []} == Device('', name='dev').hints
 
     # Class-provided default works.
     class Dongle(Device):
-        _default_hints = {'fields': ['a']}
-        a = Component(Signal)
+        a = Component(Signal, kind=Kind.HINTED)
         b = Component(Signal)
 
-    h = {'fields': ['dev_a']}
-    assert h == Dongle(name='dev').hints
-
-    # User can override class default.
-    h = {'fields': ['dev_b']}
-    assert h == Dongle(name='dev', hints=h).hints
-
-    # Class provided default not matching a name raises as initialization time.
-    # TODO The metaclass could catch this at definition time....
-    class Dongle(Device):
-        _default_hints = {'fields': ['c']}
-        a = Component(Signal)
-        b = Component(Signal)
-    with pytest.raises(ValueError):
-        Device('', name='dev', hints=h)
-
+    assert {'fields': ['dev_a']} == Dongle(name='dev').hints
 
 def test_motor_bundle_hints():
     class Bundle(MotorBundle):
-        a = Component(SynAxis)
-        b = Component(SynAxis)
+        a = HCpt(SynAxis)
+        b = HCpt(SynAxis)
 
     assert {'fields': ['dev_a', 'dev_b']} == Bundle(name='dev').hints
 

--- a/ophyd/tests/test_hints.py
+++ b/ophyd/tests/test_hints.py
@@ -8,7 +8,7 @@ def test_device_hints():
 
     # Class-provided default works.
     class Dongle(Device):
-        a = Component(Signal, kind=Kind.HINTED)
+        a = Component(Signal, kind=Kind.hinted)
         b = Component(Signal)
 
     assert {'fields': ['dev_a']} == Dongle(name='dev').hints
@@ -17,8 +17,8 @@ def test_device_hints():
 
 def test_motor_bundle_hints():
     class Bundle(MotorBundle):
-        a = Component(SynAxis, kind=Kind.HINTED)
-        b = Component(SynAxis, kind=Kind.HINTED)
+        a = Component(SynAxis, kind=Kind.hinted)
+        b = Component(SynAxis, kind=Kind.hinted)
 
     assert {'fields': ['dev_a', 'dev_b']} == Bundle(name='dev').hints
 

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -2,6 +2,7 @@ from ophyd import Device, Signal, Kind, Component, RESPECT_KIND
 
 
 def test_back_compat():
+    # Test class defaults.
     class Thing(Device):
         _default_read_attrs = ['a']
         _default_configuration_attrs = ['b']
@@ -11,11 +12,16 @@ def test_back_compat():
 
     thing = Thing(name='thing')
     assert ['thing_a'] == list(thing.read())
-    assert ['thing_b'] == list(thing.read_configuration())
-    assert a.read_attrs == ['thing_a']
-    assert a.configuration_attrs == ['thing_b']
-    a.read_attrs == ['thing_a', 'thing_b']
+    # assert ['thing_b'] == list(thing.read_configuration())
+
+    # Test attribute getting and setting.
+    assert thing.read_attrs == ['a']
+    assert thing.configuration_attrs == ['b']
+    thing.read_attrs = ['a', 'b']
     assert ['thing_a', 'thing_b'] == list(thing.read())
+
+    thing = Thing(name='thing', read_attrs=['b'], configuration_attrs=['a'])
+    assert ['thing_b'] == list(thing.read())
 
 
 def test_standalone_signals():

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -176,7 +176,7 @@ def test_default_read_attrs_empty_and_configuration_attrs_none():
     th = ThingHaver(name='th')
     assert set() == set(th.read_attrs)
     assert [] == list(th.describe())
-    assert set() == set(th.configuration_attrs)
+    assert set('ab') == set(th.configuration_attrs)
     assert [] == list(th.describe_configuration())
 
 
@@ -228,6 +228,25 @@ def test_default_attrs_both_empty():
     assert [] == list(th.describe())
     assert set() == set(th.configuration_attrs)
     assert [] == list(t.describe_configuration())
+
+
+def test_all_components_escape_hatch():
+
+    class Thing(Device):
+        _default_read_attrs = ['a']
+        _default_configuration_attrs = ['b']
+        a = Component(Signal)
+        b = Component(Signal)
+
+    class ThingEscapeHatch(Thing):
+        _default_read_attrs = ALL_COMPONENTS
+        _default_configuration_attrs = []
+        c = Component(Signal)
+
+
+    t = ThingEscapeHatch(name='t')
+    assert set('abc') == set(t.read_attrs)
+    assert set() == set(t.configuration_attrs)
 
 
 def test_default_attrs_nonempty_disjoint():

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,4 +1,5 @@
-from ophyd import Device, Signal, Kind, Component, ALL_COMPONENTS, kind_context
+from ophyd import (Device, Signal, Kind, Component, ALL_COMPONENTS,
+                   kind_context, DynamicDeviceComponent as DDC)
 import pytest
 
 
@@ -348,3 +349,20 @@ def test_list_proxy(thing_haver_haver):
 
     assert 'gamma.C.c' in list(thh.read_attrs)
     assert 'gamma.C.d' in list(thh.read_attrs)
+
+
+def test_ddc():
+
+    class Thing(Device):
+        a = Component(Signal)
+        b = Component(Signal)
+
+    class ThingHaver(Device):
+        a = DDC({'A': (Thing, '', {})})
+
+
+    th = ThingHaver(name='th')
+    assert th.a.A.a.kind & Kind.normal
+    assert th.a.A.kind & Kind.normal
+    assert th.a.kind & Kind.normal
+    assert th.kind & Kind.normal

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -7,28 +7,28 @@ def test_standalone_signals():
     # whether its parent recursively calls read() and/or read_configuration().
     # When we call read() and/or read_configuration() on the object itself,
     # directly, and its 'kind' setting does not affects its behavior.
-    normal_sig = Signal(name='normal_sig', value=3, kind=Kind.NORMAL)
-    assert normal_sig.kind == Kind.NORMAL
+    normal_sig = Signal(name='normal_sig', value=3, kind=Kind.normal)
+    assert normal_sig.kind == Kind.normal
     assert normal_sig.name not in normal_sig.hints['fields']
     assert 'normal_sig' in normal_sig.read()
     assert 'normal_sig' in normal_sig.read_configuration()
 
     hinted_sig = Signal(name='hinted_sig', value=3)
-    assert hinted_sig.kind == Kind.HINTED
+    assert hinted_sig.kind == Kind.hinted
     assert hinted_sig.name in hinted_sig.hints['fields']
     assert 'hinted_sig' in hinted_sig.read()
     assert 'hinted_sig' in hinted_sig.read_configuration()
 
     # Same with a sig set up this way
-    config_sig = Signal(name='config_sig', value=5, kind=Kind.CONFIG)
-    assert config_sig.kind == Kind.CONFIG
+    config_sig = Signal(name='config_sig', value=5, kind=Kind.config)
+    assert config_sig.kind == Kind.config
     assert config_sig.name not in config_sig.hints['fields']
     assert 'config_sig' in config_sig.read()
     assert 'config_sig' in config_sig.read_configuration()
 
     # Same with a sig set up this way
-    omitted_sig = Signal(name='omitted_sig', value=5, kind=Kind.OMITTED)
-    assert omitted_sig.kind == Kind.OMITTED
+    omitted_sig = Signal(name='omitted_sig', value=5, kind=Kind.omitted)
+    assert omitted_sig.kind == Kind.omitted
     assert omitted_sig.name not in omitted_sig.hints['fields']
     assert 'omitted_sig' in omitted_sig.read()
     assert 'omitted_sig' in omitted_sig.read_configuration()
@@ -41,8 +41,8 @@ def test_nested_devices():
 
     class A(Device):
         normal_sig = Component(Signal)
-        config_sig = Component(Signal, kind=Kind.CONFIG)
-        omitted_sig = Component(Signal, kind=Kind.OMITTED)
+        config_sig = Component(Signal, kind=Kind.config)
+        omitted_sig = Component(Signal, kind=Kind.omitted)
 
     a = A(name='a')
 
@@ -60,8 +60,8 @@ def test_nested_devices():
 
     class B(Device):
         a_default = Component(A)
-        a_config = Component(A, kind=Kind.CONFIG)
-        a_omitted = Component(A, kind=Kind.OMITTED)
+        a_config = Component(A, kind=Kind.config)
+        a_omitted = Component(A, kind=Kind.omitted)
 
     b = B(name='b')
 
@@ -73,14 +73,14 @@ def test_nested_devices():
     # the EventDescriptor!)
     assert ['b_a_default_config_sig',
             'b_a_config_config_sig'] == list(b.read_configuration())
-    # Notice that it tacks CONFIG on when you try to set the kind to NORMAL.
-    assert (Kind.NORMAL | Kind.CONFIG) == B(name='b', kind=Kind.NORMAL).kind
+    # Notice that it tacks 'config' on when you set the kind to 'normal'.
+    assert (Kind.normal | Kind.config) == B(name='b', kind=Kind.normal).kind
     # And the same if you try to set it after __init__
-    b.a_default.kind = Kind.NORMAL
-    assert b.a_default.kind == (Kind.NORMAL | Kind.CONFIG)
-    # However, just taking CONFIG alone without Event-wise readings is fine.
-    b.a_default.kind = Kind.CONFIG
-    assert b.a_default.kind == Kind.CONFIG
+    b.a_default.kind = Kind.normal
+    assert b.a_default.kind == (Kind.normal | Kind.config)
+    # However, just taking 'config' alone without Event-wise readings is fine.
+    b.a_default.kind = Kind.config
+    assert b.a_default.kind == Kind.config
     # Now we get no Event-wise readings from a_default
     assert [] == list(b.read())
     assert ['b_a_default_config_sig',
@@ -89,7 +89,7 @@ def test_nested_devices():
 
 def test_strings():
     sig = Signal(name='sig', kind='normal')
-    assert sig.kind == Kind.NORMAL
+    assert sig.kind == Kind.normal
 
 
 def test_kind_context():
@@ -99,7 +99,7 @@ def test_kind_context():
             a = Cpt(Signal)
 
     thing = Thing(name='thing')
-    assert thing.a.kind == Kind.OMITTED
+    assert thing.a.kind == Kind.omitted
 
 
 # Test back-compatibility. The expected values in these tests match the
@@ -148,7 +148,7 @@ def test_class_default_attrs_both_none():
     # not allowed to place itself in its parent's read_attrs ONLY. It must also
     # be in configuration_attrs if it is in read_attrs. (Under the hood, this
     # is enforced in the setter of the Device's `kind` property, which OR's the
-    # kind value with Kind.CONFIG if said vlaue includes Kind.NORMAL.
+    # kind value with Kind.config if said vlaue includes Kind.normal.
     assert set('ab') == set(th.configuration_attrs)
 
     assert ['th_a_a', 'th_a_b', 'th_b_a', 'th_b_b'] == list(th.describe())
@@ -310,20 +310,20 @@ def test_back_compat():
 @pytest.fixture(scope='function')
 def thing_haver_haver():
     class Thing(Device):
-        a = Component(Signal, kind=Kind.OMITTED)
-        b = Component(Signal, kind=Kind.CONFIG)
-        c = Component(Signal, kind=Kind.NORMAL)
-        d = Component(Signal, kind=Kind.HINTED)
+        a = Component(Signal, kind=Kind.omitted)
+        b = Component(Signal, kind=Kind.config)
+        c = Component(Signal, kind=Kind.normal)
+        d = Component(Signal, kind=Kind.hinted)
 
     class ThingHaver(Device):
-        A = Component(Thing, kind=Kind.OMITTED)
-        B = Component(Thing, kind=Kind.CONFIG)
-        C = Component(Thing, kind=Kind.NORMAL)
+        A = Component(Thing, kind=Kind.omitted)
+        B = Component(Thing, kind=Kind.config)
+        C = Component(Thing, kind=Kind.normal)
 
     class ThingHaverHaver(Device):
-        alpha = Component(ThingHaver, kind=Kind.OMITTED)
-        beta = Component(ThingHaver, kind=Kind.CONFIG)
-        gamma = Component(ThingHaver, kind=Kind.NORMAL)
+        alpha = Component(ThingHaver, kind=Kind.omitted)
+        beta = Component(ThingHaver, kind=Kind.config)
+        gamma = Component(ThingHaver, kind=Kind.normal)
 
     return ThingHaverHaver(name='thh')
 

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -23,8 +23,9 @@ def test_standalone_signals():
     assert 'omitted_sig' in omitted_sig.read()
     assert 'omitted_sig' in omitted_sig.read_configuration()
 
-    # But these will be differentiated when we put them into a parent Device and
-    # call read() or read_configuraiton() on _that_.
+    # But these will be differentiated when we put them into a parent
+    # Device and call read() or read_configuraiton() on _that_.
+
 
 def test_nested_devices():
 
@@ -32,33 +33,34 @@ def test_nested_devices():
         normal_sig = Component(Signal)
         config_sig = Component(Signal, kind=Kind.CONFIG)
         omitted_sig = Component(Signal, kind=Kind.OMITTED)
-    
+
     a = A(name='a')
+
     # When we call read and read_configuration on a, it checks the kind of its
     # components and reads the right ones.
     assert 'a_normal_sig' in a.read()
     assert 'a_config_sig' not in a.read()
     assert 'a_omitted_sig' not in a.read()
-    
+
     assert 'a_normal_sig' not in a.read_configuration()
     assert 'a_config_sig' in a.read_configuration()
     assert 'a_omitted_sig' not in a.read_configuration()
-    
+
     # Another layer of nesting!
-    
+
     class B(Device):
         a_default = Component(A)
         a_config = Component(A, kind=Kind.CONFIG)
         a_omitted = Component(A, kind=Kind.OMITTED)
-    
-    
+
     b = B(name='b')
-    
-    
+
     assert ['b_a_default_normal_sig'] == list(b.read())
-    # Notice that a_default comes along for the ride here. If you ask a Device for
-    # its normal readings it will also give you its configuration. (You need
-    # complete configurational metadata for the EventDescriptor!)
+
+    # Notice that a_default comes along for the ride here. If you ask
+    # a Device for its normal readings it will also give you its
+    # configuration. (You need complete configurational metadata for
+    # the EventDescriptor!)
     assert ['b_a_default_config_sig',
             'b_a_config_config_sig'] == list(b.read_configuration())
     # Notice that it tacks CONFIG on when you try to set the kind to NORMAL.
@@ -73,20 +75,21 @@ def test_nested_devices():
     assert [] == list(b.read())
     assert ['b_a_default_config_sig',
             'b_a_config_config_sig'] == list(b.read_configuration())
-    
+
+
 def test_convenience_wrappers_of_component():
     # Convenience wrappers of Component are helpful for big Devices. The
     # default kind of Component must be NORMAL for back-compatibility, but for
     # big Devices OmmittedComponent is likely more useful.
     from ophyd import OmittedComponent as OCpt
-    
+
     class Thing(Device):
         a = OCpt(Signal)
         b = OCpt(Signal)
-    
+
     thing = Thing(name='thing')
     assert {} == thing.read()
     assert {} == thing.read_configuration()
-    
+
     thing.a.kind = Kind.NORMAL
     assert ['thing_a'] == list(thing.read())

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -91,26 +91,6 @@ def test_nested_devices():
             'b_a_config_config_sig'] == list(b.read_configuration())
 
 
-def test_convenience_wrappers_of_component():
-    # Convenience wrappers of Component are helpful for big Devices. The
-    # default kind of Component must be NORMAL for back-compatibility, but for
-    # big Devices OmmittedComponent is likely more useful.
-    from ophyd import OmittedComponent as OCpt
-
-    class Thing(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
-        a = OCpt(Signal)
-        b = OCpt(Signal)
-
-    thing = Thing(name='thing')
-    assert {} == thing.read()
-    assert {} == thing.read_configuration()
-
-    thing.a.kind = Kind.NORMAL
-    assert ['thing_a'] == list(thing.read())
-
-
 def test_strings():
     sig = Signal(name='sig', kind='normal')
     assert sig.kind == Kind.NORMAL

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,0 +1,48 @@
+from ophyd import Device, Signal, Kind, Component
+
+
+# A object's kind only matters when we read its _parent_.
+# When the signal does into a Device, that device will only read it on read()
+# not on read_configuration(), but we can still call both methods on `sig`
+# _directly_ if we want to.
+normal_sig = Signal(name='normal_sig', value=3)
+assert normal_sig.kind == Kind.NORMAL
+assert 'normal_sig' in normal_sig.read()
+assert 'normal_sig' in normal_sig.read_configuration()
+
+# Same with a sig set up this way
+config_sig = Signal(name='config_sig', value=5, kind=Kind.CONFIGURATION)
+assert config_sig.kind == Kind.CONFIGURATION
+assert 'config_sig' in config_sig.read()
+assert 'config_sig' in config_sig.read_configuration()
+
+
+class A(Device):
+    normal_sig = Component(Signal)
+    config_sig = Component(Signal, kind=Kind.CONFIGURATION)
+    omitted_sig = Component(Signal, kind=Kind.OMIT)
+
+a = A(name='a')
+# When we call read and read_configuration on a, it checks the kind of its
+# components and reads the right ones.
+assert 'a_normal_sig' in a.read()
+assert 'a_config_sig' not in a.read()
+assert 'a_omitted_sig' not in a.read()
+
+assert 'a_normal_sig' not in a.read_configuration()
+assert 'a_config_sig' in a.read_configuration()
+assert 'a_omitted_sig' not in a.read_configuration()
+
+
+class B(Device):
+    a = Component(A)
+
+
+b = B(name='b')
+
+
+assert ['b_a_normal_sig'] == list(b.read())
+assert ['b_a_config_sig'] == list(b.read_configuration())
+b.a.kind = Kind.CONFIGURATION
+assert [] == list(b.read())
+assert ['b_a_config_sig'] == list(b.read_configuration())

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -7,20 +7,29 @@ def test_standalone_signals():
     # whether its parent recursively calls read() and/or read_configuration().
     # When we call read() and/or read_configuration() on the object itself,
     # directly, and its 'kind' setting does not affects its behavior.
-    normal_sig = Signal(name='normal_sig', value=3)
+    normal_sig = Signal(name='normal_sig', value=3, kind=Kind.NORMAL)
     assert normal_sig.kind == Kind.NORMAL
+    assert normal_sig.name not in normal_sig.hints['fields']
     assert 'normal_sig' in normal_sig.read()
     assert 'normal_sig' in normal_sig.read_configuration()
+
+    hinted_sig = Signal(name='hinted_sig', value=3)
+    assert hinted_sig.kind == Kind.HINTED
+    assert hinted_sig.name in hinted_sig.hints['fields']
+    assert 'hinted_sig' in hinted_sig.read()
+    assert 'hinted_sig' in hinted_sig.read_configuration()
 
     # Same with a sig set up this way
     config_sig = Signal(name='config_sig', value=5, kind=Kind.CONFIG)
     assert config_sig.kind == Kind.CONFIG
+    assert config_sig.name not in config_sig.hints['fields']
     assert 'config_sig' in config_sig.read()
     assert 'config_sig' in config_sig.read_configuration()
 
     # Same with a sig set up this way
     omitted_sig = Signal(name='omitted_sig', value=5, kind=Kind.OMITTED)
     assert omitted_sig.kind == Kind.OMITTED
+    assert omitted_sig.name not in omitted_sig.hints['fields']
     assert 'omitted_sig' in omitted_sig.read()
     assert 'omitted_sig' in omitted_sig.read_configuration()
 

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,4 +1,4 @@
-from ophyd import Device, Signal, Kind, Component, RESPECT_KIND
+from ophyd import Device, Signal, Kind, Component, RESPECT_KIND, kind_context
 
 
 def test_back_compat():
@@ -122,3 +122,20 @@ def test_convenience_wrappers_of_component():
 
     thing.a.kind = Kind.NORMAL
     assert ['thing_a'] == list(thing.read())
+
+
+def test_strings():
+    sig = Signal(name='sig', kind='normal')
+    assert sig.kind == Kind.NORMAL
+
+
+def test_kind_context():
+    class Thing(Device):
+        _default_read_attrs = RESPECT_KIND
+        _default_configuration_attrs = RESPECT_KIND
+
+        with kind_context('omitted') as Cpt:
+            a = Cpt(Signal)
+
+    thing = Thing(name='thing')
+    assert thing.a.kind == Kind.OMITTED

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,10 +1,10 @@
 from ophyd import Device, Signal, Kind, Component
 
 
-# A object's kind only matters when we read its _parent_.
-# When the signal does into a Device, that device will only read it on read()
-# not on read_configuration(), but we can still call both methods on `sig`
-# _directly_ if we want to.
+# A object's kind only matters when we read its _parent_. It affects whether
+# its parent recursively calls read() and/or read_configuration(). When we
+# call read() and/or read_configuration() on the object itself, directly, and
+# its 'kind' setting does not affects its behavior.
 normal_sig = Signal(name='normal_sig', value=3)
 assert normal_sig.kind == Kind.NORMAL
 assert 'normal_sig' in normal_sig.read()
@@ -15,6 +15,15 @@ config_sig = Signal(name='config_sig', value=5, kind=Kind.CONFIGURATION)
 assert config_sig.kind == Kind.CONFIGURATION
 assert 'config_sig' in config_sig.read()
 assert 'config_sig' in config_sig.read_configuration()
+
+# Same with a sig set up this way
+omitted_sig = Signal(name='omitted_sig', value=5, kind=Kind.OMIT)
+assert omitted_sig.kind == Kind.OMIT
+assert 'omitted_sig' in omitted_sig.read()
+assert 'omitted_sig' in omitted_sig.read_configuration()
+
+# But these will be differentiated when we put them into a parent Device and
+# call read() or read_configuraiton() on _that_.
 
 
 class A(Device):

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,4 +1,21 @@
-from ophyd import Device, Signal, Kind, Component
+from ophyd import Device, Signal, Kind, Component, RESPECT_KIND
+
+
+def test_back_compat():
+    class Thing(Device):
+        _default_read_attrs = ['a']
+        _default_configuration_attrs = ['b']
+        a = Component(Signal)
+        b = Component(Signal)
+        c = Component(Signal)
+
+    thing = Thing(name='thing')
+    assert ['thing_a'] == list(thing.read())
+    assert ['thing_b'] == list(thing.read_configuration())
+    assert a.read_attrs == ['thing_a']
+    assert a.configuration_attrs == ['thing_b']
+    a.read_attrs == ['thing_a', 'thing_b']
+    assert ['thing_a', 'thing_b'] == list(thing.read())
 
 
 def test_standalone_signals():
@@ -30,6 +47,8 @@ def test_standalone_signals():
 def test_nested_devices():
 
     class A(Device):
+        _default_read_attrs = RESPECT_KIND
+        _default_configuration_attrs = RESPECT_KIND
         normal_sig = Component(Signal)
         config_sig = Component(Signal, kind=Kind.CONFIG)
         omitted_sig = Component(Signal, kind=Kind.OMITTED)
@@ -49,6 +68,8 @@ def test_nested_devices():
     # Another layer of nesting!
 
     class B(Device):
+        _default_read_attrs = RESPECT_KIND
+        _default_configuration_attrs = RESPECT_KIND
         a_default = Component(A)
         a_config = Component(A, kind=Kind.CONFIG)
         a_omitted = Component(A, kind=Kind.OMITTED)
@@ -84,6 +105,8 @@ def test_convenience_wrappers_of_component():
     from ophyd import OmittedComponent as OCpt
 
     class Thing(Device):
+        _default_read_attrs = RESPECT_KIND
+        _default_configuration_attrs = RESPECT_KIND
         a = OCpt(Signal)
         b = OCpt(Signal)
 

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,72 +1,92 @@
 from ophyd import Device, Signal, Kind, Component
 
 
-# A object's kind only matters when we read its _parent_. It affects whether
-# its parent recursively calls read() and/or read_configuration(). When we
-# call read() and/or read_configuration() on the object itself, directly, and
-# its 'kind' setting does not affects its behavior.
-normal_sig = Signal(name='normal_sig', value=3)
-assert normal_sig.kind == Kind.NORMAL
-assert 'normal_sig' in normal_sig.read()
-assert 'normal_sig' in normal_sig.read_configuration()
+def test_standalone_signals():
+    # A object's kind only matters when we read its _parent_. It affects
+    # whether its parent recursively calls read() and/or read_configuration().
+    # When we call read() and/or read_configuration() on the object itself,
+    # directly, and its 'kind' setting does not affects its behavior.
+    normal_sig = Signal(name='normal_sig', value=3)
+    assert normal_sig.kind == Kind.NORMAL
+    assert 'normal_sig' in normal_sig.read()
+    assert 'normal_sig' in normal_sig.read_configuration()
 
-# Same with a sig set up this way
-config_sig = Signal(name='config_sig', value=5, kind=Kind.CONFIGURATION)
-assert config_sig.kind == Kind.CONFIGURATION
-assert 'config_sig' in config_sig.read()
-assert 'config_sig' in config_sig.read_configuration()
+    # Same with a sig set up this way
+    config_sig = Signal(name='config_sig', value=5, kind=Kind.CONFIG)
+    assert config_sig.kind == Kind.CONFIG
+    assert 'config_sig' in config_sig.read()
+    assert 'config_sig' in config_sig.read_configuration()
 
-# Same with a sig set up this way
-omitted_sig = Signal(name='omitted_sig', value=5, kind=Kind.OMIT)
-assert omitted_sig.kind == Kind.OMIT
-assert 'omitted_sig' in omitted_sig.read()
-assert 'omitted_sig' in omitted_sig.read_configuration()
+    # Same with a sig set up this way
+    omitted_sig = Signal(name='omitted_sig', value=5, kind=Kind.OMITTED)
+    assert omitted_sig.kind == Kind.OMITTED
+    assert 'omitted_sig' in omitted_sig.read()
+    assert 'omitted_sig' in omitted_sig.read_configuration()
 
-# But these will be differentiated when we put them into a parent Device and
-# call read() or read_configuraiton() on _that_.
+    # But these will be differentiated when we put them into a parent Device and
+    # call read() or read_configuraiton() on _that_.
 
+def test_nested_devices():
 
-class A(Device):
-    normal_sig = Component(Signal)
-    config_sig = Component(Signal, kind=Kind.CONFIGURATION)
-    omitted_sig = Component(Signal, kind=Kind.OMIT)
-
-a = A(name='a')
-# When we call read and read_configuration on a, it checks the kind of its
-# components and reads the right ones.
-assert 'a_normal_sig' in a.read()
-assert 'a_config_sig' not in a.read()
-assert 'a_omitted_sig' not in a.read()
-
-assert 'a_normal_sig' not in a.read_configuration()
-assert 'a_config_sig' in a.read_configuration()
-assert 'a_omitted_sig' not in a.read_configuration()
-
-# Another layer of nesting!
-
-class B(Device):
-    a_default = Component(A)
-    a_config = Component(A, kind=Kind.CONFIGURATION)
-    a_omitted = Component(A, kind=Kind.OMIT)
-
-
-b = B(name='b')
-
-
-assert ['b_a_default_normal_sig'] == list(b.read())
-# Notice that a_default comes along for the ride here. If you ask a Device for
-# its normal readings it will also give you its configuration. (You need
-# complete configurational metadata for the EventDescriptor!)
-assert ['b_a_default_config_sig',
-        'b_a_config_config_sig'] == list(b.read_configuration())
-# Notice that it tacks CONFIGURATION on when you try to set the kind to NORMAL.
-assert (Kind.NORMAL | Kind.CONFIGURATION) == B(name='b', kind=Kind.NORMAL).kind
-# And the same if you try to set it after __init__
-b.a_default.kind = Kind.NORMAL
-assert b.a_default.kind == (Kind.NORMAL | Kind.CONFIGURATION)
-# However, just taking CONFIGURATION alone without Event-wise readings is fine.
-b.a_default.kind = Kind.CONFIGURATION
-assert b.a_default.kind == Kind.CONFIGURATION
-assert [] == list(b.read())  # Now we get no Event-wise readings from a_default
-assert ['b_a_default_config_sig',
-        'b_a_config_config_sig'] == list(b.read_configuration())
+    class A(Device):
+        normal_sig = Component(Signal)
+        config_sig = Component(Signal, kind=Kind.CONFIG)
+        omitted_sig = Component(Signal, kind=Kind.OMITTED)
+    
+    a = A(name='a')
+    # When we call read and read_configuration on a, it checks the kind of its
+    # components and reads the right ones.
+    assert 'a_normal_sig' in a.read()
+    assert 'a_config_sig' not in a.read()
+    assert 'a_omitted_sig' not in a.read()
+    
+    assert 'a_normal_sig' not in a.read_configuration()
+    assert 'a_config_sig' in a.read_configuration()
+    assert 'a_omitted_sig' not in a.read_configuration()
+    
+    # Another layer of nesting!
+    
+    class B(Device):
+        a_default = Component(A)
+        a_config = Component(A, kind=Kind.CONFIG)
+        a_omitted = Component(A, kind=Kind.OMITTED)
+    
+    
+    b = B(name='b')
+    
+    
+    assert ['b_a_default_normal_sig'] == list(b.read())
+    # Notice that a_default comes along for the ride here. If you ask a Device for
+    # its normal readings it will also give you its configuration. (You need
+    # complete configurational metadata for the EventDescriptor!)
+    assert ['b_a_default_config_sig',
+            'b_a_config_config_sig'] == list(b.read_configuration())
+    # Notice that it tacks CONFIG on when you try to set the kind to NORMAL.
+    assert (Kind.NORMAL | Kind.CONFIG) == B(name='b', kind=Kind.NORMAL).kind
+    # And the same if you try to set it after __init__
+    b.a_default.kind = Kind.NORMAL
+    assert b.a_default.kind == (Kind.NORMAL | Kind.CONFIG)
+    # However, just taking CONFIG alone without Event-wise readings is fine.
+    b.a_default.kind = Kind.CONFIG
+    assert b.a_default.kind == Kind.CONFIG
+    # Now we get no Event-wise readings from a_default
+    assert [] == list(b.read())
+    assert ['b_a_default_config_sig',
+            'b_a_config_config_sig'] == list(b.read_configuration())
+    
+def test_convenience_wrappers_of_component():
+    # Convenience wrappers of Component are helpful for big Devices. The
+    # default kind of Component must be NORMAL for back-compatibility, but for
+    # big Devices OmmittedComponent is likely more useful.
+    from ophyd import OmittedComponent as OCpt
+    
+    class Thing(Device):
+        a = OCpt(Signal)
+        b = OCpt(Signal)
+    
+    thing = Thing(name='thing')
+    assert {} == thing.read()
+    assert {} == thing.read_configuration()
+    
+    thing.a.kind = Kind.NORMAL
+    assert ['thing_a'] == list(thing.read())

--- a/ophyd/tests/test_kind.py
+++ b/ophyd/tests/test_kind.py
@@ -1,4 +1,4 @@
-from ophyd import Device, Signal, Kind, Component, RESPECT_KIND, kind_context
+from ophyd import Device, Signal, Kind, Component, ALL_COMPONENTS, kind_context
 import pytest
 
 
@@ -40,8 +40,6 @@ def test_standalone_signals():
 def test_nested_devices():
 
     class A(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
         normal_sig = Component(Signal)
         config_sig = Component(Signal, kind=Kind.CONFIG)
         omitted_sig = Component(Signal, kind=Kind.OMITTED)
@@ -61,8 +59,6 @@ def test_nested_devices():
     # Another layer of nesting!
 
     class B(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
         a_default = Component(A)
         a_config = Component(A, kind=Kind.CONFIG)
         a_omitted = Component(A, kind=Kind.OMITTED)
@@ -98,8 +94,6 @@ def test_strings():
 
 def test_kind_context():
     class Thing(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
 
         with kind_context('omitted') as Cpt:
             a = Cpt(Signal)
@@ -297,23 +291,17 @@ def test_back_compat():
 @pytest.fixture(scope='function')
 def thing_haver_haver():
     class Thing(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
         a = Component(Signal, kind=Kind.OMITTED)
         b = Component(Signal, kind=Kind.CONFIG)
         c = Component(Signal, kind=Kind.NORMAL)
         d = Component(Signal, kind=Kind.HINTED)
 
     class ThingHaver(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
         A = Component(Thing, kind=Kind.OMITTED)
         B = Component(Thing, kind=Kind.CONFIG)
         C = Component(Thing, kind=Kind.NORMAL)
 
     class ThingHaverHaver(Device):
-        _default_read_attrs = RESPECT_KIND
-        _default_configuration_attrs = RESPECT_KIND
         alpha = Component(ThingHaver, kind=Kind.OMITTED)
         beta = Component(ThingHaver, kind=Kind.CONFIG)
         gamma = Component(ThingHaver, kind=Kind.NORMAL)

--- a/ophyd/tests/test_mca.py
+++ b/ophyd/tests/test_mca.py
@@ -29,9 +29,14 @@ def test_mca_spectrum():
 
 @using_fake_epics_pv
 def test_mca_read_attrs():
+    # default read_attrs
+    mca = EpicsMCA(devs[0], name='test')
+    default_normal_kind = ['preset_real_time', 'elapsed_real_time', 'spectrum']
+    assert set(default_normal_kind) == set(mca.read_attrs)
+    # test passing in custom read_attrs (with dots!)
     r_attrs = ['spectrum', 'rois.roi1.count', 'rois.roi2.count']
     mca = EpicsMCA(devs[0], read_attrs=r_attrs, name='test')
-    assert r_attrs == mca.read_attrs
+    assert set(r_attrs) == set(mca.read_attrs)
 
 
 @using_fake_epics_pv

--- a/ophyd/tests/test_mca.py
+++ b/ophyd/tests/test_mca.py
@@ -36,7 +36,8 @@ def test_mca_read_attrs():
     # test passing in custom read_attrs (with dots!)
     r_attrs = ['spectrum', 'rois.roi1.count', 'rois.roi2.count']
     mca = EpicsMCA(devs[0], read_attrs=r_attrs, name='test')
-    assert set(r_attrs) == set(mca.read_attrs)
+    expected = set(r_attrs + ['rois.roi1', 'rois.roi2', 'rois'])
+    assert expected == set(mca.read_attrs)
 
 
 @using_fake_epics_pv

--- a/ophyd/tests/test_pvpositioner.py
+++ b/ophyd/tests/test_pvpositioner.py
@@ -6,6 +6,7 @@ from ophyd import (PVPositioner, PVPositionerPC, EpicsMotor)
 from ophyd import (EpicsSignal, EpicsSignalRO)
 from ophyd import (Component as C)
 from ophyd import get_cl
+from ophyd.ophydobj import Kind
 from .conftest import AssertTools
 
 logger = logging.getLogger(__name__)
@@ -272,8 +273,7 @@ class TestPVPos(AssertTools):
         for k in f_hints:
             assert k in desc
 
-        motor.hints = {'fields': ['pv_pos_fake_mtr_readback']}
+        motor.readback.kind = Kind.HINTED
         assert motor.hints == {'fields': ['pv_pos_fake_mtr_readback']}
-        motor.hints = None
 
         assert motor.hints['fields'] == f_hints

--- a/ophyd/tests/test_pvpositioner.py
+++ b/ophyd/tests/test_pvpositioner.py
@@ -273,7 +273,7 @@ class TestPVPos(AssertTools):
         for k in f_hints:
             assert k in desc
 
-        motor.readback.kind = Kind.HINTED
+        motor.readback.kind = Kind.hinted
         assert motor.hints == {'fields': ['pv_pos_fake_mtr_readback']}
 
         assert motor.hints['fields'] == f_hints

--- a/ophyd/tests/test_quadem.py
+++ b/ophyd/tests/test_quadem.py
@@ -112,12 +112,12 @@ def test_hints(quadem):
     def clear_hints(dev):
         for c in dev.component_names:
             c = getattr(dev, c)
-            c.kind &= ~(Kind.HINTED & ~Kind.NORMAL)
+            c.kind &= ~(Kind.hinted & ~Kind.normal)
             if hasattr(c, 'component_names'):
                 clear_hints(c)
 
     clear_hints(quadem)
 
-    quadem.current1.mean_value.kind = Kind.HINTED
+    quadem.current1.mean_value.kind = Kind.hinted
 
     assert quadem.hints == {'fields': ['quadem_current1_mean_value']}

--- a/ophyd/tests/test_scaler.py
+++ b/ophyd/tests/test_scaler.py
@@ -6,7 +6,7 @@ from copy import copy
 
 from ophyd import scaler
 from ophyd.utils import enum
-from .conftest   import using_fake_epics_pv
+from .conftest import using_fake_epics_pv
 from .test_utils import assert_OD_equal_ignore_ts
 
 

--- a/ophyd/utils/_backport_enum.py
+++ b/ophyd/utils/_backport_enum.py
@@ -1,0 +1,893 @@
+"""
+This is vendored from cpython/Lib/enum.py from d518d8bc8d5dac1a1270612f424d33e0e5afc2b5
+"""
+import sys
+from types import MappingProxyType, DynamicClassAttribute
+
+# try _collections first to reduce startup cost
+try:
+    from _collections import OrderedDict
+except ImportError:
+    from collections import OrderedDict
+
+
+__all__ = [
+        'EnumMeta',
+        'Enum', 'IntEnum', 'Flag', 'IntFlag',
+        'auto', 'unique',
+        ]
+
+
+def _is_descriptor(obj):
+    """Returns True if obj is a descriptor, False otherwise."""
+    return (
+            hasattr(obj, '__get__') or
+            hasattr(obj, '__set__') or
+            hasattr(obj, '__delete__'))
+
+
+def _is_dunder(name):
+    """Returns True if a __dunder__ name, False otherwise."""
+    return (name[:2] == name[-2:] == '__' and
+            name[2:3] != '_' and
+            name[-3:-2] != '_' and
+            len(name) > 4)
+
+
+def _is_sunder(name):
+    """Returns True if a _sunder_ name, False otherwise."""
+    return (name[0] == name[-1] == '_' and
+            name[1:2] != '_' and
+            name[-2:-1] != '_' and
+            len(name) > 2)
+
+def _make_class_unpicklable(cls):
+    """Make the given class un-picklable."""
+    def _break_on_call_reduce(self, proto):
+        raise TypeError('%r cannot be pickled' % self)
+    cls.__reduce_ex__ = _break_on_call_reduce
+    cls.__module__ = '<unknown>'
+
+_auto_null = object()
+class auto:
+    """
+    Instances are replaced with an appropriate value in Enum class suites.
+    """
+    value = _auto_null
+
+
+class _EnumDict(dict):
+    """Track enum member order and ensure member names are not reused.
+
+    EnumMeta will use the names found in self._member_names as the
+    enumeration member names.
+
+    """
+    def __init__(self):
+        super().__init__()
+        self._member_names = []
+        self._last_values = []
+        self._ignore = []
+
+    def __setitem__(self, key, value):
+        """Changes anything not dundered or not a descriptor.
+
+        If an enum member name is used twice, an error is raised; duplicate
+        values are not checked for.
+
+        Single underscore (sunder) names are reserved.
+
+        """
+        if _is_sunder(key):
+            if key not in (
+                    '_order_', '_create_pseudo_member_',
+                    '_generate_next_value_', '_missing_', '_ignore_',
+                    ):
+                raise ValueError('_names_ are reserved for future Enum use')
+            if key == '_generate_next_value_':
+                setattr(self, '_generate_next_value', value)
+            elif key == '_ignore_':
+                if isinstance(value, str):
+                    value = value.replace(',',' ').split()
+                else:
+                    value = list(value)
+                self._ignore = value
+                already = set(value) & set(self._member_names)
+                if already:
+                    raise ValueError('_ignore_ cannot specify already set names: %r' % (already, ))
+        elif _is_dunder(key):
+            if key == '__order__':
+                key = '_order_'
+        elif key in self._member_names:
+            # descriptor overwriting an enum?
+            raise TypeError('Attempted to reuse key: %r' % key)
+        elif key in self._ignore:
+            pass
+        elif not _is_descriptor(value):
+            if key in self:
+                # enum overwriting a descriptor?
+                raise TypeError('%r already defined as: %r' % (key, self[key]))
+            if isinstance(value, auto):
+                if value.value == _auto_null:
+                    value.value = self._generate_next_value(key, 1, len(self._member_names), self._last_values[:])
+                value = value.value
+            self._member_names.append(key)
+            self._last_values.append(value)
+        super().__setitem__(key, value)
+
+
+# Dummy value for Enum as EnumMeta explicitly checks for it, but of course
+# until EnumMeta finishes running the first time the Enum class doesn't exist.
+# This is also why there are checks in EnumMeta like `if Enum is not None`
+Enum = None
+
+
+class EnumMeta(type):
+    """Metaclass for Enum"""
+    @classmethod
+    def __prepare__(metacls, cls, bases):
+        # create the namespace dict
+        enum_dict = _EnumDict()
+        # inherit previous flags and _generate_next_value_ function
+        member_type, first_enum = metacls._get_mixins_(bases)
+        if first_enum is not None:
+            enum_dict['_generate_next_value_'] = getattr(first_enum, '_generate_next_value_', None)
+        return enum_dict
+
+    def __new__(metacls, cls, bases, classdict):
+        # an Enum class is final once enumeration items have been defined; it
+        # cannot be mixed with other types (int, float, etc.) if it has an
+        # inherited __new__ unless a new __new__ is defined (or the resulting
+        # class will fail).
+        #
+        # remove any keys listed in _ignore_
+        classdict.setdefault('_ignore_', []).append('_ignore_')
+        ignore = classdict['_ignore_']
+        for key in ignore:
+            classdict.pop(key, None)
+        member_type, first_enum = metacls._get_mixins_(bases)
+        __new__, save_new, use_args = metacls._find_new_(classdict, member_type,
+                                                        first_enum)
+
+        # save enum items into separate mapping so they don't get baked into
+        # the new class
+        enum_members = {k: classdict[k] for k in classdict._member_names}
+        for name in classdict._member_names:
+            del classdict[name]
+
+        # adjust the sunders
+        _order_ = classdict.pop('_order_', None)
+
+        # check for illegal enum names (any others?)
+        invalid_names = set(enum_members) & {'mro', }
+        if invalid_names:
+            raise ValueError('Invalid enum member name: {0}'.format(
+                ','.join(invalid_names)))
+
+        # create a default docstring if one has not been provided
+        if '__doc__' not in classdict:
+            classdict['__doc__'] = 'An enumeration.'
+
+        # create our new Enum type
+        enum_class = super().__new__(metacls, cls, bases, classdict)
+        enum_class._member_names_ = []               # names in definition order
+        enum_class._member_map_ = OrderedDict()      # name->value map
+        enum_class._member_type_ = member_type
+
+        # save attributes from super classes so we know if we can take
+        # the shortcut of storing members in the class dict
+        base_attributes = {a for b in enum_class.mro() for a in b.__dict__}
+
+        # Reverse value->name map for hashable values.
+        enum_class._value2member_map_ = {}
+
+        # If a custom type is mixed into the Enum, and it does not know how
+        # to pickle itself, pickle.dumps will succeed but pickle.loads will
+        # fail.  Rather than have the error show up later and possibly far
+        # from the source, sabotage the pickle protocol for this class so
+        # that pickle.dumps also fails.
+        #
+        # However, if the new class implements its own __reduce_ex__, do not
+        # sabotage -- it's on them to make sure it works correctly.  We use
+        # __reduce_ex__ instead of any of the others as it is preferred by
+        # pickle over __reduce__, and it handles all pickle protocols.
+        if '__reduce_ex__' not in classdict:
+            if member_type is not object:
+                methods = ('__getnewargs_ex__', '__getnewargs__',
+                        '__reduce_ex__', '__reduce__')
+                if not any(m in member_type.__dict__ for m in methods):
+                    _make_class_unpicklable(enum_class)
+
+        # instantiate them, checking for duplicates as we go
+        # we instantiate first instead of checking for duplicates first in case
+        # a custom __new__ is doing something funky with the values -- such as
+        # auto-numbering ;)
+        for member_name in classdict._member_names:
+            value = enum_members[member_name]
+            if not isinstance(value, tuple):
+                args = (value, )
+            else:
+                args = value
+            if member_type is tuple:   # special case for tuple enums
+                args = (args, )     # wrap it one more time
+            if not use_args:
+                enum_member = __new__(enum_class)
+                if not hasattr(enum_member, '_value_'):
+                    enum_member._value_ = value
+            else:
+                enum_member = __new__(enum_class, *args)
+                if not hasattr(enum_member, '_value_'):
+                    if member_type is object:
+                        enum_member._value_ = value
+                    else:
+                        enum_member._value_ = member_type(*args)
+            value = enum_member._value_
+            enum_member._name_ = member_name
+            enum_member.__objclass__ = enum_class
+            enum_member.__init__(*args)
+            # If another member with the same value was already defined, the
+            # new member becomes an alias to the existing one.
+            for name, canonical_member in enum_class._member_map_.items():
+                if canonical_member._value_ == enum_member._value_:
+                    enum_member = canonical_member
+                    break
+            else:
+                # Aliases don't appear in member names (only in __members__).
+                enum_class._member_names_.append(member_name)
+            # performance boost for any member that would not shadow
+            # a DynamicClassAttribute
+            if member_name not in base_attributes:
+                setattr(enum_class, member_name, enum_member)
+            # now add to _member_map_
+            enum_class._member_map_[member_name] = enum_member
+            try:
+                # This may fail if value is not hashable. We can't add the value
+                # to the map, and by-value lookups for this value will be
+                # linear.
+                enum_class._value2member_map_[value] = enum_member
+            except TypeError:
+                pass
+
+        # double check that repr and friends are not the mixin's or various
+        # things break (such as pickle)
+        for name in ('__repr__', '__str__', '__format__', '__reduce_ex__'):
+            class_method = getattr(enum_class, name)
+            obj_method = getattr(member_type, name, None)
+            enum_method = getattr(first_enum, name, None)
+            if obj_method is not None and obj_method is class_method:
+                setattr(enum_class, name, enum_method)
+
+        # replace any other __new__ with our own (as long as Enum is not None,
+        # anyway) -- again, this is to support pickle
+        if Enum is not None:
+            # if the user defined their own __new__, save it before it gets
+            # clobbered in case they subclass later
+            if save_new:
+                enum_class.__new_member__ = __new__
+            enum_class.__new__ = Enum.__new__
+
+        # py3 support for definition order (helps keep py2/py3 code in sync)
+        if _order_ is not None:
+            if isinstance(_order_, str):
+                _order_ = _order_.replace(',', ' ').split()
+            if _order_ != enum_class._member_names_:
+                raise TypeError('member order does not match _order_')
+
+        return enum_class
+
+    def __bool__(self):
+        """
+        classes/types should always be True.
+        """
+        return True
+
+    def __call__(cls, value, names=None, *, module=None, qualname=None, type=None, start=1):
+        """Either returns an existing member, or creates a new enum class.
+
+        This method is used both when an enum class is given a value to match
+        to an enumeration member (i.e. Color(3)) and for the functional API
+        (i.e. Color = Enum('Color', names='RED GREEN BLUE')).
+
+        When used for the functional API:
+
+        `value` will be the name of the new class.
+
+        `names` should be either a string of white-space/comma delimited names
+        (values will start at `start`), or an iterator/mapping of name, value pairs.
+
+        `module` should be set to the module this class is being created in;
+        if it is not set, an attempt to find that module will be made, but if
+        it fails the class will not be picklable.
+
+        `qualname` should be set to the actual location this class can be found
+        at in its module; by default it is set to the global scope.  If this is
+        not correct, unpickling will fail in some circumstances.
+
+        `type`, if set, will be mixed in as the first base class.
+
+        """
+        if names is None:  # simple value lookup
+            return cls.__new__(cls, value)
+        # otherwise, functional API: we're creating a new Enum type
+        return cls._create_(value, names, module=module, qualname=qualname, type=type, start=start)
+
+    def __contains__(cls, member):
+        return isinstance(member, cls) and member._name_ in cls._member_map_
+
+    def __delattr__(cls, attr):
+        # nicer error message when someone tries to delete an attribute
+        # (see issue19025).
+        if attr in cls._member_map_:
+            raise AttributeError(
+                    "%s: cannot delete Enum member." % cls.__name__)
+        super().__delattr__(attr)
+
+    def __dir__(self):
+        return (['__class__', '__doc__', '__members__', '__module__'] +
+                self._member_names_)
+
+    def __getattr__(cls, name):
+        """Return the enum member matching `name`
+
+        We use __getattr__ instead of descriptors or inserting into the enum
+        class' __dict__ in order to support `name` and `value` being both
+        properties for enum members (which live in the class' __dict__) and
+        enum members themselves.
+
+        """
+        if _is_dunder(name):
+            raise AttributeError(name)
+        try:
+            return cls._member_map_[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __getitem__(cls, name):
+        return cls._member_map_[name]
+
+    def __iter__(cls):
+        return (cls._member_map_[name] for name in cls._member_names_)
+
+    def __len__(cls):
+        return len(cls._member_names_)
+
+    @property
+    def __members__(cls):
+        """Returns a mapping of member name->value.
+
+        This mapping lists all enum members, including aliases. Note that this
+        is a read-only view of the internal mapping.
+
+        """
+        return MappingProxyType(cls._member_map_)
+
+    def __repr__(cls):
+        return "<enum %r>" % cls.__name__
+
+    def __reversed__(cls):
+        return (cls._member_map_[name] for name in reversed(cls._member_names_))
+
+    def __setattr__(cls, name, value):
+        """Block attempts to reassign Enum members.
+
+        A simple assignment to the class namespace only changes one of the
+        several possible ways to get an Enum member from the Enum class,
+        resulting in an inconsistent Enumeration.
+
+        """
+        member_map = cls.__dict__.get('_member_map_', {})
+        if name in member_map:
+            raise AttributeError('Cannot reassign members.')
+        super().__setattr__(name, value)
+
+    def _create_(cls, class_name, names, *, module=None, qualname=None, type=None, start=1):
+        """Convenience method to create a new Enum class.
+
+        `names` can be:
+
+        * A string containing member names, separated either with spaces or
+          commas.  Values are incremented by 1 from `start`.
+        * An iterable of member names.  Values are incremented by 1 from `start`.
+        * An iterable of (member name, value) pairs.
+        * A mapping of member name -> value pairs.
+
+        """
+        metacls = cls.__class__
+        bases = (cls, ) if type is None else (type, cls)
+        _, first_enum = cls._get_mixins_(bases)
+        classdict = metacls.__prepare__(class_name, bases)
+
+        # special processing needed for names?
+        if isinstance(names, str):
+            names = names.replace(',', ' ').split()
+        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
+            original_names, names = names, []
+            last_values = []
+            for count, name in enumerate(original_names):
+                value = first_enum._generate_next_value_(name, start, count, last_values[:])
+                last_values.append(value)
+                names.append((name, value))
+
+        # Here, names is either an iterable of (name, value) or a mapping.
+        for item in names:
+            if isinstance(item, str):
+                member_name, member_value = item, names[item]
+            else:
+                member_name, member_value = item
+            classdict[member_name] = member_value
+        enum_class = metacls.__new__(metacls, class_name, bases, classdict)
+
+        # TODO: replace the frame hack if a blessed way to know the calling
+        # module is ever developed
+        if module is None:
+            try:
+                module = sys._getframe(2).f_globals['__name__']
+            except (AttributeError, ValueError) as exc:
+                pass
+        if module is None:
+            _make_class_unpicklable(enum_class)
+        else:
+            enum_class.__module__ = module
+        if qualname is not None:
+            enum_class.__qualname__ = qualname
+
+        return enum_class
+
+    @staticmethod
+    def _get_mixins_(bases):
+        """Returns the type for creating enum members, and the first inherited
+        enum class.
+
+        bases: the tuple of bases that was given to __new__
+
+        """
+        if not bases:
+            return object, Enum
+
+        # double check that we are not subclassing a class with existing
+        # enumeration members; while we're at it, see if any other data
+        # type has been mixed in so we can use the correct __new__
+        member_type = first_enum = None
+        for base in bases:
+            if  (base is not Enum and
+                    issubclass(base, Enum) and
+                    base._member_names_):
+                raise TypeError("Cannot extend enumerations")
+        # base is now the last base in bases
+        if not issubclass(base, Enum):
+            raise TypeError("new enumerations must be created as "
+                    "`ClassName([mixin_type,] enum_type)`")
+
+        # get correct mix-in type (either mix-in type of Enum subclass, or
+        # first base if last base is Enum)
+        if not issubclass(bases[0], Enum):
+            member_type = bases[0]     # first data type
+            first_enum = bases[-1]  # enum type
+        else:
+            for base in bases[0].__mro__:
+                # most common: (IntEnum, int, Enum, object)
+                # possible:    (<Enum 'AutoIntEnum'>, <Enum 'IntEnum'>,
+                #               <class 'int'>, <Enum 'Enum'>,
+                #               <class 'object'>)
+                if issubclass(base, Enum):
+                    if first_enum is None:
+                        first_enum = base
+                else:
+                    if member_type is None:
+                        member_type = base
+
+        return member_type, first_enum
+
+    @staticmethod
+    def _find_new_(classdict, member_type, first_enum):
+        """Returns the __new__ to be used for creating the enum members.
+
+        classdict: the class dictionary given to __new__
+        member_type: the data type whose __new__ will be used by default
+        first_enum: enumeration to check for an overriding __new__
+
+        """
+        # now find the correct __new__, checking to see of one was defined
+        # by the user; also check earlier enum classes in case a __new__ was
+        # saved as __new_member__
+        __new__ = classdict.get('__new__', None)
+
+        # should __new__ be saved as __new_member__ later?
+        save_new = __new__ is not None
+
+        if __new__ is None:
+            # check all possibles for __new_member__ before falling back to
+            # __new__
+            for method in ('__new_member__', '__new__'):
+                for possible in (member_type, first_enum):
+                    target = getattr(possible, method, None)
+                    if target not in {
+                            None,
+                            None.__new__,
+                            object.__new__,
+                            Enum.__new__,
+                            }:
+                        __new__ = target
+                        break
+                if __new__ is not None:
+                    break
+            else:
+                __new__ = object.__new__
+
+        # if a non-object.__new__ is used then whatever value/tuple was
+        # assigned to the enum member name will be passed to __new__ and to the
+        # new enum member's __init__
+        if __new__ is object.__new__:
+            use_args = False
+        else:
+            use_args = True
+
+        return __new__, save_new, use_args
+
+
+class Enum(metaclass=EnumMeta):
+    """Generic enumeration.
+
+    Derive from this class to define new enumerations.
+
+    """
+    def __new__(cls, value):
+        # all enum instances are actually created during class construction
+        # without calling this method; this method is called by the metaclass'
+        # __call__ (i.e. Color(3) ), and by pickle
+        if type(value) is cls:
+            # For lookups like Color(Color.RED)
+            return value
+        # by-value search for a matching enum member
+        # see if it's in the reverse mapping (for hashable values)
+        try:
+            if value in cls._value2member_map_:
+                return cls._value2member_map_[value]
+        except TypeError:
+            # not there, now do long search -- O(n) behavior
+            for member in cls._member_map_.values():
+                if member._value_ == value:
+                    return member
+        # still not found -- try _missing_ hook
+        return cls._missing_(value)
+
+    def _generate_next_value_(name, start, count, last_values):
+        for last_value in reversed(last_values):
+            try:
+                return last_value + 1
+            except TypeError:
+                pass
+        else:
+            return start
+
+    @classmethod
+    def _missing_(cls, value):
+        raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+
+    def __repr__(self):
+        return "<%s.%s: %r>" % (
+                self.__class__.__name__, self._name_, self._value_)
+
+    def __str__(self):
+        return "%s.%s" % (self.__class__.__name__, self._name_)
+
+    def __dir__(self):
+        added_behavior = [
+                m
+                for cls in self.__class__.mro()
+                for m in cls.__dict__
+                if m[0] != '_' and m not in self._member_map_
+                ]
+        return (['__class__', '__doc__', '__module__'] + added_behavior)
+
+    def __format__(self, format_spec):
+        # mixed-in Enums should use the mixed-in type's __format__, otherwise
+        # we can get strange results with the Enum name showing up instead of
+        # the value
+
+        # pure Enum branch
+        if self._member_type_ is object:
+            cls = str
+            val = str(self)
+        # mix-in branch
+        else:
+            cls = self._member_type_
+            val = self._value_
+        return cls.__format__(val, format_spec)
+
+    def __hash__(self):
+        return hash(self._name_)
+
+    def __reduce_ex__(self, proto):
+        return self.__class__, (self._value_, )
+
+    # DynamicClassAttribute is used to provide access to the `name` and
+    # `value` properties of enum members while keeping some measure of
+    # protection from modification, while still allowing for an enumeration
+    # to have members named `name` and `value`.  This works because enumeration
+    # members are not set directly on the enum class -- __getattr__ is
+    # used to look them up.
+
+    @DynamicClassAttribute
+    def name(self):
+        """The name of the Enum member."""
+        return self._name_
+
+    @DynamicClassAttribute
+    def value(self):
+        """The value of the Enum member."""
+        return self._value_
+
+    @classmethod
+    def _convert(cls, name, module, filter, source=None):
+        """
+        Create a new Enum subclass that replaces a collection of global constants
+        """
+        # convert all constants from source (or module) that pass filter() to
+        # a new Enum called name, and export the enum and its members back to
+        # module;
+        # also, replace the __reduce_ex__ method so unpickling works in
+        # previous Python versions
+        module_globals = vars(sys.modules[module])
+        if source:
+            source = vars(source)
+        else:
+            source = module_globals
+        # We use an OrderedDict of sorted source keys so that the
+        # _value2member_map is populated in the same order every time
+        # for a consistent reverse mapping of number to name when there
+        # are multiple names for the same number rather than varying
+        # between runs due to hash randomization of the module dictionary.
+        members = [
+                (name, source[name])
+                for name in source.keys()
+                if filter(name)]
+        try:
+            # sort by value
+            members.sort(key=lambda t: (t[1], t[0]))
+        except TypeError:
+            # unless some values aren't comparable, in which case sort by name
+            members.sort(key=lambda t: t[0])
+        cls = cls(name, members, module=module)
+        cls.__reduce_ex__ = _reduce_ex_by_name
+        module_globals.update(cls.__members__)
+        module_globals[name] = cls
+        return cls
+
+
+class IntEnum(int, Enum):
+    """Enum where members are also (and must be) ints"""
+
+
+def _reduce_ex_by_name(self, proto):
+    return self.name
+
+class Flag(Enum):
+    """Support for flags"""
+
+    def _generate_next_value_(name, start, count, last_values):
+        """
+        Generate the next value when not given.
+
+        name: the name of the member
+        start: the initital start value or None
+        count: the number of existing members
+        last_value: the last value assigned or None
+        """
+        if not count:
+            return start if start is not None else 1
+        for last_value in reversed(last_values):
+            try:
+                high_bit = _high_bit(last_value)
+                break
+            except Exception:
+                raise TypeError('Invalid Flag value: %r' % last_value) from None
+        return 2 ** (high_bit+1)
+
+    @classmethod
+    def _missing_(cls, value):
+        original_value = value
+        if value < 0:
+            value = ~value
+        possible_member = cls._create_pseudo_member_(value)
+        if original_value < 0:
+            possible_member = ~possible_member
+        return possible_member
+
+    @classmethod
+    def _create_pseudo_member_(cls, value):
+        """
+        Create a composite member iff value contains only members.
+        """
+        pseudo_member = cls._value2member_map_.get(value, None)
+        if pseudo_member is None:
+            # verify all bits are accounted for
+            _, extra_flags = _decompose(cls, value)
+            if extra_flags:
+                raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+            # construct a singleton enum pseudo-member
+            pseudo_member = object.__new__(cls)
+            pseudo_member._name_ = None
+            pseudo_member._value_ = value
+            # use setdefault in case another thread already created a composite
+            # with this value
+            pseudo_member = cls._value2member_map_.setdefault(value, pseudo_member)
+        return pseudo_member
+
+    def __contains__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return other._value_ & self._value_ == other._value_
+
+    def __repr__(self):
+        cls = self.__class__
+        if self._name_ is not None:
+            return '<%s.%s: %r>' % (cls.__name__, self._name_, self._value_)
+        members, uncovered = _decompose(cls, self._value_)
+        return '<%s.%s: %r>' % (
+                cls.__name__,
+                '|'.join([str(m._name_ or m._value_) for m in members]),
+                self._value_,
+                )
+
+    def __str__(self):
+        cls = self.__class__
+        if self._name_ is not None:
+            return '%s.%s' % (cls.__name__, self._name_)
+        members, uncovered = _decompose(cls, self._value_)
+        if len(members) == 1 and members[0]._name_ is None:
+            return '%s.%r' % (cls.__name__, members[0]._value_)
+        else:
+            return '%s.%s' % (
+                    cls.__name__,
+                    '|'.join([str(m._name_ or m._value_) for m in members]),
+                    )
+
+    def __bool__(self):
+        return bool(self._value_)
+
+    def __or__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.__class__(self._value_ | other._value_)
+
+    def __and__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.__class__(self._value_ & other._value_)
+
+    def __xor__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.__class__(self._value_ ^ other._value_)
+
+    def __invert__(self):
+        members, uncovered = _decompose(self.__class__, self._value_)
+        inverted = self.__class__(0)
+        for m in self.__class__:
+            if m not in members and not (m._value_ & self._value_):
+                inverted = inverted | m
+        return self.__class__(inverted)
+
+
+class IntFlag(int, Flag):
+    """Support for integer-based Flags"""
+
+    @classmethod
+    def _missing_(cls, value):
+        if not isinstance(value, int):
+            raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+        new_member = cls._create_pseudo_member_(value)
+        return new_member
+
+    @classmethod
+    def _create_pseudo_member_(cls, value):
+        pseudo_member = cls._value2member_map_.get(value, None)
+        if pseudo_member is None:
+            need_to_create = [value]
+            # get unaccounted for bits
+            _, extra_flags = _decompose(cls, value)
+            # timer = 10
+            while extra_flags:
+                # timer -= 1
+                bit = _high_bit(extra_flags)
+                flag_value = 2 ** bit
+                if (flag_value not in cls._value2member_map_ and
+                        flag_value not in need_to_create
+                        ):
+                    need_to_create.append(flag_value)
+                if extra_flags == -flag_value:
+                    extra_flags = 0
+                else:
+                    extra_flags ^= flag_value
+            for value in reversed(need_to_create):
+                # construct singleton pseudo-members
+                pseudo_member = int.__new__(cls, value)
+                pseudo_member._name_ = None
+                pseudo_member._value_ = value
+                # use setdefault in case another thread already created a composite
+                # with this value
+                pseudo_member = cls._value2member_map_.setdefault(value, pseudo_member)
+        return pseudo_member
+
+    def __or__(self, other):
+        if not isinstance(other, (self.__class__, int)):
+            return NotImplemented
+        result = self.__class__(self._value_ | self.__class__(other)._value_)
+        return result
+
+    def __and__(self, other):
+        if not isinstance(other, (self.__class__, int)):
+            return NotImplemented
+        return self.__class__(self._value_ & self.__class__(other)._value_)
+
+    def __xor__(self, other):
+        if not isinstance(other, (self.__class__, int)):
+            return NotImplemented
+        return self.__class__(self._value_ ^ self.__class__(other)._value_)
+
+    __ror__ = __or__
+    __rand__ = __and__
+    __rxor__ = __xor__
+
+    def __invert__(self):
+        result = self.__class__(~self._value_)
+        return result
+
+
+def _high_bit(value):
+    """returns index of highest bit, or -1 if value is zero or negative"""
+    return value.bit_length() - 1
+
+def unique(enumeration):
+    """Class decorator for enumerations ensuring unique member values."""
+    duplicates = []
+    for name, member in enumeration.__members__.items():
+        if name != member.name:
+            duplicates.append((name, member.name))
+    if duplicates:
+        alias_details = ', '.join(
+                ["%s -> %s" % (alias, name) for (alias, name) in duplicates])
+        raise ValueError('duplicate values found in %r: %s' %
+                (enumeration, alias_details))
+    return enumeration
+
+def _decompose(flag, value):
+    """Extract all members from the value."""
+    # _decompose is only called if the value is not named
+    not_covered = value
+    negative = value < 0
+    # issue29167: wrap accesses to _value2member_map_ in a list to avoid race
+    #             conditions between iterating over it and having more pseudo-
+    #             members added to it
+    if negative:
+        # only check for named flags
+        flags_to_check = [
+                (m, v)
+                for v, m in list(flag._value2member_map_.items())
+                if m.name is not None
+                ]
+    else:
+        # check for named flags and powers-of-two flags
+        flags_to_check = [
+                (m, v)
+                for v, m in list(flag._value2member_map_.items())
+                if m.name is not None or _power_of_two(v)
+                ]
+    members = []
+    for member, member_value in flags_to_check:
+        if member_value and member_value & value == member_value:
+            members.append(member)
+            not_covered &= ~member_value
+    if not members and value in flag._value2member_map_:
+        members.append(flag._value2member_map_[value])
+    members.sort(key=lambda m: m._value_, reverse=True)
+    if len(members) > 1 and members[0].value == value:
+        # we have the breakdown, don't need the value member itself
+        members.pop(0)
+    return members, not_covered
+
+def _power_of_two(value):
+    if value < 1:
+        return False
+    return value == 2 ** _high_bit(value)


### PR DESCRIPTION
Closes #540 Closes #539 Closes #502 Closes #487 

It is possible we make poor life choices, but this seems to work and has a number of additional nice properties

 - the ground truth of if a component is included in the `read` or `read_configuration` (or both!) walks of the Device tree is now held in the components
 - it is now clear how to configure this at class definition time
 - the old API of _setting_ `read_attrs` and `configuration_attrs` still works
 - changing the state of a parent via `dev.child.kind = Kind.OMITTED` won't affect grand chlidren.
 - leaf-nodes can be made hinted via `dev.child.leaf.kind = Kind.HINTED` 
 - The many versions of `_default_*_attrs` still work as before

API breaks

 - read_attrs / configuration_attrs will now contain all of the components touched when walking the tree.  This also means that setting `dev.read_attrs` may not always round trip.  This is probably not a big deal, see discussion at https://github.com/NSLS-II/ophyd/issues/540#issuecomment-388599250 for why we have to break _something_ here.
- when adding grand-chlidren via `dev.read_attrs` we no longer allow generation 'skipping' and forcibly set up the state of all of the devices along the way to be consistent.  I can think of and edge case where this matters, but I don't think people should be doing that anyway...
 - can no longer directly set `dev.hints` as a dictionary.
