### PR TITLE
MAINT: AttributeSignal should run subscriptions

### DIFF
--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1007,7 +1007,10 @@ class AttributeSignal(Signal):
         return getattr(self.base, self.attr)
 
     def put(self, value, **kwargs):
-        return setattr(self.base, self.attr, value)
+        old_value = self.get()
+        setattr(self.base, self.attr, value)
+        self._run_subs(sub_type=self.SUB_VALUE, old_value=old_value,
+                       value=value, timestamp=time.time())
 
     def describe(self):
         value = self.value

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+from unittest.mock import Mock
 
 import numpy as np
 
@@ -262,9 +263,11 @@ def test_attribute_signal():
     assert (dev.describe()['mydev_attrsig']['source'] == 'PY:mydev.prop')
     assert (dev.describe()['mydev_sub_attrsig']['source'] == 'PY:mydev.sub1.prop')
     assert dev.attrsig.get() == init_value
+    cb = Mock()
+    dev.attrsig.subscribe(cb)
     dev.attrsig.put(55)
     assert dev.attrsig.get() == 55
-
+    assert cb.called
     assert dev.sub_attrsig.get() == init_value
     dev.sub_attrsig.put(0)
 


### PR DESCRIPTION
## Description
Noticed this while making a `typhon` widget for an `AttributeSignal`. When you call `.put` on your `AttributeSignal`it never runs it's subscriptions. I realize we won't get updated when the underlying attribute gets swapped out but it is nice to get updated when somebody writes using the `AttributeSignal` interface.

## Question
Was also curious how people felt about the ability to add a little metadata to these signals. (I'd do this in a separate PR, but since you have read this far). The idea is that we might want to add a little extra data to `.describe` but not subclass.

```python
class MyDevice(Device):
        calculated_width = Cpt(AttributeSignal, attr='width_calc', desc={'units': 'mm'})
```