### PR TITLE
ENH: add instantiate_fake_device, clear_fake_device

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -916,7 +916,7 @@ def make_fake_device(cls):
 
 
 def clear_fake_device(dev, *, default_value=0, default_string_value='',
-                      ignore_exceptions=True):
+                      ignore_exceptions=False):
     '''Clear a fake device by setting all signals to a specific value
 
     Parameters

--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -991,7 +991,7 @@ def instantiate_fake_device(dev_cls, *, name=None, prefix='_prefix',
         default = param.default
         if default == param.empty:
             # NOTE: could check param.annotation here
-            default = f'_{param.name}_'
+            default = '_{}_'.format(param.name)
         return specified_kw.get(name, default)
 
     kwargs = {name: get_kwarg(name, param)


### PR DESCRIPTION
Adds a couple convenience functions for more easily working with fake devices.

`instantiate_fake_device`: creates a fake device class and instantiates it for you, making its best guess at keyword arguments

`clear_fake_device`: resets all components of a device (and its sub-devices) to specific values. This works around the default of `None` for all signals that causes problems with `.describe()`.