### PR TITLE
FIX: Setting Capture has no effect in Single Mode.

### DIFF
--- a/ophyd/areadetector/filestore_mixins.py
+++ b/ophyd/areadetector/filestore_mixins.py
@@ -424,7 +424,8 @@ class FileStorePluginBase(FileStoreBase):
         filename, read_path, write_path = self.make_filename()
 
         # Ensure we do not have an old file open.
-        set_and_wait(self.capture, 0)
+        if self.file_write_mode != 'Single':
+            set_and_wait(self.capture, 0)
         # These must be set before parent is staged (specifically
         # before capture mode is turned on. They will not be reset
         # on 'unstage' anyway.


### PR DESCRIPTION
Ophyd unconditionally tries to set the `capture` component of the TIFF plugin of the AD to `0` in https://github.com/NSLS-II/ophyd/blob/18de9724f0d9cf78f1a0e3abe3dd8da9408b6260/ophyd/areadetector/filestore_mixins.py#L427

However, this action is not supported when the TIFF plugin is in the "Single" file write mode, so that it results in the error `ERROR: capture not supported in Single mode`:
![tiff-plugin](https://user-images.githubusercontent.com/13209176/53767849-ffe0ec00-3ea4-11e9-902f-81ffe1dee1ba.jpg)

This PR attempts to workaround this situation.
