### PR TITLE
TST: Hide caproto imports.

### DIFF
--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from ophyd import (set_cl, EpicsMotor, Signal, EpicsSignal, EpicsSignalRO,
                    Component as Cpt)
 from ophyd.utils.epics_pvs import (AlarmSeverity, AlarmStatus)
-from caproto.tests.conftest import run_example_ioc
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +108,7 @@ def fake_motor_ioc(prefix, request):
                step_size=f'{prefix}step_size',
                )
 
+    from caproto.tests.conftest import run_example_ioc
     process = run_example_ioc('ophyd.tests.fake_motor_ioc',
                               request=request,
                               pv_to_check=pvs['setpoint'],
@@ -130,6 +130,7 @@ def signal_test_ioc(prefix, request):
                set_severity=f'{prefix}set_severity',
                )
 
+    from caproto.tests.conftest import run_example_ioc
     process = run_example_ioc('ophyd.tests.signal_ioc',
                               request=request,
                               pv_to_check=pvs['read_only'],

--- a/ophyd/tests/conftest.py
+++ b/ophyd/tests/conftest.py
@@ -108,6 +108,7 @@ def fake_motor_ioc(prefix, request):
                step_size=f'{prefix}step_size',
                )
 
+    pytest.importorskip('caproto.tests.conftest')
     from caproto.tests.conftest import run_example_ioc
     process = run_example_ioc('ophyd.tests.fake_motor_ioc',
                               request=request,
@@ -130,6 +131,7 @@ def signal_test_ioc(prefix, request):
                set_severity=f'{prefix}set_severity',
                )
 
+    pytest.importorskip('caproto.tests.conftest')
     from caproto.tests.conftest import run_example_ioc
     process = run_example_ioc('ophyd.tests.signal_ioc',
                               request=request,


### PR DESCRIPTION
This makes it possible for other libraries (e.g. suitcases) to reuse some
ophyd fixtures (e.g. ``hw``) without installing all of the optional caproto
test dependencies. This is no small thing: the set of of depedencies we avoid
having to manage includes curio, trio, special attr verison for trio, asv,
pytest-benchmark.