### PR TITLE
FIX: remove erroneous configuration in ScalerCH init

### DIFF
--- a/ophyd/scaler.py
+++ b/ophyd/scaler.py
@@ -116,19 +116,6 @@ class ScalerCH(Device):
 
     egu = C(EpicsSignal, '.EGU', kind=Kind.config)
 
-    def __init__(self, *args, **kwargs):
-
-        super().__init__(*args, **kwargs)
-
-        active_channels = []
-        for s in self.channels.component_names:
-            ch_name = getattr(self.channels, s).name
-            if ch_name:
-                active_channels.append(ch_name)
-
-        self.channels.read_attrs = list(active_channels)
-        self.channels.configuration_attrs = list(active_channels)
-
     def match_names(self):
         for s in self.channels.component_names:
             getattr(self.channels, s).match_name()

--- a/ophyd/tests/test_scaler.py
+++ b/ophyd/tests/test_scaler.py
@@ -102,3 +102,12 @@ def test_signal_separate():
     data = sca.read()
     assert 'scaler_channels_chan1' in data
     assert 'scaler_channels_chan2' not in data
+
+
+@using_fake_epics_pv
+def smoke_test_scalerCH():
+    sca = scaler.ScalerCH(scalers[0])
+    sca.wait_for_connection()
+    data = sca.read()
+    assert 'scaler_channels_chan1' in data
+    assert 'scaler_channels_chan2' not in data


### PR DESCRIPTION
This is now handled by the components and this particular code causes
exceptions on init because it is using the wrong names.