### PR TITLE
Added a lazy version of __iter__ method

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1265,6 +1265,9 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         def __contains__(self, value):
             return getattr(self._parent, value).kind & self._kind
 
+        def __iter__(self):
+            yield from self.__internal_list()
+
         def __eq__(self, other):
             return list(self) == other
 


### PR DESCRIPTION
@tacaswell 's fix of the slowdown we noticed. override `__iter__` to be lazy. Default is to call `__getitem__` [here](https://github.com/python/cpython/blob/master/Lib/_collections_abc.py#L879) which basically creates a new list calling `__internal_list` which walks the tree upon *every access*.