### PR TITLE
ENH: make_fake_device factory function

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -627,8 +627,8 @@ class SynSignalWithRegistry(SynSignal):
 
     """
 
-    def __init__(self, *args, reg=DO_NOT_USE, save_path=None, save_func=np.save,
-                 save_spec='NPY_SEQ', save_ext='npy',
+    def __init__(self, *args, reg=DO_NOT_USE, save_path=None,
+                 save_func=np.save, save_spec='NPY_SEQ', save_ext='npy',
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.save_func = save_func

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -133,16 +133,13 @@ class SynSignal(Signal):
         return super().get()
 
 
-class SynSignalRO(SynSignal):
-    def put(self, value, *, timestamp=None, force=False):
-        raise NotImplementedError("The signal {} is readonly."
-                                  "".format(self.name))
-
-
 class SignalRO(Signal):
     def put(self, value, *, timestamp=None, force=False):
-        raise NotImplementedError("The signal {} is readonly."
-                                  "".format(self.name))
+        raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+
+
+class SynSignalRO(SignalRO, SynSignal):
+    pass
 
 
 def periodic_update(ref, period, period_jitter):

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -137,6 +137,9 @@ class SignalRO(Signal):
     def put(self, value, *, timestamp=None, force=False):
         raise ReadOnlyError("The signal {} is readonly.".format(self.name))
 
+    def set(self, value, *, timestamp=None, force=False):
+        raise ReadOnlyError("The signal {} is readonly.".format(self.name))
+
 
 class SynSignalRO(SignalRO, SynSignal):
     pass

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -10,15 +10,20 @@ import os
 import warnings
 import weakref
 import uuid
+import copy
+import logging
 
-from .signal import Signal
+from .signal import Signal, EpicsSignal, EpicsSignalRO
 from .status import DeviceStatus, StatusBase
-from .device import Device, Component, Component as C, Kind
+from .device import (Device, Component, Component as C,
+                     DynamicDeviceComponent as DDC, Kind)
 from types import SimpleNamespace
 from .pseudopos import (PseudoPositioner, PseudoSingle,
                         real_position_argument, pseudo_position_argument)
 from .positioner import SoftPositioner
-from .utils import DO_NOT_USE
+from .utils import DO_NOT_USE, ReadOnlyError, LimitError
+
+logger = logging.getLogger(__name__)
 
 
 # two convenience functions 'vendored' from bluesky.utils
@@ -841,6 +846,145 @@ class SynAxisNoPosition(SynAxis):
     @property
     def position(self):
         raise AttributeError
+
+
+def make_fake_class(cls):
+    """
+    Inspect cls and construct a fake class that has the same structure.
+
+    This works by replacing EpicsSignal with FakeEpicsSignal and EpicsSignalRO
+    with FakeEpicsSignalRO. The fake class will be a subclass of the real
+    class.
+
+    This assumes that EPICS connections are done entirely in EpicsSignal and
+    EpicsSignalRO subcomponents. If this is not true, this will fail silently
+    until the test.
+
+    Parameters
+    ----------
+    cls: `ophyd.Device`
+
+    Returns
+    -------
+    fake_class: `ophyd.Device`
+    """
+    # Cache to avoid repeating work.
+    # EpicsSignal and EpicsSignalRO begin in the cache.
+    if cls not in fake_class_cache:
+        if not issubclass(cls, Device):
+            # Ignore non-devices and non-epics-signals
+            logger.debug('Ignore cls=%s, bases are %s', cls, cls.__bases__)
+            fake_class_cache[cls] = cls
+            return cls
+        fake_dict = {}
+        # Update all the components recursively
+        for cpt_name in cls.component_names:
+            cpt = getattr(cls, cpt_name)
+            fake_cpt = copy.copy(cpt)
+            if isinstance(cpt, Component):
+                fake_cpt.cls = make_fake_class(cpt.cls)
+                logger.debug('switch cpt_name=%s to cls=%s',
+                             cpt_name, fake_cpt.cls)
+            # DDCpt stores the classes in a different place
+            elif isinstance(cpt, DDC):
+                fake_defn = {}
+                for ddcpt_name, ddcpt_tuple in cpt.defn.items():
+                    subcls = make_fake_class(ddcpt_tuple[0])
+                    fake_defn[ddcpt_name] = [subcls] + list(ddcpt_tuple[1:])
+                fake_cpt.defn = fake_defn
+            else:
+                raise RuntimeError(("{} is not a component or a dynamic "
+                                    "device component. I don't know how you "
+                                    "found this error, should be impossible "
+                                    "to reach it.".format(cpt)))
+            fake_dict[cpt_name] = fake_cpt
+        fake_class = type('Fake{}'.format(cls.__name__), (cls,), fake_dict)
+        fake_class_cache[cls] = fake_class
+        logger.debug('fake_class_cache[%s] = %s', cls, fake_class)
+    return fake_class_cache[cls]
+
+
+class FakeEpicsSignal(Signal):
+    """
+    Fake version of EpicsSignal that's really just a signal.
+
+    We can emulate EPICS features here. Currently we just emulate the put
+    limits because it was involved in a kwarg.
+    """
+    def __init__(self, read_pv, write_pv=None, *, pv_kw=None,
+                 put_complete=False, string=False, limits=False,
+                 auto_monitor=False, name=None, **kwargs):
+        """
+        Mimic EpicsSignal signature
+        """
+        super().__init__(name=name, **kwargs)
+        self._use_limits = limits
+        self._sim_getter = None
+        self._sim_putter = None
+
+    def sim_set_getter(self, getter):
+        """
+        Set a method to call instead of get
+        """
+        self._sim_getter = getter
+
+    def sim_set_putter(self, putter):
+        """
+        Set a method to call instead of put
+        """
+        self._sim_putter = putter
+
+    def get(self, *args, **kwargs):
+        if self._sim_getter:
+            return self._sim_getter(*args, **kwargs)
+        return super().get(*args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        if self._sim_putter is not None:
+            return self._sim_putter(*args, **kwargs)
+        return super().put(*args, **kwargs)
+
+    def sim_put(self, *args, **kwargs):
+        """
+        Update the read-only signal's value.
+
+        Implement here instead of FakeEpicsSignalRO so you can call it with
+        every fake signal.
+        """
+        return Signal.put(self, *args, **kwargs)
+
+    @property
+    def limits(self):
+        return self._limits
+
+    def sim_limits(self, limits):
+        """
+        Set the fake signal's limits.
+        """
+        self._limits = limits
+
+    def check_value(self, value):
+        """
+        Check fake limits before putting
+        """
+        super().check_value(value)
+        if self._use_limits and not self.limits[0] < value < self.limits[1]:
+            raise LimitError('value={} limits={}'.format(value, self.limits))
+
+
+class FakeEpicsSignalRO(FakeEpicsSignal):
+    """
+    Read-only FakeEpicsSignal
+    """
+    def put(self, *args, **kwargs):
+        raise ReadOnlyError()
+
+    def set(self, *args, **kwargs):
+        raise ReadOnlyError()
+
+
+fake_class_cache = {EpicsSignal: FakeEpicsSignal,
+                    EpicsSignalRO: FakeEpicsSignalRO}
 
 
 def hw():

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -1,5 +1,11 @@
-from ophyd.sim import SynGauss, Syn2DGauss, SynAxis
+from ophyd.sim import (SynGauss, Syn2DGauss, SynAxis,
+                       make_fake_device, FakeEpicsSignal, FakeEpicsSignalRO)
+from ophyd.device import (Device, Component as Cpt, FormattedComponent as FCpt,
+                          DynamicDeviceComponent as DDCpt)
+from ophyd.signal import Signal, EpicsSignal, EpicsSignalRO
+from ophyd.utils import ReadOnlyError, LimitError, DisconnectedError
 import numpy as np
+import pytest
 
 
 def test_random_state_gauss1d():
@@ -106,3 +112,88 @@ def test_synaxis_timestamps():
     motor.setpoint.put(3)
     time.sleep(2*motor.delay)
     orig_time = tester(motor, orig_time)
+
+
+# Classes for testing make_fake_device
+class SampleNested(Device):
+    yolk = Cpt(EpicsSignal, ':YOLK')
+    whites = Cpt(EpicsSignalRO, ':WHITES')
+
+
+class Sample(Device):
+    egg = Cpt(SampleNested, ':EGG')
+    butter = Cpt(EpicsSignal, ':BUTTER')
+    flour = Cpt(EpicsSignalRO, ':FLOUR')
+    sink = FCpt(EpicsSignal, '{self.sink_location}:SINK')
+    fridge = DDCpt({'milk': (EpicsSignal, ':MILK', {}),
+                    'cheese': (EpicsSignalRO, ':CHEESE', {})})
+    nothing = Cpt(Signal)
+
+    sink_location = 'COUNTER'
+
+
+def test_make_fake_device():
+    assert make_fake_device(EpicsSignal) == FakeEpicsSignal
+    assert make_fake_device(EpicsSignalRO) == FakeEpicsSignalRO
+
+    FakeSample = make_fake_device(Sample)
+    my_fake = FakeSample('KITCHEN', name='kitchen')
+    assert isinstance(my_fake, Sample)
+
+    # Skipped
+    assert my_fake.nothing.__class__ is Signal
+
+    # Normal
+    assert isinstance(my_fake.butter, FakeEpicsSignal)
+    assert isinstance(my_fake.flour, FakeEpicsSignalRO)
+    assert isinstance(my_fake.sink, FakeEpicsSignal)
+
+    # Nested
+    assert isinstance(my_fake.egg.yolk, FakeEpicsSignal)
+    assert isinstance(my_fake.egg.whites, FakeEpicsSignalRO)
+
+    # Dynamic
+    assert isinstance(my_fake.fridge.milk, FakeEpicsSignal)
+    assert isinstance(my_fake.fridge.cheese, FakeEpicsSignalRO)
+
+    my_fake.read()
+
+
+def test_do_not_break_real_class():
+    make_fake_device(Sample)
+    assert Sample.butter.cls is EpicsSignal
+    assert Sample.egg.cls is SampleNested
+    assert SampleNested.whites.cls is EpicsSignalRO
+    assert Sample.fridge.defn['milk'][0] is EpicsSignal
+
+    with pytest.raises(DisconnectedError):
+        my_real = Sample('KITCHEN', name='kitchen')
+        my_real.read()
+
+
+def test_fake_epics_signal():
+    sig = FakeEpicsSignal('PVNAME', name='sig', limits=True)
+    sig.sim_limits((0, 10))
+    with pytest.raises(LimitError):
+        sig.put(11)
+    sig.put(4)
+    assert sig.get() == 4
+    sig.sim_put(5)
+    assert sig.get() == 5
+    sig.sim_set_putter(lambda x: sig.sim_put(x + 1))
+    sig.put(6)
+    assert sig.get() == 7
+    sig.sim_set_getter(lambda: 2.3)
+    assert sig.get() == 2.3
+
+
+def test_fake_epics_signal_ro():
+    sig = FakeEpicsSignalRO('PVNAME', name='sig')
+    with pytest.raises(ReadOnlyError):
+        sig.put(3)
+    with pytest.raises(ReadOnlyError):
+        sig.put(4)
+    with pytest.raises(ReadOnlyError):
+        sig.set(5)
+    sig.sim_put(1)
+    assert sig.get() == 1

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -173,7 +173,7 @@ def test_do_not_break_real_class():
 
 def test_fake_epics_signal():
     sig = FakeEpicsSignal('PVNAME', name='sig', limits=True)
-    sig.set_sim_limits((0, 10))
+    sig.sim_set_limits((0, 10))
     with pytest.raises(LimitError):
         sig.put(11)
     sig.put(4)

--- a/ophyd/tests/test_sim.py
+++ b/ophyd/tests/test_sim.py
@@ -173,7 +173,7 @@ def test_do_not_break_real_class():
 
 def test_fake_epics_signal():
     sig = FakeEpicsSignal('PVNAME', name='sig', limits=True)
-    sig.sim_limits((0, 10))
+    sig.set_sim_limits((0, 10))
     with pytest.raises(LimitError):
         sig.put(11)
     sig.put(4)
@@ -183,8 +183,6 @@ def test_fake_epics_signal():
     sig.sim_set_putter(lambda x: sig.sim_put(x + 1))
     sig.put(6)
     assert sig.get() == 7
-    sig.sim_set_getter(lambda: 2.3)
-    assert sig.get() == 2.3
 
 
 def test_fake_epics_signal_ro():


### PR DESCRIPTION
There isn't a convenient way in the library to test logic provided by `Device` subclasses. It can be done with `using_fake_epics_pv` but it tends to be awkward.

This PR introduces `make_fake_device`, which inspects a device class and creates a "fake" version of it with the same constructor, call signatures, etc. It does this by copying the `Component` objects and swapping the `cls` fields from `EpicsSignal` to `FakeEpicsSignal` and from `EpicsSignalRO` to `FakeEpicsSignalRO`, making a subclass with the fake signals. The fake signals are intended to do as little as possible to avoid adding failure points to tests unrelated to the real devices classes we are spoofing.

This is an idea I was throwing around at SLAC in https://github.com/pcdshub/pcdsdevices/pull/229.

I also make some minor tweaks to `sim.py` in the process.