### PR TITLE
FIX: always treat motor positions as floats

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -225,7 +225,7 @@ class ReadbackSignal(SignalRO):
 
 class SetpointSignal(Signal):
     def put(self, value, *, timestamp=None, force=False):
-        self.parent.set(value)
+        self.parent.set(float(value))
 
     def get(self):
         return self.parent.sim_state['setpoint']


### PR DESCRIPTION
This ensures that if they are set with an integer they cast that to
float so that `describe` always returns the same datatype.