### PR TITLE
FIX: read_attrs/config_attrs backcompatibility __contains__

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1274,7 +1274,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             getattr(self._parent, value).kind &= ~self._remove_kind
 
         def __contains__(self, value):
-            return getattr(self._parent, value).kind & self._kind
+            return self.__internal_list().__contains__(value)
 
         def __iter__(self):
             yield from self.__internal_list()

--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1274,7 +1274,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
             getattr(self._parent, value).kind &= ~self._remove_kind
 
         def __contains__(self, value):
-            return self.__internal_list().__contains__(value)
+            return value in self.__internal_list()
 
         def __iter__(self):
             yield from self.__internal_list()


### PR DESCRIPTION
This method was raising an `AttributeError` instead of returning `False` when something was not in the list e.g. `'not_a_real_signal' in device.read_attrs` would error out. I opted to check the full list rather than taking any shortcuts.

I ran into this when testing some of our older modules with `ophyd=1.2.0` that were checking if certain strings were in the `read_attrs` list. Is there a suggested way to check if something will be read if `read_attrs` is ever removed?