### PR TITLE
FIX: monitor + get*() issue

### DIFF
--- a/ophyd/__init__.py
+++ b/ophyd/__init__.py
@@ -41,7 +41,7 @@ def set_cl(control_layer=None, *, pv_telemetry=False):
     shim.setup(logger)
 
     exports = ('setup', 'caput', 'caget', 'get_pv', 'thread_class', 'name',
-               'release_pvs')
+               'release_pvs', 'get_dispatcher')
     # this sets the module level value
     cl = types.SimpleNamespace(**{k: getattr(shim, k)
                                   for k in exports})

--- a/ophyd/_caproto_shim.py
+++ b/ophyd/_caproto_shim.py
@@ -14,6 +14,11 @@ _dispatcher = None
 name = 'caproto'
 
 
+def get_dispatcher():
+    'The event dispatcher for the caproto control layer'
+    return _dispatcher
+
+
 class CaprotoCallbackThread(_CallbackThread):
     ...
 

--- a/ophyd/_dispatch.py
+++ b/ophyd/_dispatch.py
@@ -59,11 +59,52 @@ class _CallbackThread(threading.Thread):
         self.context = None
 
 
+class DispatcherThreadContext:
+    '''
+    A thread context associated with a single Dispatcher event type
+
+    Parameters
+    ----------
+    dispatcher : Dispatcher
+    event_type : str
+
+    Attributes
+    ----------
+    dispatcher : Dispatcher
+    event_type : str
+    event_thread : _CallbackThread
+    '''
+
+    def __init__(self, dispatcher, event_type):
+        self.dispatcher = dispatcher
+        self.event_type = event_type
+        self.event_thread = None
+
+    def run(self, func, *args, **kwargs):
+        '''
+        If in the correct threading context, run func(*args, **kwargs) directly,
+        otherwise schedule it to be run in that thread.
+        '''
+        if self.event_thread is None:
+            self.event_thread = self.dispatcher._threads[self.event_type]
+
+        current_thread = threading.currentThread()
+        if current_thread is self.event_thread:
+            print('calling', func, args, kwargs)
+            func(*args, **kwargs)
+        else:
+            print('scheduling', func, args, kwargs)
+            self.event_thread.queue.put((func, args, kwargs))
+
+    __call__ = run
+
+
 class EventDispatcher:
     def __init__(self, *, context, logger, timeout=0.1,
                  thread_class=_CallbackThread, debug_monitor=False,
                  utility_threads=4):
         self._threads = {}
+        self._thread_contexts = {}
         self._thread_class = thread_class
         self._timeout = timeout
 
@@ -135,13 +176,9 @@ class EventDispatcher:
         'Schedule `callback` with the given args and kwargs in a util thread'
         self._utility_queue.put((callback, args, kwargs))
 
-    def run_in_thread(self, event_type, callback, *args, **kwargs):
-        event_thread = self._threads[event_type]
-        current_thread = threading.currentThread()
-        if current_thread is event_thread:
-            callback(*args, **kwargs)
-        else:
-            event_thread.queue.put((callback, args, kwargs))
+    def get_thread_context(self, name):
+        'Get the DispatcherThreadContext for the given thread name'
+        return self._thread_contexts[name]
 
     def _start_thread(self, name, *, callback_queue=None):
         'Start dispatcher thread by name'
@@ -152,6 +189,7 @@ class EventDispatcher:
                                                  logger=self.logger,
                                                  daemon=True,
                                                  callback_queue=callback_queue)
+        self._thread_contexts[name] = DispatcherThreadContext(self, name)
         self._threads[name].start()
 
 

--- a/ophyd/_dispatch.py
+++ b/ophyd/_dispatch.py
@@ -90,10 +90,8 @@ class DispatcherThreadContext:
 
         current_thread = threading.currentThread()
         if current_thread is self.event_thread:
-            print('calling', func, args, kwargs)
             func(*args, **kwargs)
         else:
-            print('scheduling', func, args, kwargs)
             self.event_thread.queue.put((func, args, kwargs))
 
     __call__ = run

--- a/ophyd/_dispatch.py
+++ b/ophyd/_dispatch.py
@@ -135,6 +135,14 @@ class EventDispatcher:
         'Schedule `callback` with the given args and kwargs in a util thread'
         self._utility_queue.put((callback, args, kwargs))
 
