### PR TITLE
API: remove pv_kw from EpicsSignal classes

### DIFF
--- a/ophyd/sim.py
+++ b/ophyd/sim.py
@@ -1031,9 +1031,9 @@ class FakeEpicsSignal(SynSignal):
     We can emulate EpicsSignal features here. We currently emulate the put
     limits and some enum handling.
     """
-    def __init__(self, read_pv, write_pv=None, *, pv_kw=None,
-                 put_complete=False, string=False, limits=False,
-                 auto_monitor=False, name=None, **kwargs):
+    def __init__(self, read_pv, write_pv=None, *, put_complete=False,
+                 string=False, limits=False, auto_monitor=False, name=None,
+                 **kwargs):
         """
         Mimic EpicsSignal signature
         """


### PR DESCRIPTION
Closes #643 

In the issue, @ZLLentz brought up the following:
>  I agree with the intent of this issue, but we should also see if any of the features here could have use cases that we want to make explicit arguments.

The keywords in pyepics `epics.PV` are as follows:
```python
    def __init__(self, pvname, callback=None, form='time',
                 verbose=False, auto_monitor=None, count= None,
                 connection_callback=None,
                 connection_timeout=None, access_callback=None):
```
I believe we are good as-is. Thoughts?