### PR TITLE
FIX: Comparing list to tuple for invalid array_size

### DIFF
--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -245,7 +245,7 @@ class ImagePlugin(PluginBase):
     @property
     def image(self):
         array_size = self.array_size.get()
-        if array_size == [0, 0, 0]:
+        if array_size == (0, 0, 0):
             raise RuntimeError('Invalid image; ensure array_callbacks are on')
 
         if array_size[-1] == 0:


### PR DESCRIPTION
`get` will return a tuple. Comparing this to a list will never return `True`.