### PR TITLE
ENH: NDDerivedSignal

### DIFF
--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -24,11 +24,39 @@ class NDDerivedSignal(DerivedSignal):
     """
     DerivedSignal to shape a flattened array
 
-    The purpose of this class is to take a flattened array and shape in its'
+    The purpose of this class is to take a flattened array and shape in its
     proper form. The shape of the final array may be static in which case the
     shape and number of dimensions can be set as static integers. Otherwise,
-    other signals from this classes parent can inform what the proper shape of
-    the array
+     other signals from this classes parent can inform the proper shape of
+    the array.
+
+    Parameters
+    ----------
+    derived_from : str, ``ophyd.Signal``
+        Either a `str` that specifies the attribute of the parent we will get
+        the unshaped array or an ``ophyd.Signal`` itself.
+
+    shape: tuple
+        A tuple containing integers in the case of a static array or links to
+        ``Signal`` objects. The specifications of the signals follows the same
+        rules as the ``derived_from`` parameter
+
+    num_dimensions: int, str, ``Signal``
+        The number of dimensions of the array. This can either be a static
+        ``int`` or a ``Signal`` itself.
+
+    Example
+    -------
+    .. code:: python
+
+        class TwoDimensionalDetector(Device):
+
+            flat_array = Cpt(EpicsSignal, ':Array')
+            width = Cpt(EpicsSignalRO, ':Width')
+            height = Cpt(EpicsSignalRO, ':Height')
+            shaped_array = Cpt(NDDerivedSignal('flat_array',
+                                               shape=('height', 'width'),
+                                               num_dimensions=2)
     """
     def __init__(self, derived_from, shape, num_dimensions,
                  parent=None, **kwargs):

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -41,7 +41,7 @@ class NDDerivedSignal(DerivedSignal):
         ``Signal`` objects. The specifications of the signals follows the same
         rules as the ``derived_from`` parameter
 
-    num_dimensions: int, str, ``Signal``
+    num_dimensions: int, str, ``Signal``, optional
         The number of dimensions of the array. This can either be a static
         ``int`` or a ``Signal`` itself.
 
@@ -58,7 +58,7 @@ class NDDerivedSignal(DerivedSignal):
                                                shape=('height', 'width'),
                                                num_dimensions=2)
     """
-    def __init__(self, derived_from, shape, num_dimensions,
+    def __init__(self, derived_from, shape, num_dimensions=None,
                  parent=None, **kwargs):
         super().__init__(derived_from, parent=parent, **kwargs)
         # Assemble our shape of signals
@@ -69,6 +69,8 @@ class NDDerivedSignal(DerivedSignal):
             self._shape.append(dim)
         self._shape = tuple(self._shape)
         # Assemble ndims
+        if not num_dimensions:
+            num_dimensions = len(self._shape)
         if isinstance(num_dimensions, str):
             num_dimensions = getattr(parent, num_dimensions)
         self._num_dimensions = num_dimensions

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -47,7 +47,7 @@ class NDDerivedSignal(DerivedSignal):
 
         # Ensure callbacks are fired when array is reshaped
         for dim in self._shape + (self._num_dimensions, ):
-            if not isinstance(dim, (int, float)):
+            if not isinstance(dim, int):
                 dim.subscribe(self._array_shape_callback,
                               event_type=self.SUB_VALUE,
                               run=False)

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -109,7 +109,7 @@ class NDDerivedSignal(DerivedSignal):
         return np.array(array).reshape(array_shape)
 
     def subscribe(self, callback, event_type=None, run=True):
-        super().subscribe(callback, event_type=event_type, run=run)
+        cid = super().subscribe(callback, event_type=event_type, run=run)
         if not self._has_subscribed and (event_type is None
                                          or event_type == self.SUB_VALUE):
             # Ensure callbacks are fired when array is reshaped
@@ -119,6 +119,8 @@ class NDDerivedSignal(DerivedSignal):
                                   event_type=self.SUB_VALUE,
                                   run=False)
         self._has_subscribed = True
+        return cid
+
 
     def _array_shape_callback(self, **kwargs):
         value = self.inverse(self._derived_from.value)

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -58,9 +58,9 @@ class NDDerivedSignal(DerivedSignal):
                                                shape=('height', 'width'),
                                                num_dimensions=2)
     """
