### PR TITLE
ENH: fixes to Signal from working at TES

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -190,8 +190,8 @@ class Signal(OphydObject):
                                value)
                 success = False
             except Exception as ex:
-                self.log.debug('set_and_wait(%r, %s) failed', self.name, value,
-                               exc_info=ex)
+                self.log.exception('set_and_wait(%r, %s) failed',
+                                   self.name, value)
                 success = False
             else:
                 self.log.debug('set_and_wait(%r, %s) succeeded => %s',

--- a/ophyd/tests/test_utils.py
+++ b/ophyd/tests/test_utils.py
@@ -5,7 +5,8 @@ import numpy as np
 import tempfile
 
 from ophyd.utils import epics_pvs as epics_utils
-from ophyd.utils import (make_dir_tree, makedirs)
+from ophyd.utils import (make_dir_tree, makedirs, set_and_wait)
+from ophyd import Signal
 
 
 logger = logging.getLogger(__name__)
@@ -52,31 +53,30 @@ def test_records_from_db():
     assert ('bo', '$(P)$(S)_calcEnable') in records
 
 
-def test_data_type():
+@pytest.mark.parametrize('value, dtype, shape', [
+    [1, 'integer', []],
+    [1.0, 'number', []],
+    [1e-3, 'number', []],
+    ['foo', 'string', []],
+    [np.array([1, 2, 3]), 'array', [3]],
+    [np.array([[1, 2], [3, 4]]), 'array', [2, 2]],
+    [(1, 2, 3), 'array', [3]],
+    [[1, 2, 3], 'array', [3]],
+    [[], 'array', [0]]
+]
+)
+def test_data_type_and_shape(value, dtype, shape):
     utils = epics_utils
-
-    assert utils.data_type(1) == 'integer'
-    assert utils.data_type(2) != 'number'
-    assert utils.data_type(1e-3) == 'number'
-    assert utils.data_type(2.718) == 'number'
-    assert utils.data_type('foo') == 'string'
-    assert utils.data_type(np.array([1, 2, 3])) == 'array'
-    with pytest.raises(ValueError):
-        utils.data_type([1, 2, 3])
-    with pytest.raises(ValueError):
-        utils.data_type(dict())
+    assert utils.data_type(value) == dtype
+    assert utils.data_shape(value) == shape
 
 
-def test_data_shape():
+@pytest.mark.parametrize('value',
+                         [dict()])
+def test_invalid_data_type(value):
     utils = epics_utils
-
-    assert utils.data_shape(1) == list()
-    assert utils.data_shape('foo') == list()
-    assert utils.data_shape(np.array([1, 2, 3])) == [3, ]
-    assert utils.data_shape(np.array([[1, 2], [3, 4]])) == [2, 2]
-
     with pytest.raises(ValueError):
-        utils.data_shape([])
+        utils.data_type(value)
 
 
 def assert_OD_equal_ignore_ts(a, b):
@@ -110,3 +110,10 @@ def test_make_dir_tree():
 def test_valid_pvname():
     with pytest.raises(epics_utils.BadPVName):
         epics_utils.validate_pv_name('this.will.fail')
+
+
+def test_array_into_softsignal():
+    data = np.array([1, 2, 3])
+    s = Signal(name='np.array')
+    set_and_wait(s, data)
+    assert np.all(s.get() == data)

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -290,7 +290,7 @@ def _compare_maybe_enum(a, b, enums, atol, rtol):
 
 
 _type_map = {'number': (float, np.floating),
-             'array': (np.ndarray, ),
+             'array': (np.ndarray, list, tuple),
              'string': (str, ),
              'integer': (int, np.integer),
              }
@@ -308,7 +308,9 @@ def data_type(val):
         if isinstance(val, py_types):
             return json_type
     # no legit type found...
-    raise ValueError('{} not a valid type (int, float, ndarray, str)'.format(val))
+    raise ValueError(
+        '{!r} '.format(val) +
+        'not a valid type (int, float, ndarray, str, list, tuple)')
 
 
 def data_shape(val):
@@ -323,7 +325,10 @@ def data_shape(val):
     for json_type, py_types in _type_map.items():
         if isinstance(val, py_types):
             if json_type is 'array':
-                return list(val.shape)
+                try:
+                    return list(val.shape)
+                except AttributeError:
+                    return [len(val)]
             else:
                 return list()
     raise ValueError('Cannot determine shape of {}'.format(val))

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -322,16 +322,14 @@ def data_shape(val):
         Empty list if val is number or string, otherwise
         ``list(np.ndarray.shape)``
     '''
-    for json_type, py_types in _type_map.items():
-        if isinstance(val, py_types):
-            if json_type is 'array':
-                try:
-                    return list(val.shape)
-                except AttributeError:
-                    return [len(val)]
-            else:
-                return list()
-    raise ValueError('Cannot determine shape of {}'.format(val))
+    dtype = data_type(val)
+    if dtype != 'array':
+        return []
+
+    try:
+        return list(val.shape)
+    except AttributeError:
+        return [len(val)]
 
 
 # Vendored from pyepics v3.3.0

--- a/ophyd/utils/epics_pvs.py
+++ b/ophyd/utils/epics_pvs.py
@@ -282,7 +282,11 @@ def _compare_maybe_enum(a, b, enums, atol, rtol):
                            rtol=rtol if rtol is not None else 1e-5,
                            atol=atol if atol is not None else 1e-8,
                            )
-    return a == b
+    ret = a == b
+    try:
+        return bool(ret)
+    except ValueError:
+        return np.all(ret)
 
 
 _type_map = {'number': (float, np.floating),


### PR DESCRIPTION
- the check in set_and_wait used to fail with
   value error for arrays and the exception was going
   to the debug log
 - at TES we used list(...) to get around this
 - Teddy updated Signal to correctly report it's type,
   but the type sniffer did not correctly handle lists