+    def run_in_thread(self, event_type, callback, *args, **kwargs):
+        event_thread = self._threads[event_type]
+        current_thread = threading.currentThread()
+        if current_thread is event_thread:
+            callback(*args, **kwargs)
+        else:
+            event_thread.queue.put((callback, args, kwargs))
+
     def _start_thread(self, name, *, callback_queue=None):
         'Start dispatcher thread by name'
         self._threads[name] = self._thread_class(name=name, dispatcher=self,

--- a/ophyd/_dummy_shim.py
+++ b/ophyd/_dummy_shim.py
@@ -1,8 +1,38 @@
 import threading
 
+
+class DummyDispatcherThreadContext:
+    dispatcher = None
+    event_type = None
+    event_thread = None
+
+    def run(self, *args, **kwargs):
+        ...
+
+    __call__ = run
+
+
+class DummyDispatcher:
+    context = None
+    logger = None
+    stop_event = None
+    timeout = 0.1
+    threads = {}
+
+    def stop(self):
+        ...
+
+    def schedule_utility_task(self, callback, *args, **kwargs):
+        ...
+
+    def get_thread_context(self, name):
+        return DummyDispatcherThreadContext()
+
+
 thread_class = threading.Thread
 pv_form = 'time'
 name = 'dummy'
+_dispatcher = DummyDispatcher()
 
 
 def setup(logger):
@@ -26,4 +56,4 @@ def release_pvs(*args, **kwargs):
 
 
 def get_dispatcher():
-    raise NotImplementedError
+    return _dispatcher

--- a/ophyd/_dummy_shim.py
+++ b/ophyd/_dummy_shim.py
@@ -23,3 +23,7 @@ def get_pv(*args, **kwargs):
 
 def release_pvs(*args, **kwargs):
     raise NotImplementedError
+
+
+def get_dispatcher():
+    raise NotImplementedError

--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -139,8 +139,11 @@ def release_pvs(*pvs):
         for pv in pvs:
             pv.clear_callbacks()
             pv.clear_auto_monitor()
+        event.set()
 
-    _dispatcher.run_in_thread('monitor', _release_pvs)
+    event = threading.Event()
+    _dispatcher.get_thread_context('monitor').run(_release_pvs)
+    event.wait()
 
 
 def get_pv(pvname, form='time', connect=False, context=None, timeout=5.0,

--- a/ophyd/_pyepics_shim.py
+++ b/ophyd/_pyepics_shim.py
@@ -21,6 +21,11 @@ name = 'pyepics'
 _dispatcher = None
 
 
+def get_dispatcher():
+    'The event dispatcher for the pyepics control layer'
+    return _dispatcher
+
+
 class PyepicsCallbackThread(_CallbackThread):
     def attach_context(self):
         super().attach_context()
@@ -129,13 +134,13 @@ class PyepicsShimPV(epics.PV):
 
 
 def release_pvs(*pvs):
-    for pv in pvs:
-        pv.clear_callbacks()
-        # Perform the clear auto monitor in one of our _dispatcher threads:
-        # they are guaranteed to be in the right CA context
-        wrapped = wrap_callback(_dispatcher, 'monitor', pv.clear_auto_monitor)
-        # queue the call in the 'monitor' _dispatcher:
-        wrapped()
+    # Run _release_pvs in the 'monitor' thread, assuring that the CA context is correct
+    def _release_pvs():
+        for pv in pvs:
+            pv.clear_callbacks()
+            pv.clear_auto_monitor()
+
+    _dispatcher.run_in_thread('monitor', _release_pvs)
 
 
 def get_pv(pvname, form='time', connect=False, context=None, timeout=5.0,

--- a/ophyd/ophydobj.py
+++ b/ophyd/ophydobj.py
@@ -1,3 +1,4 @@
+import functools
 from itertools import count
 
 import time
@@ -310,6 +311,7 @@ class OphydObject:
 
         # wrapper for callback to snarf exceptions
         def wrap_cb(cb):
+            @functools.wraps(cb)
             def inner(*args, **kwargs):
                 try:
                     cb(*args, **kwargs)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -867,7 +867,7 @@ class EpicsSignalBase(Signal):
         metadata = self._metadata_changed(self.pvname, kwargs, update=False,
                                           require_timestamp=True,
                                           from_monitor=from_monitor)
-        if not from_monitor and self._monitors[self.pvname]:
+        if not from_monitor:
             # Update values internally for consistency, but do not run callbacks
             self._metadata.update(**metadata)
             self._readback = value
@@ -1258,7 +1258,7 @@ class EpicsSignal(EpicsSignalBase):
         self._metadata.update(**metadata)
         self._setpoint = self._fix_type(value)
 
-        if not from_monitor and self._monitors[self.setpoint_pvname]:
+        if not from_monitor:
             # Not from a monitor, and there is an ongoing subscription
             ...
         else:

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -650,7 +650,7 @@ class EpicsSignalBase(Signal):
 
         self._connection_states[pvname] = conn
 
-        if not self._received_first_metadata[pvname]:
+        if conn and not self._received_first_metadata[pvname]:
             pv.get_all_metadata_callback(self._initial_metadata_callback,
                                          timeout=10)
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1294,17 +1294,6 @@ class EpicsSignal(EpicsSignalBase):
         self._write_pv.put(value, use_complete=use_complete, callback=callback,
                            **kwargs)
 
-        old_value = self._setpoint
-        self._setpoint = value
-
-        if self._read_pvname == self.setpoint_pvname:
-            # readback and setpoint PV are one in the same, so update the
-            # readback as well
-            timestamp = time.time()
-            super().put(value, timestamp=timestamp, force=True)
-            self._run_subs(sub_type=self.SUB_SETPOINT, old_value=old_value,
-                           value=value, timestamp=timestamp)
-
     def set(self, value, *, timeout=None, settle_time=None):
         '''Set is like `EpicsSignal.put`, but is here for bluesky compatibility
 

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -837,11 +837,8 @@ class EpicsSignalBase(Signal):
         if form != 'time' or not has_monitor:
             # Different form such as 'ctrl' holds additional data not available
             # through the DBR_TIME channel access monitor
-            metadata = self._metadata_changed(self.pvname, info, update=False,
-                                              require_timestamp=True,
-                                              from_monitor=False)
-            # Update values internally for consistency, but do not run callbacks
-            self._metadata.update(**metadata)
+            self._metadata_changed(self.pvname, info, update=True,
+                                   require_timestamp=True, from_monitor=False)
 
         if not has_monitor:
             # No monitor - readback can only be updated here
@@ -1198,11 +1195,8 @@ class EpicsSignal(EpicsSignalBase):
         if form != 'time' or not has_monitor:
             # Different form such as 'ctrl' holds additional data not available
             # through the DBR_TIME channel access monitor
-            metadata = self._metadata_changed(self.setpoint_pvname, info,
-                                              require_timestamp=True,
-                                              from_monitor=False,
-                                              update=False)
-            self._metadata.update(**metadata)
+            self._metadata_changed(self.setpoint_pvname, info, update=True,
+                                   from_monitor=False, require_timestamp=True)
 
         if not has_monitor:
             # No monitor - setpoint can only be updated here
@@ -1264,8 +1258,6 @@ class EpicsSignal(EpicsSignalBase):
                                           from_monitor=True,
                                           update=False)
 
-        # Update values internally for consistency, but only run callbacks if this
-        # is due to a monitor
         old_value = self._setpoint
         self._metadata.update(**metadata)
         self._setpoint = self._fix_type(value)

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -1249,7 +1249,10 @@ class EpicsSignal(EpicsSignalBase):
         self._metadata.update(**metadata)
         self._setpoint = self._fix_type(value)
 
-        if from_monitor:
+        if not from_monitor and self._monitors[self.setpoint_pvname]:
+            # Not from a monitor, and there is an ongoing subscription
+            ...
+        else:
             self._run_subs(sub_type=self.SUB_SETPOINT,
                            old_value=old_value, value=value,
                            timestamp=self._metadata['setpoint_timestamp'],

--- a/ophyd/signal.py
+++ b/ophyd/signal.py
@@ -637,7 +637,7 @@ class EpicsSignalBase(Signal):
         self._set_event_if_ready()
 
     def _metadata_changed(self, pvname, cl_metadata, *, from_monitor,
-                          require_timestamp=False, update=True):
+                          update, require_timestamp=False):
         'Notification: the metadata of a single PV has changed'
         metadata = self._get_metadata_from_kwargs(
             pvname, cl_metadata, require_timestamp=require_timestamp)
@@ -1224,8 +1224,8 @@ class EpicsSignal(EpicsSignalBase):
         super()._pv_access_callback(read_access, write_access, pv)
         self._set_event_if_ready()
 
-    def _metadata_changed(self, pvname, cl_metadata, *, from_monitor,
-                          require_timestamp=False, update=True):
+    def _metadata_changed(self, pvname, cl_metadata, *, from_monitor, update,
+                          require_timestamp=False):
         'Metadata for one PV has changed'
         metadata = super()._metadata_changed(
             pvname, cl_metadata, from_monitor=from_monitor, update=update,
@@ -1253,13 +1253,11 @@ class EpicsSignal(EpicsSignalBase):
         if timestamp is None:
             timestamp = time.time()
 
-        metadata = self._metadata_changed(self.setpoint_pvname, kwargs,
-                                          require_timestamp=True,
-                                          from_monitor=True,
-                                          update=False)
+        self._metadata_changed(self.setpoint_pvname, kwargs,
+                               require_timestamp=True, from_monitor=True,
+                               update=True)
 
         old_value = self._setpoint
-        self._metadata.update(**metadata)
         self._setpoint = self._fix_type(value)
 
         self._run_subs(sub_type=self.SUB_SETPOINT,

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -456,7 +456,7 @@ def test_epicssignalro_alarm_status(set_severity_signal, alarm_status_signal, ro
     assert ro_signal.alarm_severity == severity
 
 
-def test_hints(cleanup, motor):
-    sig = EpicsSignalRO(motor.user_readback.pvname)
+def test_hints(cleanup, fake_motor_ioc):
+    sig = EpicsSignalRO(fake_motor_ioc.pvs['setpoint'])
     cleanup.add(sig)
     assert sig.hints == {'fields': [sig.name]}

--- a/ophyd/tests/test_signal.py
+++ b/ophyd/tests/test_signal.py
@@ -512,4 +512,7 @@ def test_epicssignal_get_in_callback(cleanup, fake_motor_ioc):
     time.sleep(0.5)
 
     print(called)
+    # Arbitrary threshold, but if @klauer screwed something up again, this will
+    # blow up
+    assert len(called) < 20
     print('total', len(called))


### PR DESCRIPTION
This PR aims to fix a callback-related issue created by the latest Signal refactor.

The Signal refactor intended to keep metadata information and values up-to-date with individual `.get()` and `.get_setpoint()` requests in `EpicsSignal`.  It also ran callbacks for value and metadata upon receiving new information.

DBR_CTRL Updates
----------------
First, note that EpicsSignal monitors using DBR_TIME on the control layer. If the `get()` requested a DBR_CTRL type by specifying `get(..., form='ctrl')`, for example, units and such would be updated internally.  There is no `DBR_` type which encapsulates all of the possible metadata.

The issue
---------
Callbacks being run by `.get()` on every call meant that an infinite recursionscenario was very easy to run into.

I discovered this while subscribing to `Plugin.nd_array_port` and calling `detector.get_asyn_digraph()`, which internally calls `plugin.nd_array_port.get()`, which spawned a callback, which caused my subscription to be run, ..., and so on and so forth.

The fix (1)
-------
* For consistency, update EpicsSignal internals regardless of the source of new information.
* For monitor callbacks (i.e., `_read_changed(..., from_monitor=True)`) subscriptions will be run.
* For `get()` calls (i.e., `_read_changed(..., from_monitor=False)`), subscriptions will not be run.

The fix (2)
-----------
An additionally important fix is the following:
* Metadata callbacks must be guaranteed to run in one thread

This is handled by the dispatcher 'metadata' thread.  Some new useful API is exposed through the dispatcher and helper `DispatcherThreadContext` objects.

Future
------
* Should we consider a `_run_subs_if_changed`-sort of utility method such that subscriptions are only run if anything has changed since the last update? This can easily be compared with the subscription argument cache stored on every ophyd object.
* Metadata + value should be stored in the same dictionary for better atomic updating...