-    def __init__(self, derived_from, shape, num_dimensions=None,
+    def __init__(self, derived_from, *, shape, num_dimensions=None,
                  parent=None, **kwargs):
-        super().__init__(derived_from, parent=parent, **kwargs)
+        super().__init__(derived_from=derived_from, parent=parent, **kwargs)
         # Assemble our shape of signals
         self._shape = []
         for dim in shape:
@@ -122,8 +122,8 @@ class NDDerivedSignal(DerivedSignal):
 
 
 class ADComponent(Component):
-    def __init__(self, cls, suffix, lazy=True, **kwargs):
-        super().__init__(cls, suffix, lazy=lazy, **kwargs)
+    def __init__(self, cls, suffix=None, *, lazy=True, **kwargs):
+        super().__init__(cls, suffix=suffix, lazy=lazy, **kwargs)
 
     def find_docs(self, parent_class):
         '''Find all the documentation related to this class, all the way up the
@@ -160,6 +160,9 @@ class ADComponent(Component):
                                          prefix=' ' * 4))
             block.append('')
             return '\n'.join(block)
+
+        if self.suffix is None:
+            return
 
         suffixes = [self.suffix]
 

--- a/ophyd/areadetector/base.py
+++ b/ophyd/areadetector/base.py
@@ -75,13 +75,6 @@ class NDDerivedSignal(DerivedSignal):
             num_dimensions = getattr(parent, num_dimensions)
         self._num_dimensions = num_dimensions
 
-        # Ensure callbacks are fired when array is reshaped
-        for dim in self._shape + (self._num_dimensions, ):
-            if not isinstance(dim, int):
-                dim.subscribe(self._array_shape_callback,
-                              event_type=self.SUB_VALUE,
-                              run=False)
-
     @property
     def derived_shape(self):
         """Shape of output signal"""
@@ -113,6 +106,16 @@ class NDDerivedSignal(DerivedSignal):
 
         array = self._derived_from.get()
         return np.array(array).reshape(array_shape)
+
+    def subscribe(self, callback, event_type=None, run=True):
+        super().subscribe(callback, event_type=event_type, run=run)
+        if event_type is None or event_type == self.SUB_VALUE:
+            # Ensure callbacks are fired when array is reshaped
+            for dim in self._shape + (self._num_dimensions, ):
+                if not isinstance(dim, int):
+                    dim.subscribe(self._array_shape_callback,
+                                  event_type=self.SUB_VALUE,
+                                  run=False)
 
     def _array_shape_callback(self, **kwargs):
         value = self.inverse(self._derived_from.value)

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -283,6 +283,12 @@ class ImagePlugin(PluginBase):
     _plugin_type = 'NDPluginStdArrays'
 
     array_data = C(EpicsSignal, 'ArrayData')
+    shaped_image = C(NDDerivedSignal, 'array_data',
+                     shape=('array_size.height',
+                            'array_size.width',
+                            'array_size.depth')
+                     ndims='ndimensions',
+                     kind='omitted')
 
     @property
     def image(self):

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -287,7 +287,7 @@ class ImagePlugin(PluginBase):
                      shape=('array_size.height',
                             'array_size.width',
                             'array_size.depth'),
-                     ndims='ndimensions',
+                     num_dimensions='ndimensions',
                      kind='omitted')
 
     @property

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 
 from .. import Component as Cpt
 from .base import (ADBase, ADComponent as C, ad_group,
-                   EpicsSignalWithRBV as SignalWithRBV)
+                   EpicsSignalWithRBV as SignalWithRBV, NDDerivedSignal)
 from ..signal import (EpicsSignalRO, EpicsSignal, ArrayAttributeSignal)
 from ..device import DynamicDeviceComponent as DDC, GenerateDatumInterface
 from ..utils import enum, set_and_wait
@@ -286,7 +286,7 @@ class ImagePlugin(PluginBase):
     shaped_image = C(NDDerivedSignal, 'array_data',
                      shape=('array_size.height',
                             'array_size.width',
-                            'array_size.depth')
+                            'array_size.depth'),
                      ndims='ndimensions',
                      kind='omitted')
 

--- a/ophyd/areadetector/plugins.py
+++ b/ophyd/areadetector/plugins.py
@@ -283,7 +283,7 @@ class ImagePlugin(PluginBase):
     _plugin_type = 'NDPluginStdArrays'
 
     array_data = C(EpicsSignal, 'ArrayData')
-    shaped_image = C(NDDerivedSignal, 'array_data',
+    shaped_image = C(NDDerivedSignal, derived_from='array_data',
                      shape=('array_size.height',
                             'array_size.width',
                             'array_size.depth'),

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -529,7 +529,10 @@ class DerivedSignal(Signal):
     def _repr_info(self):
         'Yields pairs of (key, value) to generate the Signal repr'
         yield from super()._repr_info()
-        yield ('derived_from', self._derived_from.dotted_name)
+        if self.parent is not None:
+            yield ('derived_from', self._derived_from.dotted_name)
+        else:
+            yield ('derived_from', self._derived_from)
 
 
 class EpicsSignalBase(Signal):

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1,5 +1,4 @@
 # vi: ts=4 sw=4
-from collections import ChainMap
 import logging
 import time
 import threading
@@ -458,7 +457,8 @@ class DerivedSignal(Signal):
         desc['derived_from'] = self._derived_from.name
         # Description of the derived signal 
         derived_desc = self._derived_from.describe()[self._derived_from.name]
-        return {self.name: dict(ChainMap(desc, derived_desc))}
+        derived_desc.update(desc)
+        return {self.name: derived_desc}
 
     def _update_metadata_from_callback(self, **kwargs):
         updated_md = {key: kwargs[key] for key in self.metadata_keys

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1,4 +1,5 @@
 # vi: ts=4 sw=4
+from collections import ChainMap
 import logging
 import time
 import threading
@@ -453,9 +454,11 @@ class DerivedSignal(Signal):
 
     def describe(self):
         '''Description based on the original signal description'''
-        desc = self._derived_from.describe()[self._derived_from.name]
+        desc = super().describe()[self.name]  # Description of this signal
         desc['derived_from'] = self._derived_from.name
-        return {self.name: desc}
+        # Description of the derived signal 
+        derived_desc = self._derived_from.describe()[self._derived_from.name]
+        return {self.name: dict(ChainMap(desc, derived_desc))}
 
     def _update_metadata_from_callback(self, **kwargs):
         updated_md = {key: kwargs[key] for key in self.metadata_keys

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -455,7 +455,7 @@ class DerivedSignal(Signal):
         '''Description based on the original signal description'''
         desc = super().describe()[self.name]  # Description of this signal
         desc['derived_from'] = self._derived_from.name
-        # Description of the derived signal 
+        # Description of the derived signal
         derived_desc = self._derived_from.describe()[self._derived_from.name]
         derived_desc.update(desc)
         return {self.name: derived_desc}

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -529,7 +529,7 @@ class DerivedSignal(Signal):
     def _repr_info(self):
         'Yields pairs of (key, value) to generate the Signal repr'
         yield from super()._repr_info()
-        yield ('derived_from', self._derived_from)
+        yield ('derived_from', self._derived_from.dotted_name)
 
 
 class EpicsSignalBase(Signal):

--- a/ophyd/tests/test_areadetector.py
+++ b/ophyd/tests/test_areadetector.py
@@ -3,20 +3,22 @@ import logging
 import os
 import shutil
 import time
+from unittest.mock import Mock
 
+import numpy as np
 import pytest
 from io import StringIO
 from pathlib import PurePath, Path
 
 from ophyd.utils.paths import make_dir_tree
-from ophyd import (SimDetector, SingleTrigger, Component,
+from ophyd import (SimDetector, SingleTrigger, Component, Device,
                    DynamicDeviceComponent, EpicsSignalRO, Kind, wait)
 from ophyd.areadetector.plugins import (ImagePlugin, StatsPlugin,
                                         ColorConvPlugin, ProcessPlugin,
                                         OverlayPlugin, ROIPlugin,
                                         TransformPlugin, NetCDFPlugin,
                                         TIFFPlugin, JPEGPlugin, HDF5Plugin)
-
+from ophyd.areadetector.base import NDDerivedSignal
 from ophyd.areadetector.filestore_mixins import (
     FileStoreTIFF, FileStoreIterativeWrite,
     FileStoreHDF5)
@@ -26,6 +28,7 @@ from ophyd.areadetector.filestore_mixins import (
 from ophyd.areadetector.plugins import PluginBase
 from ophyd.areadetector.util import stub_templates
 from ophyd.device import (Component as Cpt, )
+from ophyd.signal import Signal
 import uuid
 import epics
 
@@ -536,3 +539,37 @@ def test_many_connect(ad_prefix, cleanup):
     for j in range(5):
         print(j)
         tester()
+
+
+def test_ndderivedsignal_with_scalars():
+    sig = Signal(value=np.zeros(12), name='zeros')
+    shaped = NDDerivedSignal(sig, shape=(4, 3), num_dimensions=2, name='shaped')
+    shaped.derived_shape == (4, 3)
+    shaped.derived_ndims == 2
+    assert shaped.get().shape == (4, 3)
+    # Describe returns list
+    assert shaped.describe()[shaped.name]['shape'] == [4, 3]
+    shaped.put(np.ones((4, 3)))
+    assert all(sig.get() == np.ones(12))
+
+
+def test_ndderivedsignal_with_parent():
+
+    class Detector(Device):
+        flat_image = Component(Signal, value=np.ones(12))
+        width = Component(Signal, value=4)
+        height = Component(Signal, value=3)
+        ndims = Component(Signal, value=2)
+        shaped_image = Component(NDDerivedSignal, 'flat_image',
+                                 shape=('width', 'height'),
+                                 num_dimensions='ndims')
+
+
+    det = Detector(name='det')
+    det.shaped_image.get().shape == (4, 3)
+    cb = Mock()
+    det.shaped_image.subscribe(cb)
+    det.width.put(6)
+    det.height.put(2)
+    assert cb.called
+    assert det.shaped_image._readback.shape == (6, 2)


### PR DESCRIPTION
# Description
This introduces `NDDerivedSignal` a subclass of `DerivedSignal` to reshape a flat array into a shaped one based on either static values or other components of the class. This was made with the purpose of the supporting shaped image signals, but I believe it is general enough to apply to any situation where you have a flat array this is intended to be reshaped.

# Motivation
This is useful for a variety of reasons, my major motivation is for `typhon` which can not tell a flat array from an image without checking if we are looking at an `AreaDetector` class explicitly. However, this certainly makes things like a `LiveImage` callback far easier to write. 

Also closes #673, before `DerivedSignal.describe` used most of the original signals description. We now infer the `data_type` and `shape` from the value of our `DerivedSignal` so changing types and shapes will be properly reflected.

# Tests
Tests on both the base `NDDerivedSignal` implementation and on `ImagePlugin` itself.