### PR TITLE
FIX: correct logger name

### DIFF
--- a/ophyd/log.py
+++ b/ophyd/log.py
@@ -128,7 +128,7 @@ class LogFormatter(logging.Formatter):
 plain_log_format = "[%(levelname)1.1s %(asctime)s.%(msecs)03d %(module)s:%(lineno)d] %(message)s"
 color_log_format = ("%(color)s[%(levelname)1.1s %(asctime)s.%(msecs)03d "
                     "%(module)s:%(lineno)d]%(end_color)s %(message)s")
-logger = logging.getLogger('bluesky')
+logger = logging.getLogger('ophyd')
 
 
 current_handler = None  # overwritten below


### PR DESCRIPTION
I guess when the `log.py` was ported from bluesky via #664, the logger name wasn't changed accordingly. This PR corrects it.