### PR TITLE
CI: Split CL builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,41 @@ cache:
 matrix:
   include:
     - python: 3.6
-      env: BUILD_DOCS=true
+      env:
+        - BUILD_DOCS=true
+        - TEST_CL=pyepics
+    - python: 3.6
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=caproto
+    - python: 3.6
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=p4p
     - python: 3.7
-      env: BUILD_DOCS=
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=pyepics
+    - python: 3.7
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=caproto
+    - python: 3.7
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=p4p
     - python: nightly
-      env: BUILD_DOCS=
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=pyepics
+    - python: nightly
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=caproto
+    - python: nightly
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=p4p
 
 before_install:
   - export MPLBACKEND=agg
@@ -80,14 +110,15 @@ script:
   - echo "Checking if the areaDetector IOC is running:"
   - caproto-get -v 13SIM1:cam1:Acquire
 
-  # non-caproto-based tests
-  - coverage run --concurrency=thread --parallel-mode run_tests.py -v -k 'not caproto'
-  - coverage combine
-  - coverage report
-  - codecov
-
-  # caproto-based tests (xfail for now)
-  - timeout 5m python run_tests.py -v -k 'caproto' || /bin/true
+  - |
+    if [ "${TEST_CL}" == "caproto" ]; then
+      python run_tests.py -v -k "caproto"
+    else
+      coverage run --concurrency=thread --parallel-mode run_tests.py -v -k "${TEST_CL}"
+      coverage combine
+      coverage report
+      codecov
+    fi
 
   - set -e
   # Build docs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,15 +110,10 @@ script:
   - echo "Checking if the areaDetector IOC is running:"
   - caproto-get -v 13SIM1:cam1:Acquire
 
-  - |
-    if [ "${TEST_CL}" == "caproto" ]; then
-      python run_tests.py -v -k "caproto"
-    else
-      coverage run --concurrency=thread --parallel-mode run_tests.py -v -k "${TEST_CL}"
-      coverage combine
-      coverage report
-      codecov
-    fi
+  - coverage run --concurrency=thread --parallel-mode run_tests.py -v -k "${TEST_CL}"
+  - coverage combine
+  - coverage report
+  - codecov
 
   - set -e
   # Build docs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,31 @@ matrix:
       env:
         - BUILD_DOCS=
         - TEST_CL=p4p
+  allow_failures:
+    - python: 3.6
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=caproto
+    - python: 3.6
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=p4p
+    - python: 3.7
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=caproto
+    - python: 3.7
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=p4p
+    - python: nightly
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=caproto
+    - python: nightly
+      env:
+        - BUILD_DOCS=
+        - TEST_CL=p4p
 
 before_install:
   - export MPLBACKEND=agg


### PR DESCRIPTION
Currently we run tests using `pyepics` and `caproto` in a build matrix of three python versions. This expands the build matrix to be 3 python versions x 3 control layers (`pyepics`, `caproto`, `p4p`). 

`caproto` is set to allowed fail because that's how the travis configuration is currently, and `p4p` is also allowed to fail because it's still a PR and somewhat experimental. Hopefully as these tests stabilize, they can be moved out of allowed failures.

Advantages:
- Easy to quickly differentiate control layer problems vs general ophyd problems
- Obvious to see when changes break specific control layers rather than all of them
- Control layers with long logs (caproto) don't break the 10,000 line travis limit for the other layers
- Easy to expand if we add support for `tango`, etc.

Disadvantages:
- The build matrix is getting big
- Not sure if we can combine coverage from the different control layers

Questions:
- How does codecov respond when 9 builds are associated with the same PR?