### PR TITLE
MAINT: Signal should describe itself

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -213,9 +213,10 @@ class Signal(OphydObject):
 
     def describe(self):
         """Return the description as a dictionary"""
+        val = self.value
         return {self.name: {'source': 'SIM:{}'.format(self.name),
-                            'dtype': 'number',
-                            'shape': []}}
+                            'dtype': data_type(val),
+                            'shape': data_shape(val)}}
 
     def read_configuration(self):
         "Subclasses may customize this."

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -52,7 +52,7 @@ class Signal(OphydObject):
     SUB_VALUE = 'value'
     _default_sub = SUB_VALUE
 
-    def __init__(self, *, name, value=None, timestamp=None, parent=None,
+    def __init__(self, *, name, value=0., timestamp=None, parent=None,
                  labels=None,
                  kind=Kind.hinted, tolerance=None, rtolerance=None, cl=None):
         super().__init__(name=name, parent=parent, kind=kind, labels=labels)


### PR DESCRIPTION
## Description
Currently `ophyd` assumes you have a single floating point number as the value. This is not necessarily the case as `Signal` will be whatever you tell it.

This code simply mirrors the `data_type` and `data_shape` methods used in `EpicsSignal`.

### The Catch
`Signal` initializes itself as `None`. `None` is not a valid `data_type` therefore:

```python
signal = ophyd.Signal('signal')
signal.describe()
```
Raises an error. This same situation is true if the user puts any unacceptable data type into the signal.

## Motivation
Downstream clients like Typhon expect that `Signal` has an accurate description of itself. Currently if a user places a string in a `Signal` it tells us it is a number which then breaks when we convert it for display.

Closes #574 