### PR TITLE
ENH: Add enum spoofing to FakeEpicsSignal, fix some bugs

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1006,7 +1006,7 @@ class FakeEpicsSignal(SynSignal):
 
     def sim_set_enum_strs(self, enums):
         """
-        Set the enum_strs for a fake devices
+        Set the enum_strs for a fake device
 
         Parameters
         ----------


### PR DESCRIPTION
After submitting the `FakeEpicsSignal` and `make_fake_device` code a couple months ago, I used it to clean up the tests for the SLAC devices library, but noticed some things were missing.

This adds:
- `sim_set_enum_strs` so that you can get/set using the enum string as a real PV would behave
- some checks `EpicsSignal` was doing but this class was not
- `EpicsSignalWithRBV` to the base cases so that fake area detector classes are built correctly
- relevant tests for the above