### PR TITLE
FIX/TST: Device.put for non-DeviceTuple values

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -1167,7 +1167,7 @@ class Device(BlueskyInterface, OphydObject, metaclass=ComponentMeta):
         '''
         if not isinstance(dev_t, self._device_tuple):
             try:
-                dev_t = self._device_tuple(dev_t)
+                dev_t = self._device_tuple(*dev_t)
             except TypeError as ex:
                 raise ValueError('{}\n\tDevice tuple fields: {}'
                                  ''.format(ex, self._device_tuple._fields))

--- a/ophyd/tests/test_device.py
+++ b/ophyd/tests/test_device.py
@@ -330,9 +330,27 @@ def test_summary():
     d.__str__()
     d.__repr__()
 
+
 def test_labels():
     class MyDevice(Device):
         cpt = Component(FakeSignal, 'suffix')
 
     d = MyDevice('', name='test', labels={'a', 'b'})
     assert d._ophyd_labels_ == {'a', 'b'}
+
+
+def test_device_put():
+    class MyDevice(Device):
+        a = Component(Signal)
+        b = Component(Signal)
+
+    d = MyDevice('', name='test')
+    d.put((1, 2))
+    assert d.get() == (1, 2)
+
+    devtuple = d.get_device_tuple()
+    d.put(devtuple(a=10, b=12))
+    assert d.get() == (10, 12)
+
+    with pytest.raises(ValueError):
+        d.put((1, 2, 3))


### PR DESCRIPTION
Fix the (much-maligned) `.put` functionality of `ophyd.Device` in cases where the user did not use the Device-specific `DeviceTuple`.

I'm a bit surprised this never popped up before, but it was broken for all inputs where there was more than one signal. Incidentally, that also happens to be where it is useful - on a device composed of multiple components.