### PR TITLE
FIX: Follow up #600

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -11,11 +11,18 @@ from ..device import (Device, Component as Cpt)
 from ..signal import (ArrayAttributeSignal)
 
 
-class V26Mixin(Device):
+class V22Mixin(Device):
+    ...
+
+
+class V26Mixin(V22Mixin):
     adcore_version = Cpt(EpicsSignalRO, 'ADCoreVersion_RBV',
                          string=True, kind='config')
     driver_version = Cpt(EpicsSignalRO, 'DriverVersion_RBV',
                          string=True, kind='config')
+
+class V33Mixin(V26Mixin):
+    ...
 
 
 class EpicsSignalWithRBV(EpicsSignal):

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -11,7 +11,7 @@ from ..device import (Device, Component as Cpt)
 from ..signal import (ArrayAttributeSignal)
 
 
-class V33Mixin(Device):
+class V26Mixin(Device):
     adcore_version = Cpt(EpicsSignalRO, 'ADCoreVersion_RBV',
                          string=True, kind='config')
     driver_version = Cpt(EpicsSignalRO, 'DriverVersion_RBV',

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -11,7 +11,7 @@ from ..device import (Device, Component as Cpt)
 from ..signal import (ArrayAttributeSignal)
 
 
-class v33_mixin(Device):
+class V33Mixin(Device):
     adcore_version = Cpt(EpicsSignalRO, 'ADCoreVersion_RBV',
                          string=True, kind='config')
     driver_version = Cpt(EpicsSignalRO, 'DriverVersion_RBV',

--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -48,6 +48,8 @@ class V33CamMixin(V33Mixin):
         self.stage_sigs['wait_for_plugins'] = 'Yes'
         for c in self.parent.component_names:
             cpt = getattr(self, c)
+            if cpt is self:
+                continue
             if hasattr(cpt, 'ensure_nonblocking'):
                 cpt.ensure_nonblocking()
 

--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -36,7 +36,7 @@ __all__ = ['CamBase',
            ]
 
 
-class V33CamMixin(V33Mixin):
+class CamV33Mixin(V33Mixin):
     wait_for_plugins = C(EpicsSignal, 'WaitForPlugins',
                          string=True, kind='config')
 

--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -46,7 +46,7 @@ class V33CamMixin(V33Mixin):
 
     def ensure_nonblocking(self):
         self.stage_sigs['wait_for_plugins'] = 'Yes'
-        for c in self.component_names:
+        for c in self.parent.component_names:
             cpt = getattr(self, c)
             if hasattr(cpt, 'ensure_nonblocking'):
                 cpt.ensure_nonblocking()

--- a/ophyd/areadetector/cam.py
+++ b/ophyd/areadetector/cam.py
@@ -3,7 +3,7 @@ import logging
 from ..utils import enum
 from .base import (ADBase, ADComponent as C, ad_group,
                    EpicsSignalWithRBV as SignalWithRBV,
-                   v33_mixin)
+                   V33Mixin)
 from ..signal import (EpicsSignalRO, EpicsSignal)
 from ..device import DynamicDeviceComponent as DDC
 
@@ -36,7 +36,7 @@ __all__ = ['CamBase',
            ]
 
 
-class v33_cam_mixin(v33_mixin):
+class V33CamMixin(V33Mixin):
     wait_for_plugins = C(EpicsSignal, 'WaitForPlugins',
                          string=True, kind='config')
 

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -34,7 +34,7 @@ from ..device import (GenerateDatumInterface, BlueskyInterface, Staged,
                       Component as Cpt)
 from ..signal import EpicsSignal
 from ..utils import set_and_wait
-from .base import v33_mixin
+from .base import V33Mixin
 
 logger = logging.getLogger(__name__)
 
@@ -103,11 +103,6 @@ def resource_factory(spec, root, resource_path, resource_kwargs,
         return datum
 
     return resource_doc, datum_factory
-
-
-class v33_file_mixin(v33_mixin):
-    create_directories = Cpt(EpicsSignal,
-                             'CreateDirectory', kind='config')
 
 
 class FileStoreBase(BlueskyInterface, GenerateDatumInterface):

--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -34,7 +34,6 @@ from ..device import (GenerateDatumInterface, BlueskyInterface, Staged,
                       Component as Cpt)
 from ..signal import EpicsSignal
 from ..utils import set_and_wait
-from .base import V33Mixin
 
 logger = logging.getLogger(__name__)
 

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -15,7 +15,8 @@ import numpy as np
 
 from ophyd import Component as Cpt
 from .base import (ADBase, ADComponent as C, ad_group,
-                   EpicsSignalWithRBV as SignalWithRBV)
+                   EpicsSignalWithRBV as SignalWithRBV,
+                   V22Mixin)
 from ..signal import (EpicsSignalRO, EpicsSignal, ArrayAttributeSignal)
 from ..device import DynamicDeviceComponent as DDC, GenerateDatumInterface
 from ..utils import enum, set_and_wait
@@ -781,9 +782,10 @@ class FilePlugin(PluginBase, GenerateDatumInterface):
     write_status = C(EpicsSignal, 'WriteStatus')
 
 
-class V33FilePluginMixin(V33Mixin):
+class FilePluginV22Mixin(V22Mixin):
     create_directories = Cpt(EpicsSignal,
                              'CreateDirectory', kind='config')
+
 
 
 class NetCDFPlugin(FilePlugin):

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -781,6 +781,11 @@ class FilePlugin(PluginBase, GenerateDatumInterface):
     write_status = C(EpicsSignal, 'WriteStatus')
 
 
+class V33FilePluginMixin(V33Mixin):
+    create_directories = Cpt(EpicsSignal,
+                             'CreateDirectory', kind='config')
+
+
 class NetCDFPlugin(FilePlugin):
     _default_suffix = 'netCDF1:'
     _suffix_re = 'netCDF\d:'

--- a/ophyd/areadetector/trigger_mixins.py
+++ b/ophyd/areadetector/trigger_mixins.py
@@ -144,7 +144,7 @@ class SingleTrigger(TriggerBase):
             self._status._finished()
 
 
-class SingleTrigger33(TriggerBase):
+class SingleTriggerV33(TriggerBase):
     _status_type = ADTriggerStatus
 
     def __init__(self, *args, image_name=None, **kwargs):


### PR DESCRIPTION
https://github.com/NSLS-II/ophyd/pull/600 went in before I got a chance to look
at it. I think I found some bugs, along with some requisite name-standardizing.

One thing I didn't go in and change but might be worth quickly considering:

We have classes named ``SingleTrigger33`` and ``V33CamMixin``. Any thoughts on
the best consistent convention for naming version-specific mixin classes? Also
--- as of df20cad in this PR --- we also have some ``V26`` mixins.
Should ``V33`` classes inherit from those? The upcoming ophyd release sets a
precedent in the ophyd API for how AD versions will be handled and deserves
some attention.