### PR TITLE
FIX: use cam.PerkinElmerDetectorCam for PerkinElmerDetector

### DIFF
--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -106,7 +106,7 @@ class Andor3Detector(DetectorBase):
 
 class BrukerDetector(DetectorBase):
     _html_docs = ['BrukerDoc.html']
-    cam = C(cam.Andor3DetectorCam, 'cam1:')
+    cam = C(cam.BrukerDetectorCam, 'cam1:')
 
 
 class FirewireLinDetector(DetectorBase):

--- a/ophyd/areadetector/detectors.py
+++ b/ophyd/areadetector/detectors.py
@@ -136,7 +136,7 @@ class MarCCDDetector(DetectorBase):
 
 class PerkinElmerDetector(DetectorBase):
     _html_docs = ['PerkinElmerDoc.html']
-    cam = C(cam.LightFieldDetectorCam, 'cam1:')
+    cam = C(cam.PerkinElmerDetectorCam, 'cam1:')
 
 
 class PSLDetector(DetectorBase):


### PR DESCRIPTION
It must have been a copy-paste typo that `PerkinElmerDetector` used a cam plugin based on `LightFieldDetectorCam`. This PR fixes this issue.