### PR TITLE
Remove read_attrs and config_attrs from __repr__

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -157,8 +157,10 @@ class Component:
         return '\n'.join(doc)
 
     def __repr__(self):
-        kw_str = ', '.join('{}={!r}'.format(k, v)
-                           for k, v in self.kwargs.items())
+      
+        kw_str = ', '.join('{}={!r}'.format(k, v) for k, v in self.kwargs.items() \
+                           if k not in ['read_attrs','configuration_attrs'])
+                           
         if self.suffix is not None:
             suffix_str = '{!r}'.format(self.suffix)
             if self.kwargs:


### PR DESCRIPTION
The __repr__ method returns a string that is to long and confusing, I have removed read_attrs and config_attrs from the string in order to reduce the complexity.