### PR TITLE
ENH: support versioning of ophyd objects

### DIFF
--- a/ophyd/device.py
+++ b/ophyd/device.py
@@ -820,7 +820,7 @@ class Device(BlueskyInterface, OphydObject):
     def __init_subclass__(cls, **kwargs):
         'This is called automatically in Python for all subclasses of Device'
         super().__init_subclass__(**kwargs)
-        cls._initialize_device(**kwargs)
+        cls._initialize_device()
 
     @classmethod
     def walk_components(cls):

--- a/ophyd/tests/test_versioning.py
+++ b/ophyd/tests/test_versioning.py
@@ -1,0 +1,36 @@
+import logging
+from unittest.mock import Mock
+
+from ophyd import (Device, Component, Signal)
+
+
+logger = logging.getLogger(__name__)
+
+
+def test_specify_version():
+    # Define a versioned Device:
+    class MyDevice(Device, version=1):
+        ...
+
+    info = MyDevice._class_info_
+    assert info['version'] == 1
+    assert info['versions'] == {1: MyDevice}
+
+    # Define a new version of that Device:
+    class MyDevice_V2(MyDevice, version=2, version_of=MyDevice):
+        ...
+
+    info = MyDevice_V2._class_info_
+    assert info['version'] == 2
+    assert info['versions'] == {1: MyDevice, 2: MyDevice_V2}
+
+    # Ensure that the original Device has also been updated:
+    assert MyDevice._class_info_['versions'] == {1: MyDevice, 2: MyDevice_V2}
+
+    # Define a user device that inherits - but does not define a new version
+    class UserDevice(MyDevice_V2):
+        ...
+
+    assert UserDevice._class_info_ == {'versions': {1: MyDevice, 2: MyDevice_V2},
+                                       'version': 2
+                                       }


### PR DESCRIPTION
This is an important feature for the upcoming AreaDetector plugin PR, which I'll open after this one goes in. Let's hash over the details of this and get it to a good state before that.

This adds two keyword-only arguments to subclasses of ophyd objects, primarily intended for use with Devices:
* `version`: the version itself - no type restrictions
* `version_of`: the class in the hierarchy that `version` is in reference to

The information on the object then allows for programmatic access of different versions of the class.

The test case below shows the intent well enough, I think:

```python
    class MyDevice(Device, version=1):
        ...
     info = MyDevice._class_info_
    assert info['version'] == 1
    assert info['versions'] == {1: MyDevice}
     # Define a new version of that Device:
    class MyDevice_V2(MyDevice, version=2, version_of=MyDevice):
        ...
     info = MyDevice_V2._class_info_
    assert info['version'] == 2
    assert info['versions'] == {1: MyDevice, 2: MyDevice_V2}
     # Ensure that the original Device has also been updated:
    assert MyDevice._class_info_['versions'] == {1: MyDevice, 2: MyDevice_V2}
     # Define a user device that inherits - but does not define a new version
    class UserDevice(MyDevice_V2):
        ...
     assert UserDevice._class_info_ == {'versions': {1: MyDevice, 2: MyDevice_V2},
                                       'version': 2
                                       }
```