### PR TITLE
FIX: Allow for nested plugins in AreaDetector

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -310,7 +310,7 @@ class ADBase(Device):
             if name == port_name:
                 return self
 
-        for name, subdevice in self.walk_subdevices():
+        for name, subdevice in self.walk_subdevices(include_lazy=True):
             if hasattr(subdevice, 'get_plugin_by_asyn_port'):
                 sig = subdevice.get_plugin_by_asyn_port(port_name)
                 if sig is not None:
@@ -332,7 +332,7 @@ class ADBase(Device):
         except AttributeError:
             pass
 
-        for name, subdevice in self.walk_subdevices():
+        for name, subdevice in self.walk_subdevices(include_lazy=True):
             if hasattr(subdevice, 'get_asyn_port_dictionary'):
                 ret.update(subdevice.get_asyn_port_dictionary())
 

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -310,10 +310,9 @@ class ADBase(Device):
             if name == port_name:
                 return self
 
-        for nm in self._sub_devices:
-            cpt = getattr(self, nm)
-            if hasattr(cpt, 'get_plugin_by_asyn_port'):
-                sig = cpt.get_plugin_by_asyn_port(port_name)
+        for name, subdevice in self.walk_subdevices():
+            if hasattr(subdevice, 'get_plugin_by_asyn_port'):
+                sig = subdevice.get_plugin_by_asyn_port(port_name)
                 if sig is not None:
                     return sig
         return None
@@ -333,10 +332,9 @@ class ADBase(Device):
         except AttributeError:
             pass
 
-        for nm in self._sub_devices:
-            sig = getattr(self, nm)
-            if hasattr(sig, 'get_asyn_port_dictionary'):
-                ret.update(sig.get_asyn_port_dictionary())
+        for name, subdevice in self.walk_subdevices():
+            if hasattr(subdevice, 'get_asyn_port_dictionary'):
+                ret.update(subdevice.get_asyn_port_dictionary())
 
         return ret
 

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -269,7 +269,7 @@ def test_get_plugin_by_asyn_port(ad_prefix, cleanup):
         roi1 = Cpt(ROIPlugin, 'ROI1:')
         stats1 = Cpt(StatsPlugin, 'Stats1:')
 
-    nested_det = MyDetector(prefix, name='nested_test')
+    nested_det = MyDetector(ad_prefix, name='nested_test')
 
     nested_det.stats1.nd_array_port.put(nested_det.roi1.port_name.get())
     nested_det.plugins.tiff1.nd_array_port.put(nested_det.cam.port_name.get())


### PR DESCRIPTION
* Add a utility `devices_in_parent` to search through entire device lineage
* Make sure any references to `_sub_devices` are replaced with the `devices_in_parent`

Closes #635 