### PR TITLE
Adding a method to ADBase that generates a plot of the asyn diGraph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
   - export EPICS_BASE=/usr/lib/epics
   - export PE_DOCKERIMAGE="klauer/simioc-docker"
   - export PE_DOCKERTAG="pyepics-docker"
+  - export MPLBACKEND=agg
   - mkdir /tmp/data
   - perl --version
   - git fetch --unshallow

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -270,7 +270,7 @@ class ADBase(Device):
             plt.tick_params(axis='y', which='both', left=False, right=False,
                             labelbottom=False)
 
-        nx.draw_networkx(G, ax, *args, **kwargs)
+        nx.draw_networkx(G, ax=ax, *args, **kwargs)
 
     def validate_asyn_ports(self):
         '''Validate that all components of pipeline are known

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -4,6 +4,7 @@ import re
 import sys
 from collections import OrderedDict
 import networkx as nx
+import matplotlib.pyplot as plt
 
 from ..signal import EpicsSignal
 from . import docs
@@ -239,6 +240,30 @@ class ADBase(Device):
                 G.add_edge(in_port, out_port)
 
         return G, port_map
+
+    def visualize_asyn_digraph(self, *args, **kwargs):
+        '''This generates a figure showing the current asyn port layout.
+
+        This method generates a plot showing all of the currently enabled
+        Areadetector plugin asyn ports and their relationships. The current
+        ports and relationships are found using self.get_asyn_digraph.
+
+        Parameters
+        ----------
+        *args, **kwargs : networkx.draw_networkx args and kwargs.
+            For the allowed args and kwargs see the `networkx.draw_networkx documentation <https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`
+        '''
+        # Generate the port_map Digraph.
+        G, port_map = self.get_asyn_digraph(self)
+        # Create and label the figure.
+        plt.figure('AD port map for {}'.format(self.name))
+        # Add the plot to the figure.
+        nx.draw_networkx(G, *args, **kwargs)
+        # Turn off the axis ticks and axis labels.
+        plt.tick_params(axis='x', which='both', bottom=False, top=False,
+                        labelbottom=False)
+        plt.tick_params(axis='y', which='both', left=False, right=False,
+                        labelbottom=False)
 
     def validate_asyn_ports(self):
         '''Validate that all components of pipeline are known

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -250,9 +250,7 @@ class ADBase(Device):
         Parameters
         ----------
         *args, **kwargs : networkx.draw_networkx args and kwargs.
-            For the allowed args and kwargs see the `networkx.draw_networkx
-documentation
-<https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`_
+            For the allowed args and kwargs see the `networkx.draw_networkx documentation <https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`_
         '''
         # Importing matplotlib.pyplot here as it is not a dependency except for
         # this method.

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -4,7 +4,6 @@ import re
 import sys
 from collections import OrderedDict
 import networkx as nx
-import matplotlib.pyplot as plt
 
 from ..signal import EpicsSignal
 from . import docs
@@ -253,6 +252,10 @@ class ADBase(Device):
         *args, **kwargs : networkx.draw_networkx args and kwargs.
             For the allowed args and kwargs see the `networkx.draw_networkx documentation <https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`
         '''
+        # Importing matplotlib.pyplot here as it is not a dependency except for
+        # this method.
+        import matplotlib.pyplot as plt
+
         # Generate the port_map Digraph.
         G, port_map = self.get_asyn_digraph(self)
         # Create and label the figure.

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -240,7 +240,7 @@ class ADBase(Device):
 
         return G, port_map
 
-    def visualize_asyn_digraph(self, *args, **kwargs):
+    def visualize_asyn_digraph(self, ax=None, *args, **kwargs):
         '''This generates a figure showing the current asyn port layout.
 
         This method generates a plot showing all of the currently enabled
@@ -249,6 +249,9 @@ class ADBase(Device):
 
         Parameters
         ----------
+        ax: matplotlib axes
+            if None (default) then a new figure is created otherwise it is
+            plotted on the specified axes.
         *args, **kwargs : networkx.draw_networkx args and kwargs.
             For the allowed args and kwargs see the `networkx.draw_networkx documentation <https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`_
         '''
@@ -258,15 +261,16 @@ class ADBase(Device):
 
         # Generate the port_map Digraph.
         G, port_map = self.get_asyn_digraph()
-        # Create and label the figure.
-        plt.figure('AD port map for {}'.format(self.name))
-        # Add the plot to the figure.
-        nx.draw_networkx(G, *args, **kwargs)
-        # Turn off the axis ticks and axis labels.
-        plt.tick_params(axis='x', which='both', bottom=False, top=False,
-                        labelbottom=False)
-        plt.tick_params(axis='y', which='both', left=False, right=False,
-                        labelbottom=False)
+        # Create and label the figure if no ax is provided.
+        if not ax:
+            fig, ax = plt.sublots()
+            ax.set_title('AD port map for {}'.format(self.name))
+            plt.tick_params(axis='x', which='both', bottom=False, top=False,
+                            labelbottom=False)
+            plt.tick_params(axis='y', which='both', left=False, right=False,
+                            labelbottom=False)
+
+        nx.draw_networkx(G, ax, *args, **kwargs)
 
     def validate_asyn_ports(self):
         '''Validate that all components of pipeline are known

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -263,7 +263,7 @@ class ADBase(Device):
         G, port_map = self.get_asyn_digraph()
         # Create and label the figure if no ax is provided.
         if not ax:
-            fig, ax = plt.sublots()
+            fig, ax = plt.subplots()
             ax.set_title('AD port map for {}'.format(self.name))
             plt.tick_params(axis='x', which='both', bottom=False, top=False,
                             labelbottom=False)

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -257,7 +257,7 @@ class ADBase(Device):
         import matplotlib.pyplot as plt
 
         # Generate the port_map Digraph.
-        G, port_map = self.get_asyn_digraph(self)
+        G, port_map = self.get_asyn_digraph()
         # Create and label the figure.
         plt.figure('AD port map for {}'.format(self.name))
         # Add the plot to the figure.

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -250,7 +250,9 @@ class ADBase(Device):
         Parameters
         ----------
         *args, **kwargs : networkx.draw_networkx args and kwargs.
-            For the allowed args and kwargs see the `networkx.draw_networkx documentation <https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`
+            For the allowed args and kwargs see the `networkx.draw_networkx
+documentation
+<https://networkx.github.io/documentation/networkx-1.10/reference/generated/networkx.drawing.nx_pylab.draw_networkx.html>`_
         '''
         # Importing matplotlib.pyplot here as it is not a dependency except for
         # this method.

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -238,6 +238,13 @@ def test_get_plugin_by_asyn_port():
     assert det.roi1 is det.get_plugin_by_asyn_port(det.roi1.port_name.get())
 
 
+def test_visualize_asyn_digraph_smoke():
+    # setup sim detector
+    det = SimDetector(prefix, name='test')
+    # smoke test
+    det.visualize_asyn_digraph()
+
+
 def test_read_configuration_smoke():
     class MyDetector(SingleTrigger, SimDetector):
         stats1 = Cpt(StatsPlugin, 'Stats1:')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ codecov
 coveralls
 pytest
 pytest-cov
+matplotlib

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 codecov
 coveralls
+matplotlib
 pytest
 pytest-cov
-matplotlib


### PR DESCRIPTION
This PR adds a method to ADBase that generates a plot of the asyn port diGraph using `networkx.draw_networkx` The new method takes in all `*args` and `**kwargs` that are available in  `draw_networkx` and  pases them through. It finds the diGraph using self.get_asyn_diGraph().